### PR TITLE
[17197] Transport Descriptor API empty implementation

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -18,13 +18,15 @@ file(GLOB_RECURSE ALL_HEADERS
 set(${PROJECT_NAME}_source_files
     ${ALL_HEADERS}
 
-    src/cpp/main.cpp
+    src/cpp/exception/Exception.cpp
+    src/cpp/transport_descriptor/TransportDescriptor.cpp
 )
 
 add_library(${PROJECT_NAME} SHARED ${${PROJECT_NAME}_source_files})
 
 target_include_directories(${PROJECT_NAME} PUBLIC
     ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_BINARY_DIR}/include
     PRIVATE
     ${PROJECT_SOURCE_DIR}/src)
 

--- a/lib/src/cpp/exception/Exception.cpp
+++ b/lib/src/cpp/exception/Exception.cpp
@@ -1,0 +1,42 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file Exception.cpp
+ */
+
+#include <exception/Exception.hpp>
+
+namespace eprosima {
+namespace qosprof {
+
+Exception::Exception(
+        const char* message) noexcept
+    : message_(message)
+{
+}
+
+Exception::Exception(
+        const std::string& message)
+    : message_(message)
+{
+}
+
+const char* Exception::what() const noexcept
+{
+    return message_.c_str();
+}
+
+} // namespace qosprof
+} // namespace eprosima

--- a/lib/src/cpp/transport_descriptor/TransportDescriptor.cpp
+++ b/lib/src/cpp/transport_descriptor/TransportDescriptor.cpp
@@ -1,0 +1,1029 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file
+ */
+
+#include <TransportDescriptor.hpp>
+
+#include <string>
+#include <vector>
+
+#include <exception/Exception.hpp>
+
+namespace eprosima {
+namespace qosprof {
+namespace transport_descriptor {
+
+std::string print(
+        const std::string& xml_file)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_kind(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_send_buffer_size(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_receive_buffer_size(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_max_message_size(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_max_initial_peers_range(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_interface_whitelist(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_interface_whitelist(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        int32_t index)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_ttl(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_non_blocking_send(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_output_port(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_wan_addr(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_keep_alive_frequency_ms(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_keep_alive_timeout_ms(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_max_logical_port(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_logical_port_range(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_logical_port_increment(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_listening_ports(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_listening_ports(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        int32_t index)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_tls(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_tls_password(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_tls_private_key_file(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_tls_rsa_private_key_file(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_tls_cert_chain_file(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_tls_tmp_dh_file(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_tls_verify_file(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_tls_verify_mode(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_tls_verify_mode(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        int32_t index)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_tls_options(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_tls_options(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        int32_t index)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_tls_verify_paths(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_tls_verify_paths(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        int32_t index)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_tls_verify_depth(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_tls_default_verify_path(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_tls_handshake_role(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_tls_server_name(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_calculate_crc(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_check_crc(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_enable_tcp_nodelay(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_segment_size(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_port_queue_capacity(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_healthy_check_timeout_ms(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::string print_rtps_dump_file(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+uint32_t size(
+        const std::string& xml_file)
+{
+    throw Unsupported("Unsupported");
+}
+
+std::vector<std::string> keys(
+        const std::string& xml_file)
+{
+    throw Unsupported("Unsupported");
+}
+
+uint32_t interface_whitelist_size(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+uint32_t listening_ports_size(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+uint32_t tls_verify_mode_size(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+uint32_t tls_options_size(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+uint32_t tls_verify_paths_size(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear(
+        const std::string& xml_file)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_send_buffer_size(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_receive_buffer_size(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_max_message_size(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_max_initial_peers_range(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_interface_whitelist(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_interface_whitelist(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        int32_t index)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_ttl(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_non_blocking_send(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_output_port(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_wan_addr(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_keep_alive_frequency_ms(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_keep_alive_timeout_ms(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_max_logical_port(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_logical_port_range(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_logical_port_increment(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_listening_ports(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_listening_ports(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        int32_t index)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_tls(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_tls_password(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_tls_private_key_file(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_tls_rsa_private_key_file(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_tls_cert_chain_file(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_tls_tmp_dh_file(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_tls_verify_file(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_tls_verify_mode(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_tls_verify_mode(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        int32_t index)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_tls_options(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_tls_options(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        int32_t index)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_tls_verify_paths(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_tls_verify_paths(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        int32_t index)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_tls_verify_depth(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_tls_default_verify_path(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_tls_handshake_role(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_tls_server_name(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_calculate_crc(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_check_crc(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_enable_tcp_nodelay(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_segment_size(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_port_queue_capacity(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_healthy_check_timeout_ms(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void clear_rtps_dump_file(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_kind(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& kind)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_send_buffer_size(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& send_buffer_size)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_receive_buffer_size(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& receive_buffer_size)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_max_message_size(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& max_message_size)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_max_initial_peers_range(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& max_initial_peers_range)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_ttl(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& ttl)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_non_blocking_send(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& non_blocking_send)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_output_port(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& output_port)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_wan_addr(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& wan_addr)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_keep_alive_frequency_ms(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& keep_alive_frequency_ms)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_keep_alive_timeout_ms(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& keep_alive_timeout_ms)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_max_logical_port(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& max_logical_port)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_logical_port_range(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& logical_port_range)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_logical_port_increment(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& logical_port_increment)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_tls_password(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& tls_password)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_tls_private_key_file(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& tls_private_key_file)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_tls_rsa_private_key_file(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& tls_rsa_private_key_file)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_tls_cert_chain_file(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& tls_cert_chain_file)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_tls_tmp_dh_file(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& tls_tmp_dh_file)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_tls_verify_file(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& tls_verify_file)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_tls_verify_depth(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& tls_verify_depth)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_tls_default_verify_path(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& tls_default_verify_path)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_tls_handshake_role(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& tls_handshake_role)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_tls_server_name(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& tls_server_name)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_calculate_crc(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& calculate_crc)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_check_crc(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& check_crc)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_enable_tcp_nodelay(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& enable_tcp_nodelay)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_segment_size(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& segment_size)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_port_queue_capacity(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& port_queue_capacity)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_healthy_check_timeout_ms(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& healthy_check_timeout_ms)
+{
+    throw Unsupported("Unsupported");
+}
+
+void set_rtps_dump_file(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& rtps_dump_file)
+{
+    throw Unsupported("Unsupported");
+}
+
+void push_interface_whitelist(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& ip_address)
+{
+    throw Unsupported("Unsupported");
+}
+
+void update_interface_whitelist(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& ip_address,
+        int32_t index)
+{
+    throw Unsupported("Unsupported");
+}
+
+void push_listening_ports(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& port)
+{
+    throw Unsupported("Unsupported");
+}
+
+void update_listening_ports(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& port,
+        int32_t index)
+{
+    throw Unsupported("Unsupported");
+}
+
+void push_tls_verify_mode(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& tls_verify_mode)
+{
+    throw Unsupported("Unsupported");
+}
+
+void update_tls_verify_mode(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& tls_verify_mode,
+        int32_t index)
+{
+    throw Unsupported("Unsupported");
+}
+
+void push_tls_options(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& tls_options)
+{
+    throw Unsupported("Unsupported");
+}
+
+void update_tls_options(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& tls_options,
+        int32_t index)
+{
+    throw Unsupported("Unsupported");
+}
+
+void push_tls_verify_path(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& tls_verify_path)
+{
+    throw Unsupported("Unsupported");
+}
+
+void update_tls_verify_path(
+        const std::string& xml_file,
+        const std::string& transport_descriptor_id,
+        const std::string& tls_verify_path,
+        int32_t index)
+{
+    throw Unsupported("Unsupported");
+}
+
+} // transport_descriptor
+} // qosprof
+} // eprosima


### PR DESCRIPTION
Return Unsupported exception so the tests can be built and linked.