### PR TITLE
Update index parsing with single set externality example

### DIFF
--- a/lib/src/cpp/domain_participant/DefaultExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/DefaultExternalUnicastLocators.cpp
@@ -22,9 +22,6 @@
 
 #include <fastdds_qos_profiles_manager/exception/Exception.hpp>
 
-#include <utils/ParseXML.hpp>
-#include <utils/ParseXMLTags.hpp>
-
 namespace eprosima {
 namespace qosprof {
 namespace domain_participant {

--- a/lib/src/cpp/domain_participant/DefaultExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/DefaultExternalUnicastLocators.cpp
@@ -22,6 +22,9 @@
 
 #include <fastdds_qos_profiles_manager/exception/Exception.hpp>
 
+#include <utils/ParseXML.hpp>
+#include <utils/ParseXMLTags.hpp>
+
 namespace eprosima {
 namespace qosprof {
 namespace domain_participant {

--- a/lib/src/cpp/domain_participant/DomainParticipant.cpp
+++ b/lib/src/cpp/domain_participant/DomainParticipant.cpp
@@ -24,8 +24,6 @@
 #include <fastdds_qos_profiles_manager/exception/Exception.hpp>
 
 #include <utils/ParseXML.hpp>
-#include <utils/ParseXMLErrorHandler.hpp>
-#include <utils/ParseXMLString.hpp>
 #include <utils/ParseXMLTags.hpp>
 
 namespace eprosima {

--- a/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
@@ -268,27 +268,17 @@ void set_externality(
     }
 
 
-    // Check if locator should be updated or created
+    // Check if locator should be created
     if (index == "")
     {
         locator_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
                 eprosima::qosprof::utils::tag::UDPv4_LOCATOR)));
             locator_list_node->appendChild(locator_node);
     }
-    // Update locator
+    // Update the locator of the given index
     else
     {
-        try
-        {
-            locator_node = manager->get_node(locator_list_node, eprosima::qosprof::utils::tag::UDPv4_LOCATOR, &index);
-        }
-        catch (const eprosima::qosprof::ElementNotFound& ex)
-        {
-            // create if not existent
-            locator_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                eprosima::qosprof::utils::tag::UDPv4_LOCATOR)));
-            locator_list_node->appendChild(locator_node);
-        }
+        locator_node = manager->get_node(locator_list_node, eprosima::qosprof::utils::tag::UDPv4_LOCATOR, &index);
     }
     // Set the externality value
     static_cast<xercesc::DOMElement*>(locator_node)->setAttribute(

--- a/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
@@ -257,31 +257,43 @@ void set_externality(
     // Obtain meta-traffic external unicast locator list node
     try
     {
-        locator_list_node = manager->get_node(rtps_node, eprosima::qosprof::utils::tag::META_EXT_UNI_LOC_LIST);
+        locator_list_node = manager->get_node(builtin_node, eprosima::qosprof::utils::tag::META_EXT_UNI_LOC_LIST);
     }
     catch (const eprosima::qosprof::ElementNotFound& ex)
     {
         // create if not existent
         locator_list_node = (xercesc::DOMNode*) doc->createElement(xercesc::XMLString::transcode(
             eprosima::qosprof::utils::tag::META_EXT_UNI_LOC_LIST));
-        rtps_node->appendChild(locator_list_node);
+        builtin_node->appendChild(locator_list_node);
     }
 
-    // Obtain locator node
-    try
-    {
-        locator_node = manager->get_node(locator_list_node, eprosima::qosprof::utils::tag::UDPv4_LOCATOR, index);
-    }
-    catch (const eprosima::qosprof::ElementNotFound& ex)
-    {
-        // create if not existent
-        locator_node = (xercesc::DOMNode*) doc->createElement(xercesc::XMLString::transcode(
-            eprosima::qosprof::utils::tag::UDPv4_LOCATOR));
-        locator_list_node->appendChild(locator_node);
-    }
 
-    // Set the name node value
-    manager->set_value_to_node(doc, locator_node, externality);
+    // Check if locator should be updated or created
+    if (index == "")
+    {
+        locator_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
+                eprosima::qosprof::utils::tag::UDPv4_LOCATOR)));
+            locator_list_node->appendChild(locator_node);
+    }
+    // Update locator
+    else
+    {
+        try
+        {
+            locator_node = manager->get_node(locator_list_node, eprosima::qosprof::utils::tag::UDPv4_LOCATOR, &index);
+        }
+        catch (const eprosima::qosprof::ElementNotFound& ex)
+        {
+            // create if not existent
+            locator_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
+                eprosima::qosprof::utils::tag::UDPv4_LOCATOR)));
+            locator_list_node->appendChild(locator_node);
+        }
+    }
+    // Set the externality value
+    static_cast<xercesc::DOMElement*>(locator_node)->setAttribute(
+            xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::EXTERNALITY),
+            xercesc::XMLString::transcode(externality.c_str()));
 
     // Validate new XML element and save it
     manager->validate_and_save_xml_document(doc);

--- a/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
@@ -256,7 +256,8 @@ void set_externality(
     // Obtain meta-traffic external unicast locator list node
     try
     {
-        locator_list_node = manager->get_node(builtin_node, eprosima::qosprof::utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST);
+        locator_list_node = manager->get_node(builtin_node,
+                        eprosima::qosprof::utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST);
     }
     catch (const eprosima::qosprof::ElementNotFound& ex)
     {

--- a/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
@@ -225,7 +225,6 @@ void set_externality(
             xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::PROFILE_NAME),
             xercesc::XMLString::transcode(profile_id.c_str()));
         participant_node = (xercesc::DOMNode*)participant_element;
-
     }
 
     // Obtain rtps node
@@ -239,7 +238,6 @@ void set_externality(
         rtps_node = (xercesc::DOMNode*) doc->createElement(xercesc::XMLString::transcode(
                             eprosima::qosprof::utils::tag::RTPS));
         participant_node->appendChild(rtps_node);
-
     }
 
     // Obtain builtin node
@@ -253,34 +251,33 @@ void set_externality(
         builtin_node = (xercesc::DOMNode*) doc->createElement(xercesc::XMLString::transcode(
                             eprosima::qosprof::utils::tag::BUILTIN));
         rtps_node->appendChild(builtin_node);
-
     }
 
     // Obtain meta-traffic external unicast locator list node
     try
     {
-        locator_list_node = manager->get_node(builtin_node, eprosima::qosprof::utils::tag::META_EXT_UNI_LOC_LIST);
+        locator_list_node = manager->get_node(builtin_node, eprosima::qosprof::utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST);
     }
     catch (const eprosima::qosprof::ElementNotFound& ex)
     {
         // create if not existent
         locator_list_node = (xercesc::DOMNode*) doc->createElement(xercesc::XMLString::transcode(
-                            eprosima::qosprof::utils::tag::META_EXT_UNI_LOC_LIST));
+                            eprosima::qosprof::utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST));
         builtin_node->appendChild(locator_list_node);
     }
 
 
     // Check if locator should be created
-    if (index == "")
+    if (index.empty())
     {
         locator_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                    eprosima::qosprof::utils::tag::UDPv4_LOCATOR)));
+                    eprosima::qosprof::utils::tag::UDP_V4_LOCATOR)));
         locator_list_node->appendChild(locator_node);
     }
     // Update the locator of the given index
     else
     {
-        locator_node = manager->get_node(locator_list_node, eprosima::qosprof::utils::tag::UDPv4_LOCATOR, &index);
+        locator_node = manager->get_node(locator_list_node, eprosima::qosprof::utils::tag::UDP_V4_LOCATOR, &index);
     }
     // Set the externality value
     static_cast<xercesc::DOMElement*>(locator_node)->setAttribute(
@@ -289,10 +286,6 @@ void set_externality(
 
     // Validate new XML element and save it
     manager->validate_and_save_xml_document(doc);
-
-    // Close XML workspace
-    xercesc::XMLPlatformUtils::Terminate();
-    return;
 }
 
 void set_cost(

--- a/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
@@ -200,12 +200,14 @@ void set_externality(
         xercesc::DOMElement* root_element = doc->getDocumentElement();
 
         // Add profiles
-        profiles_node = (xercesc::DOMNode*) doc->createElement(xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::PROFILES));
+        profiles_node =
+                (xercesc::DOMNode*) doc->createElement(xercesc::XMLString::transcode(eprosima::qosprof::utils::tag
+                                ::PROFILES));
         root_element->appendChild(profiles_node);
     }
 
     // Obtain participant node with the profile id
-   try
+    try
     {
         participant_node = manager->get_node(
             profiles_node,
@@ -216,7 +218,7 @@ void set_externality(
     catch (const eprosima::qosprof::ElementNotFound& ex)
     {
         // create if not existent
-        xercesc::DOMElement * participant_element = doc->createElement(
+        xercesc::DOMElement* participant_element = doc->createElement(
             xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::PARTICIPANT));
         profiles_node->appendChild(participant_element);
         participant_element->setAttribute(
@@ -235,7 +237,7 @@ void set_externality(
     {
         // create if not existent
         rtps_node = (xercesc::DOMNode*) doc->createElement(xercesc::XMLString::transcode(
-            eprosima::qosprof::utils::tag::RTPS));
+                            eprosima::qosprof::utils::tag::RTPS));
         participant_node->appendChild(rtps_node);
 
     }
@@ -249,7 +251,7 @@ void set_externality(
     {
         // create if not existent
         builtin_node = (xercesc::DOMNode*) doc->createElement(xercesc::XMLString::transcode(
-            eprosima::qosprof::utils::tag::BUILTIN));
+                            eprosima::qosprof::utils::tag::BUILTIN));
         rtps_node->appendChild(builtin_node);
 
     }
@@ -263,7 +265,7 @@ void set_externality(
     {
         // create if not existent
         locator_list_node = (xercesc::DOMNode*) doc->createElement(xercesc::XMLString::transcode(
-            eprosima::qosprof::utils::tag::META_EXT_UNI_LOC_LIST));
+                            eprosima::qosprof::utils::tag::META_EXT_UNI_LOC_LIST));
         builtin_node->appendChild(locator_list_node);
     }
 
@@ -272,8 +274,8 @@ void set_externality(
     if (index == "")
     {
         locator_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                eprosima::qosprof::utils::tag::UDPv4_LOCATOR)));
-            locator_list_node->appendChild(locator_node);
+                    eprosima::qosprof::utils::tag::UDPv4_LOCATOR)));
+        locator_list_node->appendChild(locator_node);
     }
     // Update the locator of the given index
     else
@@ -282,8 +284,8 @@ void set_externality(
     }
     // Set the externality value
     static_cast<xercesc::DOMElement*>(locator_node)->setAttribute(
-            xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::EXTERNALITY),
-            xercesc::XMLString::transcode(externality.c_str()));
+        xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::EXTERNALITY),
+        xercesc::XMLString::transcode(externality.c_str()));
 
     // Validate new XML element and save it
     manager->validate_and_save_xml_document(doc);

--- a/lib/src/cpp/utils/ParseXML.cpp
+++ b/lib/src/cpp/utils/ParseXML.cpp
@@ -185,23 +185,31 @@ bool ParseXML::save_xml(
 }
 
 xercesc::DOMNode* ParseXML::get_node(
-        xercesc::DOMNodeList*& node_tag_list,
+        xercesc::DOMNode*& parent_node,
         const std::string& tag_name,
-        int32_t index,
+        const std::string* index,
         const std::string& att_name,
         const std::string& att_value)
 {
+    // Obtain main list of nodes
+    xercesc::DOMNodeList* node_list = parent_node->getChildNodes();
+    if (node_list == nullptr)
+    {
+        // Throw ElementNotFound exception
+        throw ElementNotFound("non-existent " + tag_name + " profile\n");
+    }
+
     // Throw exception if no nodes
-    if (node_tag_list->getLength() == 0)
+    if (node_list->getLength() == 0)
     {
         // Throw eprosima::qosprof::ElementNotFound exception
         throw ElementNotFound("non-existent " + tag_name + " profile\n");
     }
     // Complex element Node
-    else if (node_tag_list->getLength() == 1)
+    else if (node_list->getLength() == 1)
     {
         // Return Node
-        return node_tag_list->item(0);
+        return node_list->item(0);
     }
     // MAP or LIST element node
     else
@@ -212,10 +220,10 @@ xercesc::DOMNode* ParseXML::get_node(
 
         // Iterate through the nodes
         // TODO maybe trying with node->getNextSibling() iterator this function is more efficient
-        for (int i = 0, size = node_tag_list->getLength(); i < size && !found; i++)
+        for (int i = 0, size = node_list->getLength(); i < size && !found; i++)
         {
             // Obtain index element
-            tag_node = node_tag_list->item(i);
+            tag_node = node_list->item(i);
             if (tag_node != nullptr)
             {
                 // Node is not a Element, go next
@@ -260,25 +268,52 @@ xercesc::DOMNode* ParseXML::get_node(
                                       tag_name + " does not have the attribute " + att_name + "\n");
                         }
                     }
-                    // LIST element TODO refactor
-                    else if (&index == nullptr)
+                    // LIST element
+                    else if (index != nullptr)
                     {
-                        int32_t realIndex = index;
-                        // Transform index to real index
-                        if (index < 0)
+                        // Check value of index
+                        std::string in = *index;
+
+                        // Empty index
+                        if (in == "")
                         {
-                            realIndex = node_tag_list->getLength() + index;
+                            // return parent
+                            return tag_node;
                         }
-                        // Check bounds
-                        if (realIndex < 0 || realIndex >= node_tag_list->getLength())
+                        // Index has a value
+                        else
                         {
-                            // Throw eprosima::qosprof::ElementNotFound exception
-                            throw ElementNotFound(
-                                      tag_name + " does not have an element in position " + std::to_string(
-                                          realIndex) + "\n");
+                            // Parse index value and obtain node
+                            int32_t int_index = 0;
+                            int32_t real_index = 0;
+
+                            try
+                            {
+                                // Parse index from string to int
+                                int_index = std::stoi(in);
+                                real_index = int_index;
+                            }
+                            catch(...)
+                            {
+                                throw BadParameter(in + " could not be used as integer index");
+                            }
+
+                            // Transform index to real index
+                            if (int_index < 0)
+                            {
+                                real_index = node_list->getLength() + int_index;
+                            }
+
+                            // Check bounds
+                            if (real_index < 0 || real_index >= node_list->getLength())
+                            {
+                                // Throw eprosima::qosprof::ElementNotFound exception
+                                throw ElementNotFound(
+                                    tag_name + " does not have an element in position " + std::to_string(real_index) + "\n");
+                            }
+                            // Return Node
+                            return node_list->item(real_index);
                         }
-                        // Return Node
-                        return node_tag_list->item(realIndex);
                     }
                     // Complex Element
                     else
@@ -404,13 +439,13 @@ xercesc::DOMNode* ParseXML::get_node(
         const std::string& tag_name)
 {
     // Try call main get_node function with remain empty values
-    return get_node(doc, tag_name, "", "", "");;
+    return get_node(doc, tag_name, nullptr, "", "");;
 }
 
 xercesc::DOMNode* ParseXML::get_node(
         xercesc::DOMDocument*& doc,
         const std::string& tag_name,
-        const std::string& index)
+        const std::string* index)
 {
     // Try call main get_node function with remain empty values
     return get_node(doc, tag_name, index, "", "");
@@ -423,13 +458,13 @@ xercesc::DOMNode* ParseXML::get_node(
         const std::string& att_value)
 {
     // Try call main get_node function with remain empty values
-    return get_node(doc, tag_name, "", att_name, att_value);
+    return get_node(doc, tag_name, nullptr, att_name, att_value);
 }
 
 xercesc::DOMNode* ParseXML::get_node(
         xercesc::DOMDocument*& doc,
         const std::string& tag_name,
-        const std::string& index,
+        const std::string* index,
         const std::string& att_name,
         const std::string& att_value)
 {
@@ -445,13 +480,13 @@ xercesc::DOMNode* ParseXML::get_node(
         const std::string& tag_name)
 {
     // Try call main get_node function with remain empty values
-    return get_node(parent_node, tag_name, "", "", "");
+    return get_node(parent_node, tag_name, nullptr, "", "");
 }
 
 xercesc::DOMNode* ParseXML::get_node(
         xercesc::DOMNode*& parent_node,
         const std::string& tag_name,
-        const std::string& index)
+        const std::string* index)
 {
     // Try call main get_node function with remain empty values
     return get_node(parent_node, tag_name, index, "", "");
@@ -464,126 +499,7 @@ xercesc::DOMNode* ParseXML::get_node(
         const std::string& att_value)
 {
     // Try call main get_node function with remain empty values
-    return get_node(parent_node, tag_name, "", att_name, att_value);
-}
-
-xercesc::DOMNode* ParseXML::get_node(
-        xercesc::DOMNode*& parent_node,
-        const std::string& tag_name,
-        const std::string& index,
-        const std::string& att_name,
-        const std::string& att_value)
-{
-    // Obtain main list of nodes
-    xercesc::DOMNodeList* node_list = parent_node->getChildNodes();
-    if (node_list == nullptr)
-    {
-        // Throw ElementNotFound exception
-        throw ElementNotFound("non-existent " + tag_name + " profile\n");
-    }
-
-    // Throw exception if no nodes
-    if (node_list->getLength() == 0)
-    {
-        // Throw eprosima::qosprof::ElementNotFound exception
-        throw ElementNotFound("non-existent " + tag_name + " profile\n");
-    }
-    // Complex element Node
-    else if (node_list->getLength() == 1)
-    {
-        // Return Node
-        return node_list->item(0);
-    }
-    // MAP or LIST element node
-    else
-    {
-        // empty index, return parent node
-        if (index == "")
-        {
-            return parent_node;
-        }
-        // Obtain node based on MAP
-        else if (att_name.c_str() != nullptr){
-            xercesc::DOMNode* tag_node = nullptr;
-            bool found = false;
-
-            // Iterate through the nodes
-            // TODO maybe trying with node->getNextSibling() iterator this function is more efficient
-            for (int i=0, size=node_list->getLength(); i<size && !found; i++)
-            {
-                // Obtain index element
-                tag_node = node_list->item(i);
-                if (tag_node != nullptr)
-                {
-                    // Get node name and attributes
-                    std::string name = xercesc::XMLString::transcode(tag_node->getNodeValue());
-                    xercesc::DOMNamedNodeMap* atts = tag_node->getAttributes();
-                    // If there are attributes
-                    if (atts != nullptr)
-                    {
-                        // Obtain the attribute that matches the name
-                        xercesc::DOMNode* item = atts->getNamedItem(xercesc::XMLString::transcode(att_name.c_str()));
-                        if (item != nullptr)
-                        {
-                            // If the value of the attribute match
-                            std::string val = xercesc::XMLString::transcode(item->getNodeValue());
-                            if (val == att_value)
-                            {
-                                found = true;
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Throw exception if node not found
-            if (!found)
-            {
-                // Given element does not exist
-                throw ElementNotFound(
-                    tag_name + " does not have an element with key " + att_value + "\n");
-            }
-            else
-            {
-                // Return Node
-                return tag_node;
-            }
-        }
-        // Obtain node based on LIST (when index != "")
-        else
-        {
-            // Check value of index
-            int32_t int_index = 0;
-            int32_t real_index = 0;
-
-            try
-            {
-                // Parse index from string to int
-                int_index = std::stoi(index);
-                real_index = int_index;
-            }
-            catch(...)
-            {
-                throw BadParameter(index + " could not be used as integer index");
-            }
-
-            // Transform index to real index
-            if (int_index < 0)
-            {
-                real_index = node_list->getLength() + int_index;
-            }
-
-            // Check bounds
-            if (real_index < 0 || real_index >= node_list->getLength())
-            {
-                // Throw eprosima::qosprof::ElementNotFound exception
-                throw ElementNotFound(
-                    tag_name + " does not have an element in position " + std::to_string(real_index) + "\n");
-            }
-            // Return Node
-            return node_list->item(real_index);
-        }
-    }
+    return get_node(parent_node, tag_name, nullptr, att_name, att_value);
 }
 
 } /* utils */

--- a/lib/src/cpp/utils/ParseXML.cpp
+++ b/lib/src/cpp/utils/ParseXML.cpp
@@ -289,7 +289,7 @@ xercesc::DOMNode* ParseXML::get_node(
                                 int_index = std::stoi(in);
                                 real_index = int_index;
                             }
-                            catch(...)
+                            catch (...)
                             {
                                 throw BadParameter(in + " could not be used as integer index");
                             }
@@ -305,7 +305,8 @@ xercesc::DOMNode* ParseXML::get_node(
                             {
                                 // Throw eprosima::qosprof::ElementNotFound exception
                                 throw ElementNotFound(
-                                    tag_name + " does not have an element in position " + std::to_string(real_index) + "\n");
+                                          tag_name + " does not have an element in position " +
+                                          std::to_string(real_index) + "\n");
                             }
                             // Return Node
                             return node_list->item(index_list->at(real_index));
@@ -454,7 +455,7 @@ xercesc::DOMNode* ParseXML::get_node(
         const std::string& tag_name)
 {
     // Try call main get_node function with remain empty values
-    return get_node(doc, tag_name, nullptr, "", "");;
+    return get_node(doc, tag_name, nullptr, "", "");
 }
 
 xercesc::DOMNode* ParseXML::get_node(
@@ -487,7 +488,7 @@ xercesc::DOMNode* ParseXML::get_node(
     xercesc::DOMNode* parent_node = doc->getDocumentElement();
 
     // Obtain node from main get_node function
-    return get_node(parent_node, tag_name, index, att_name, att_value);;
+    return get_node(parent_node, tag_name, index, att_name, att_value);
 }
 
 xercesc::DOMNode* ParseXML::get_node(

--- a/lib/src/cpp/utils/ParseXML.hpp
+++ b/lib/src/cpp/utils/ParseXML.hpp
@@ -76,28 +76,6 @@ public:
             xercesc::DOMDocument*& doc);
 
     /**
-     * @brief  MAIN get_node function.
-     *   Obtain the node in the list that matches tag name and
-     *   the given index or the given name-value attribute pair
-     *
-     * @param node_tag_list DOMNodeList list of nodes where tag_name should be part of
-     * @param tag_name string with the node (<tag>) name
-     * @param index int32 index of the node element in LIST cases
-     * @param att_name string key (attribute) name of the node element in MAP cases
-     * @param att_value string key (attribute) value of the node element in MAP cases
-     *
-     * @return xercesc::DOMNode* with the node found
-     *
-     * @throw ElementNotFound exception if expected node was not found
-     */
-    xercesc::DOMNode* get_node(
-            xercesc::DOMNodeList*& node_tag_list,
-            const std::string& tag_name,
-            int32_t index,
-            const std::string& att_name,
-            const std::string& att_value);
-
-    /**
      * @brief Remove the given node from the parent node
      *
      * @param parent_node DOMNode parent node which should contain the node to be deleted
@@ -139,7 +117,7 @@ public:
     xercesc::DOMNode* get_node(
             xercesc::DOMDocument*& doc,
             const std::string& tag_name,
-            const std::string& index);
+            const std::string* index);
 
     xercesc::DOMNode* get_node(
             xercesc::DOMDocument*& doc,
@@ -150,7 +128,7 @@ public:
     xercesc::DOMNode* get_node(
             xercesc::DOMDocument*& doc,
             const std::string& tag_name,
-            const std::string& index,
+            const std::string* index,
             const std::string& att_name,
             const std::string& att_value);
 
@@ -161,7 +139,7 @@ public:
     xercesc::DOMNode* get_node(
             xercesc::DOMNode*& parent_node,
             const std::string& tag_name,
-            const std::string& index);
+            const std::string* index);
 
     xercesc::DOMNode* get_node(
             xercesc::DOMNode*& parent_node,
@@ -169,10 +147,25 @@ public:
             const std::string& att_name,
             const std::string& att_value);
 
+    /**
+     * @brief  MAIN get_node function.
+     *   Obtain the node in the list that matches tag name and
+     *   the given index or the given name-value attribute pair
+     *
+     * @param parent_node DOMNode with the parent node
+     * @param tag_name string with the node (<tag>) name
+     * @param index string index of the node element in LIST cases
+     * @param att_name string key (attribute) name of the node element in MAP cases
+     * @param att_value string key (attribute) value of the node element in MAP cases
+     *
+     * @return xercesc::DOMNode* with the node found
+     *
+     * @throw ElementNotFound exception if expected node was not found
+     */
     xercesc::DOMNode* get_node(
             xercesc::DOMNode*& parent_node,
             const std::string& tag_name,
-            const std::string& index,
+            const std::string* index,
             const std::string& att_name,
             const std::string& att_value);
 

--- a/lib/src/cpp/utils/ParseXML.hpp
+++ b/lib/src/cpp/utils/ParseXML.hpp
@@ -20,6 +20,7 @@
 #define _FAST_DDS_QOS_PROFILES_MANAGER_UTILS_PARSE_XML_HPP_
 
 #include <string>
+#include <vector>
 
 #include <xercesc/dom/DOM.hpp>
 #include <xercesc/framework/LocalFileFormatTarget.hpp>
@@ -205,6 +206,15 @@ private:
     std::string get_absolute_path(
             const std::string& xml_file,
             bool& file_exists);
+
+    /**
+     * @brief Get the real index of the listed nodes (avoid empty nodes)
+     *
+     * @param[in]  node_list with the nodes to be filtered
+     * @return std::vector<uint>* with the indexes of the non-empty nodes
+     */
+    std::vector<uint>* get_real_index(
+            xercesc::DOMNodeList*& node_list);
 
     // CONSTANT CHAR USED BY XERCES
     constexpr static const char* CORE = "Core";

--- a/lib/src/cpp/utils/ParseXML.hpp
+++ b/lib/src/cpp/utils/ParseXML.hpp
@@ -19,6 +19,7 @@
 #ifndef _FAST_DDS_QOS_PROFILES_MANAGER_UTILS_PARSE_XML_HPP_
 #define _FAST_DDS_QOS_PROFILES_MANAGER_UTILS_PARSE_XML_HPP_
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -159,7 +160,7 @@ public:
      * @param att_name string key (attribute) name of the node element in MAP cases
      * @param att_value string key (attribute) value of the node element in MAP cases
      *
-     * @return xercesc::DOMNode* with the node found
+     * @return xercesc::DOMNode* with the found node
      *
      * @throw ElementNotFound exception if expected node was not found
      */
@@ -211,9 +212,9 @@ private:
      * @brief Get the real index of the listed nodes (avoid empty nodes)
      *
      * @param[in]  node_list with the nodes to be filtered
-     * @return std::vector<uint>* with the indexes of the non-empty nodes
+     * @return std::unique_ptr<std::vector<uint>> with the indexes of the non-empty nodes
      */
-    std::vector<uint>* get_real_index(
+    std::unique_ptr<std::vector<uint>>  get_real_index(
             xercesc::DOMNodeList*& node_list);
 
     // CONSTANT CHAR USED BY XERCES

--- a/lib/src/cpp/utils/ParseXML.hpp
+++ b/lib/src/cpp/utils/ParseXML.hpp
@@ -139,7 +139,7 @@ public:
     xercesc::DOMNode* get_node(
             xercesc::DOMDocument*& doc,
             const std::string& tag_name,
-            int32_t index);
+            const std::string& index);
 
     xercesc::DOMNode* get_node(
             xercesc::DOMDocument*& doc,
@@ -150,7 +150,7 @@ public:
     xercesc::DOMNode* get_node(
             xercesc::DOMDocument*& doc,
             const std::string& tag_name,
-            int32_t index,
+            const std::string& index,
             const std::string& att_name,
             const std::string& att_value);
 
@@ -161,7 +161,7 @@ public:
     xercesc::DOMNode* get_node(
             xercesc::DOMNode*& parent_node,
             const std::string& tag_name,
-            int32_t index);
+            const std::string& index);
 
     xercesc::DOMNode* get_node(
             xercesc::DOMNode*& parent_node,
@@ -172,7 +172,7 @@ public:
     xercesc::DOMNode* get_node(
             xercesc::DOMNode*& parent_node,
             const std::string& tag_name,
-            int32_t index,
+            const std::string& index,
             const std::string& att_name,
             const std::string& att_value);
 

--- a/lib/src/cpp/utils/ParseXMLTags.hpp
+++ b/lib/src/cpp/utils/ParseXMLTags.hpp
@@ -43,13 +43,12 @@ constexpr const char* RTPS = "rtps";
 /// RTPS PARTICIPANT
 constexpr const char* NAME = "name";
 constexpr const char* BUILTIN = "builtin";
-constexpr const char* DEF_EXT_UNI_LOC_LIST = "default_external_unicast_locators";
-constexpr const char* META_EXT_UNI_LOC_LIST = "metatraffic_external_unicast_locators";
+constexpr const char* METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST = "metatraffic_external_unicast_locators";
 
 // COMMONS
 /// LOCATOR
-constexpr const char* UDPv4_LOCATOR = "udpv4";
-constexpr const char* UDPv6_LOCATOR = "udpv6";
+constexpr const char* UDP_V4_LOCATOR = "udpv4";
+constexpr const char* UDP_V6_LOCATOR = "udpv6";
 constexpr const char* EXTERNALITY = "externality";
 
 } /* tag */

--- a/lib/src/cpp/utils/ParseXMLTags.hpp
+++ b/lib/src/cpp/utils/ParseXMLTags.hpp
@@ -42,6 +42,14 @@ constexpr const char* RTPS = "rtps";
 
 /// RTPS PARTICIPANT
 constexpr const char* NAME = "name";
+constexpr const char* BUILTIN = "builtin";
+constexpr const char* DEF_EXT_UNI_LOC_LIST = "default_external_unicast_locators";
+constexpr const char* META_EXT_UNI_LOC_LIST = "metatraffic_external_unicast_locators";
+
+// COMMONS
+/// LOCATOR
+constexpr const char* UDPv4_LOCATOR = "udpv4";
+constexpr const char* UDPv6_LOCATOR = "udpv6";
 
 } /* tag */
 } /* utils */

--- a/lib/src/cpp/utils/ParseXMLTags.hpp
+++ b/lib/src/cpp/utils/ParseXMLTags.hpp
@@ -50,6 +50,7 @@ constexpr const char* META_EXT_UNI_LOC_LIST = "metatraffic_external_unicast_loca
 /// LOCATOR
 constexpr const char* UDPv4_LOCATOR = "udpv4";
 constexpr const char* UDPv6_LOCATOR = "udpv6";
+constexpr const char* EXTERNALITY = "externality";
 
 } /* tag */
 } /* utils */


### PR DESCRIPTION
Participant builtin metatraffic unicast locator externality has been implemented to test the index parsing.

All utils `get_node` methods would receive a std::string and would parse it into int32.
That parsing includes error management, BadParameter exception thrown and new `get_real_index` functionality to avoid empty nodes (with blank spaces and break lines generated by the Xerces pretty format)