### PR TITLE
[17501.2] Absolute path function impl

### DIFF
--- a/lib/include/utils/ParseXML.hpp
+++ b/lib/include/utils/ParseXML.hpp
@@ -26,10 +26,12 @@
 /**
  * @brief Get the absolute path of the given file name
  *
- * @param xml_file string with the given file name
+ * @param[in]  xml_file string with the given file name
+ * @param[out] file_exists bool reference to save file existence status
  * @return std::string with the absolute path
  */
 std::string get_absolute_path(
-        const std::string& xml_file);
+        const std::string& xml_file,
+        bool& file_exists);
 
 #endif // _FAST_DDS_QOS_PROFILES_MANAGER_UTILS_PARSE_XML_HPP_

--- a/lib/include/utils/ParseXML.hpp
+++ b/lib/include/utils/ParseXML.hpp
@@ -1,0 +1,35 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file ParseXML.hpp
+ */
+
+#ifndef _FAST_DDS_QOS_PROFILES_MANAGER_UTILS_PARSE_XML_HPP_
+#define _FAST_DDS_QOS_PROFILES_MANAGER_UTILS_PARSE_XML_HPP_
+
+#include <string>
+
+#include <fastdds_qos_profiles_manager_dll.h>
+
+/**
+ * @brief Get the absolute path of the given file name
+ *
+ * @param xml_file string with the given file name
+ * @return std::string with the absolute path
+ */
+std::string get_absolute_path(
+    const std::string& xml_file);
+
+#endif // _FAST_DDS_QOS_PROFILES_MANAGER_UTILS_PARSE_XML_HPP_

--- a/lib/include/utils/ParseXML.hpp
+++ b/lib/include/utils/ParseXML.hpp
@@ -30,6 +30,6 @@
  * @return std::string with the absolute path
  */
 std::string get_absolute_path(
-    const std::string& xml_file);
+        const std::string& xml_file);
 
 #endif // _FAST_DDS_QOS_PROFILES_MANAGER_UTILS_PARSE_XML_HPP_

--- a/lib/src/cpp/utils/ParseXML.cpp
+++ b/lib/src/cpp/utils/ParseXML.cpp
@@ -1,0 +1,53 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file ParseXML.cpp
+ */
+
+#include <utils/ParseXML.hpp>
+
+#include <unistd.h>
+
+std::string get_absolute_path(
+    const std::string& xml_file)
+{
+    std::string absolute_xml_file;
+
+    //   Check if file already exists
+    char * absolute_xml_path = realpath(xml_file.c_str(), NULL);
+    //   File does not exist
+    if (absolute_xml_path == NULL)
+    {
+        // Check if it not already an absolute path
+        if (xml_file.find("/") == std::string::npos)
+        {
+            // Get current path and concat xml file name
+            absolute_xml_path = realpath(".", NULL);
+            absolute_xml_file = absolute_xml_path;
+            absolute_xml_file += "/" + xml_file;
+        }
+        // Set the given absolute path
+        else
+        {
+            absolute_xml_file = xml_file;
+        }
+    }
+    //   File exists: load file name directly
+    else
+    {
+        absolute_xml_file = absolute_xml_path;
+    }
+    return absolute_xml_file;
+}

--- a/lib/src/cpp/utils/ParseXML.cpp
+++ b/lib/src/cpp/utils/ParseXML.cpp
@@ -21,12 +21,12 @@
 #include <unistd.h>
 
 std::string get_absolute_path(
-    const std::string& xml_file)
+        const std::string& xml_file)
 {
     std::string absolute_xml_file;
 
     //   Check if file already exists
-    char * absolute_xml_path = realpath(xml_file.c_str(), NULL);
+    char* absolute_xml_path = realpath(xml_file.c_str(), NULL);
     //   File does not exist
     if (absolute_xml_path == NULL)
     {

--- a/lib/src/cpp/utils/ParseXML.cpp
+++ b/lib/src/cpp/utils/ParseXML.cpp
@@ -21,7 +21,8 @@
 #include <unistd.h>
 
 std::string get_absolute_path(
-        const std::string& xml_file)
+        const std::string& xml_file,
+        bool& file_exists)
 {
     std::string absolute_xml_file;
 
@@ -43,11 +44,17 @@ std::string get_absolute_path(
         {
             absolute_xml_file = xml_file;
         }
+
+        // Save status in the given reference
+        file_exists = false;
     }
     //   File exists: load file name directly
     else
     {
         absolute_xml_file = absolute_xml_path;
+
+        // Save status in the given reference
+        file_exists = true;
     }
     return absolute_xml_file;
 }


### PR DESCRIPTION
Under ParseXML utils env implementation (which would be completed in following PRs), this new function would check if the given file exists, and if it does not, either the path is already absolute (then it is kept as it is), or it is not absolute then current folder path is concatenated before file name.