### PR TITLE
Include DOMDocument inside ParseXML manager class

### DIFF
--- a/lib/src/cpp/common/LocatorList.cpp
+++ b/lib/src/cpp/common/LocatorList.cpp
@@ -28,6 +28,7 @@ namespace common {
 namespace locator_list {
 
 std::string print(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
         const std::string& index)
 {
@@ -35,6 +36,7 @@ std::string print(
 }
 
 std::string print_kind(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
         const std::string& index)
 {
@@ -42,6 +44,7 @@ std::string print_kind(
 }
 
 std::string print_port(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
         const std::string& index)
 {
@@ -49,6 +52,7 @@ std::string print_port(
 }
 
 std::string print_physical_port(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
         const std::string& index)
 {
@@ -56,6 +60,7 @@ std::string print_physical_port(
 }
 
 std::string print_address(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
         const std::string& index)
 {
@@ -63,6 +68,7 @@ std::string print_address(
 }
 
 std::string print_unique_lan_id(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
         const std::string& index)
 {
@@ -70,6 +76,7 @@ std::string print_unique_lan_id(
 }
 
 std::string print_wan_address(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
         const std::string& index)
 {
@@ -77,12 +84,14 @@ std::string print_wan_address(
 }
 
 uint32_t size(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
         const std::string& index)
 {
@@ -90,6 +99,7 @@ void clear(
 }
 
 void clear_port(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
         const std::string& index)
 {
@@ -97,6 +107,7 @@ void clear_port(
 }
 
 void clear_physical_port(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
         const std::string& index)
 {
@@ -104,6 +115,7 @@ void clear_physical_port(
 }
 
 void clear_address(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
         const std::string& index)
 {
@@ -111,6 +123,7 @@ void clear_address(
 }
 
 void clear_unique_lan_id(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
         const std::string& index)
 {
@@ -118,6 +131,7 @@ void clear_unique_lan_id(
 }
 
 void clear_wan_address(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
         const std::string& index)
 {
@@ -125,6 +139,7 @@ void clear_wan_address(
 }
 
 void set_kind(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
         const std::string& kind,
         const std::string& index)
@@ -133,6 +148,7 @@ void set_kind(
 }
 
 void set_port(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
         const std::string& port,
         const std::string& index)
@@ -141,6 +157,7 @@ void set_port(
 }
 
 void set_physical_port(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
         const std::string& physical_port,
         const std::string& index)
@@ -149,6 +166,7 @@ void set_physical_port(
 }
 
 void set_address(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
         const std::string& address,
         const std::string& index)
@@ -157,6 +175,7 @@ void set_address(
 }
 
 void set_unique_lan_id(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
         const std::string& unique_lan_id,
         const std::string& index)
@@ -165,6 +184,7 @@ void set_unique_lan_id(
 }
 
 void set_wan_address(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
         const std::string& wan_address,
         const std::string& index)

--- a/lib/src/cpp/common/LocatorList.cpp
+++ b/lib/src/cpp/common/LocatorList.cpp
@@ -28,70 +28,77 @@ namespace common {
 namespace locator_list {
 
 std::string print(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
-        const std::string& index)
+        const std::string& index,
+        const bool is_external)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_kind(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
-        const std::string& index)
+        const std::string& index,
+        const bool is_external)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_port(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
-        const std::string& index)
+        const std::string& index,
+        const bool is_external)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_physical_port(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
-        const std::string& index)
+        const std::string& index,
+        const bool is_external)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_address(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
-        const std::string& index)
+        const std::string& index,
+        const bool is_external)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_unique_lan_id(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
-        const std::string& index)
+        const std::string& index,
+        const bool is_external)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_wan_address(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
-        const std::string& index)
+        const std::string& index,
+        const bool is_external)
 {
     throw Unsupported("Unsupported");
 }
 
 uint32_t size(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
         const std::string& index)
 {
@@ -99,95 +106,106 @@ void clear(
 }
 
 void clear_port(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
-        const std::string& index)
+        const std::string& index,
+        const bool is_external)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_physical_port(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
-        const std::string& index)
+        const std::string& index,
+        const bool is_external)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_address(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
-        const std::string& index)
+        const std::string& index,
+        const bool is_external)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_unique_lan_id(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
-        const std::string& index)
+        const std::string& index,
+        const bool is_external)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_wan_address(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
-        const std::string& index)
+        const std::string& index,
+        const bool is_external)
 {
     throw Unsupported("Unsupported");
 }
 
 void set_kind(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
         const std::string& kind,
-        const std::string& index)
+        const std::string& index,
+        const bool is_external)
 {
     throw Unsupported("Unsupported");
 }
 
 void set_port(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
         const std::string& port,
-        const std::string& index)
+        const std::string& index,
+        const bool is_external)
 {
     throw Unsupported("Unsupported");
 }
 
 void set_physical_port(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
         const std::string& physical_port,
-        const std::string& index)
+        const std::string& index,
+        const bool is_external)
 {
     throw Unsupported("Unsupported");
 }
 
 void set_address(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
         const std::string& address,
-        const std::string& index)
+        const std::string& index,
+        const bool is_external)
 {
     throw Unsupported("Unsupported");
 }
 
 void set_unique_lan_id(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
         const std::string& unique_lan_id,
-        const std::string& index)
+        const std::string& index,
+        const bool is_external)
 {
     throw Unsupported("Unsupported");
 }
 
 void set_wan_address(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement*& xml_node,
         const std::string& wan_address,
-        const std::string& index)
+        const std::string& index,
+        const bool is_external)
 {
     throw Unsupported("Unsupported");
 }

--- a/lib/src/cpp/common/LocatorList.hpp
+++ b/lib/src/cpp/common/LocatorList.hpp
@@ -21,6 +21,8 @@
 
 #include <string>
 
+#include <xercesc/dom/DOM.hpp>
+
 #include <utils/ParseXML.hpp>
 
 namespace eprosima {
@@ -38,6 +40,7 @@ namespace locator_list {
  * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be printed. If empty, the complete list is printed.
+ * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
  * @return std::string XML section containing the locator.
  *
@@ -46,9 +49,10 @@ namespace locator_list {
  * @throw BadParameter Exception if the index is not an integer.
  */
 std::string print(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         const xercesc::DOMElement& xml_node,
-        const std::string& index);
+        const std::string& index,
+        const bool is_external);
 
 /**
  * @brief Parse XML node and print the locator kind.
@@ -56,6 +60,7 @@ std::string print(
  * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be printed.
+ * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
  * @return std::string locator kind.
  *
@@ -64,9 +69,10 @@ std::string print(
  * @throw BadParameter Exception if the index is empty or not an integer.
  */
 std::string print_kind(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         const xercesc::DOMElement& xml_node,
-        const std::string& index);
+        const std::string& index,
+        const bool is_external);
 
 /**
  * @brief Parse XML node and print the locator port.
@@ -74,6 +80,7 @@ std::string print_kind(
  * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be printed.
+ * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
  * @return std::string locator port.
  *
@@ -82,9 +89,10 @@ std::string print_kind(
  * @throw BadParameter Exception if the index is empty or not an integer.
  */
 std::string print_port(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         const xercesc::DOMElement& xml_node,
-        const std::string& index);
+        const std::string& index,
+        const bool is_external);
 
 /**
  * @brief Parse XML node and print the locator physical port.
@@ -93,6 +101,7 @@ std::string print_port(
  * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be printed.
+ * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
  * @return std::string locator TCP physical port.
  *
@@ -101,9 +110,10 @@ std::string print_port(
  * @throw BadParameter Exception if the index is empty or not an integer.
  */
 std::string print_physical_port(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         const xercesc::DOMElement& xml_node,
-        const std::string& index);
+        const std::string& index,
+        const bool is_external);
 
 /**
  * @brief Parse XML node and print the locator IP address.
@@ -111,6 +121,7 @@ std::string print_physical_port(
  * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be printed.
+ * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
  * @return std::string locator IP address.
  *
@@ -119,9 +130,10 @@ std::string print_physical_port(
  * @throw BadParameter Exception if the index is empty or not an integer.
  */
 std::string print_address(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         const xercesc::DOMElement& xml_node,
-        const std::string& index);
+        const std::string& index,
+        const bool is_external);
 
 /**
  * @brief Parse XML node and print the locator unique LAN ID.
@@ -130,6 +142,7 @@ std::string print_address(
  * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be printed.
+ * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
  * @return std::string locator TCPv4 unique LAN ID.
  *
@@ -138,9 +151,10 @@ std::string print_address(
  * @throw BadParameter Exception if the index is empty or not an integer.
  */
 std::string print_unique_lan_id(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         const xercesc::DOMElement& xml_node,
-        const std::string& index);
+        const std::string& index,
+        const bool is_external);
 
 /**
  * @brief Parse XML node and print the locator WAN IPv4 address.
@@ -149,6 +163,7 @@ std::string print_unique_lan_id(
  * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be printed.
+ * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
  * @return std::string locator TCPv4 WAN IP address.
  *
@@ -157,9 +172,10 @@ std::string print_unique_lan_id(
  * @throw BadParameter Exception if the index is empty or not an integer.
  */
 std::string print_wan_address(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         const xercesc::DOMElement& xml_node,
-        const std::string& index);
+        const std::string& index,
+        const bool is_external);
 
 /************************************************************************/
 /* Query functions                                                      */
@@ -176,7 +192,7 @@ std::string print_wan_address(
  * @throw ElementNotFound Exception if the list has not been set.
  */
 uint32_t size(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         const xercesc::DOMElement& xml_node);
 
 /************************************************************************/
@@ -196,7 +212,7 @@ uint32_t size(
  * @throw BadParameter Exception if the index is not an integer.
  */
 void clear(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement& xml_node,
         const std::string& index);
 
@@ -206,15 +222,17 @@ void clear(
  * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be modified.
+ * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
  * @throw ElementNotFound Exception if the list element does not exist, or the list does not contain
  *        any element in index position.
  * @throw BadParameter Exception if the index is empty or not an integer.
  */
 void clear_port(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement& xml_node,
-        const std::string& index);
+        const std::string& index,
+        const bool is_external);
 
 /**
  * @brief Remove locator physical port.
@@ -222,15 +240,17 @@ void clear_port(
  * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be modified.
+ * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
  * @throw ElementNotFound Exception if the list element does not exist, or the list does not contain
  *        any element in index position.
  * @throw BadParameter Exception if the index is empty or not an integer.
  */
 void clear_physical_port(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement& xml_node,
-        const std::string& index);
+        const std::string& index,
+        const bool is_external);
 
 /**
  * @brief Remove locator IP address.
@@ -238,15 +258,17 @@ void clear_physical_port(
  * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be modified.
+ * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
  * @throw ElementNotFound Exception if the list element does not exist, or the list does not contain
  *        any element in index position.
  * @throw BadParameter Exception if the index is empty or not an integer.
  */
 void clear_address(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement& xml_node,
-        const std::string& index);
+        const std::string& index,
+        const bool is_external);
 
 /**
  * @brief Remove locator unique LAN ID.
@@ -254,15 +276,17 @@ void clear_address(
  * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be modified.
+ * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
  * @throw ElementNotFound Exception if the list element does not exist, or the list does not contain
  *        any element in index position.
  * @throw BadParameter Exception if the index is empty or not an integer.
  */
 void clear_unique_lan_id(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement& xml_node,
-        const std::string& index);
+        const std::string& index,
+        const bool is_external);
 
 /**
  * @brief Remove locator WAN IP address.
@@ -270,15 +294,17 @@ void clear_unique_lan_id(
  * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be modified.
+ * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
  * @throw ElementNotFound Exception if the list element does not exist, or the list does not contain
  *        any element in index position.
  * @throw BadParameter Exception if the index is empty or not an integer.
  */
 void clear_wan_address(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement& xml_node,
-        const std::string& index);
+        const std::string& index,
+        const bool is_external);
 
 /************************************************************************/
 /* Collection functions                                                 */
@@ -291,16 +317,18 @@ void clear_wan_address(
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] kind locator kind.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
+ * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the element does not exist in the collection if an index is provided.
  * @throw BadParameter Exception if the index is not an integer.
  */
 void set_kind(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement& xml_node,
         const std::string& kind,
-        const std::string& index);
+        const std::string& index,
+        const bool is_external);
 
 /**
  * @brief Append a locator with specified port or update the existing locator port.
@@ -309,16 +337,18 @@ void set_kind(
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] port locator port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
+ * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the element does not exist in the collection if an index is provided.
  * @throw BadParameter Exception if the index is not an integer.
  */
 void set_port(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement& xml_node,
         const std::string& port,
-        const std::string& index);
+        const std::string& index,
+        const bool is_external);
 
 /**
  * @brief Append a locator with specified physical port or update the existing locator physical port
@@ -328,16 +358,18 @@ void set_port(
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] physical_port locator TCP physical port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
+ * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
  * @throw ElementInvalid Exception if the provided locator physical port is not valid.
  * @throw ElementNotFound Exception if the element does not exist in the collection if an index is provided.
  * @throw BadParameter Exception if the index is not an integer.
  */
 void set_physical_port(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement& xml_node,
         const std::string& physical_port,
-        const std::string& index);
+        const std::string& index,
+        const bool is_external);
 
 /**
  * @brief Append a locator with specified IP address or update the existing locator IP address.
@@ -346,16 +378,18 @@ void set_physical_port(
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] address locator IP address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
+ * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the element does not exist in the collection if an index is provided.
  * @throw BadParameter Exception if the index is not an integer.
  */
 void set_address(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement& xml_node,
         const std::string& address,
-        const std::string& index);
+        const std::string& index,
+        const bool is_external);
 
 /**
  * @brief Append a TCPv4 locator with specified unique LAN ID or update the existing locator unique
@@ -365,16 +399,18 @@ void set_address(
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] unique_lan_id TCPv4 locator unique LAN ID.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
+ * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
  * @throw ElementInvalid Exception if the provided locator identifier is not valid.
  * @throw ElementNotFound Exception if the element does not exist in the collection if an index is provided.
  * @throw BadParameter Exception if the index is not an integer.
  */
 void set_unique_lan_id(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement& xml_node,
         const std::string& unique_lan_id,
-        const std::string& index);
+        const std::string& index,
+        const bool is_external);
 
 /**
  * @brief Append a TCPv4 locator with specified WAN address or update the existing locator WAN address.
@@ -383,16 +419,18 @@ void set_unique_lan_id(
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] wan_address TCPv4 locator WAN address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
+ * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the element does not exist in the collection if an index is provided.
  * @throw BadParameter Exception if the index is not an integer.
  */
 void set_wan_address(
-        eprosima::qosprof::utils::ParseXML& manager,
+        utils::ParseXML& manager,
         xercesc::DOMElement& xml_node,
         const std::string& wan_address,
-        const std::string& index);
+        const std::string& index,
+        const bool is_external);
 
 } // locator_list
 } // common

--- a/lib/src/cpp/common/LocatorList.hpp
+++ b/lib/src/cpp/common/LocatorList.hpp
@@ -21,7 +21,7 @@
 
 #include <string>
 
-#include <xercesc/dom/DOM.hpp>
+#include <utils/ParseXML.hpp>
 
 namespace eprosima {
 namespace qosprof {
@@ -35,6 +35,7 @@ namespace locator_list {
 /**
  * @brief Parse XML node and print the locator.
  *
+ * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be printed. If empty, the complete list is printed.
  *
@@ -45,12 +46,14 @@ namespace locator_list {
  * @throw BadParameter Exception if the index is not an integer.
  */
 std::string print(
+        eprosima::qosprof::utils::ParseXML& manager,
         const xercesc::DOMElement& xml_node,
         const std::string& index);
 
 /**
  * @brief Parse XML node and print the locator kind.
  *
+ * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be printed.
  *
@@ -61,12 +64,14 @@ std::string print(
  * @throw BadParameter Exception if the index is empty or not an integer.
  */
 std::string print_kind(
+        eprosima::qosprof::utils::ParseXML& manager,
         const xercesc::DOMElement& xml_node,
         const std::string& index);
 
 /**
  * @brief Parse XML node and print the locator port.
  *
+ * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be printed.
  *
@@ -77,6 +82,7 @@ std::string print_kind(
  * @throw BadParameter Exception if the index is empty or not an integer.
  */
 std::string print_port(
+        eprosima::qosprof::utils::ParseXML& manager,
         const xercesc::DOMElement& xml_node,
         const std::string& index);
 
@@ -84,6 +90,7 @@ std::string print_port(
  * @brief Parse XML node and print the locator physical port.
  *        TCP only.
  *
+ * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be printed.
  *
@@ -94,12 +101,14 @@ std::string print_port(
  * @throw BadParameter Exception if the index is empty or not an integer.
  */
 std::string print_physical_port(
+        eprosima::qosprof::utils::ParseXML& manager,
         const xercesc::DOMElement& xml_node,
         const std::string& index);
 
 /**
  * @brief Parse XML node and print the locator IP address.
  *
+ * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be printed.
  *
@@ -110,6 +119,7 @@ std::string print_physical_port(
  * @throw BadParameter Exception if the index is empty or not an integer.
  */
 std::string print_address(
+        eprosima::qosprof::utils::ParseXML& manager,
         const xercesc::DOMElement& xml_node,
         const std::string& index);
 
@@ -117,6 +127,7 @@ std::string print_address(
  * @brief Parse XML node and print the locator unique LAN ID.
  *        TCPv4 only.
  *
+ * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be printed.
  *
@@ -127,6 +138,7 @@ std::string print_address(
  * @throw BadParameter Exception if the index is empty or not an integer.
  */
 std::string print_unique_lan_id(
+        eprosima::qosprof::utils::ParseXML& manager,
         const xercesc::DOMElement& xml_node,
         const std::string& index);
 
@@ -134,6 +146,7 @@ std::string print_unique_lan_id(
  * @brief Parse XML node and print the locator WAN IPv4 address.
  *        TCPv4 only.
  *
+ * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be printed.
  *
@@ -144,6 +157,7 @@ std::string print_unique_lan_id(
  * @throw BadParameter Exception if the index is empty or not an integer.
  */
 std::string print_wan_address(
+        eprosima::qosprof::utils::ParseXML& manager,
         const xercesc::DOMElement& xml_node,
         const std::string& index);
 
@@ -154,6 +168,7 @@ std::string print_wan_address(
 /**
  * @brief Number of locators defined.
  *
+ * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  *
  * @return uint32_t Number of locators in the list.
@@ -161,6 +176,7 @@ std::string print_wan_address(
  * @throw ElementNotFound Exception if the list has not been set.
  */
 uint32_t size(
+        eprosima::qosprof::utils::ParseXML& manager,
         const xercesc::DOMElement& xml_node);
 
 /************************************************************************/
@@ -171,6 +187,7 @@ uint32_t size(
  * @brief Remove locator or complete locator list. If no index provided (empty string), the complete
  *       locator list would be removed. If provided, then the corresponding locator would be removed.
  *
+ * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be removed. If empty, the complete list is removed.
  *
@@ -179,12 +196,14 @@ uint32_t size(
  * @throw BadParameter Exception if the index is not an integer.
  */
 void clear(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement& xml_node,
         const std::string& index);
 
 /**
  * @brief Remove locator port.
  *
+ * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be modified.
  *
@@ -193,12 +212,14 @@ void clear(
  * @throw BadParameter Exception if the index is empty or not an integer.
  */
 void clear_port(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement& xml_node,
         const std::string& index);
 
 /**
  * @brief Remove locator physical port.
  *
+ * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be modified.
  *
@@ -207,12 +228,14 @@ void clear_port(
  * @throw BadParameter Exception if the index is empty or not an integer.
  */
 void clear_physical_port(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement& xml_node,
         const std::string& index);
 
 /**
  * @brief Remove locator IP address.
  *
+ * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be modified.
  *
@@ -221,12 +244,14 @@ void clear_physical_port(
  * @throw BadParameter Exception if the index is empty or not an integer.
  */
 void clear_address(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement& xml_node,
         const std::string& index);
 
 /**
  * @brief Remove locator unique LAN ID.
  *
+ * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be modified.
  *
@@ -235,12 +260,14 @@ void clear_address(
  * @throw BadParameter Exception if the index is empty or not an integer.
  */
 void clear_unique_lan_id(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement& xml_node,
         const std::string& index);
 
 /**
  * @brief Remove locator WAN IP address.
  *
+ * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be modified.
  *
@@ -249,6 +276,7 @@ void clear_unique_lan_id(
  * @throw BadParameter Exception if the index is empty or not an integer.
  */
 void clear_wan_address(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement& xml_node,
         const std::string& index);
 
@@ -259,6 +287,7 @@ void clear_wan_address(
 /**
  * @brief Append a locator with specified kind or update the existing locator kind.
  *
+ * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] kind locator kind.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -268,6 +297,7 @@ void clear_wan_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 void set_kind(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement& xml_node,
         const std::string& kind,
         const std::string& index);
@@ -275,6 +305,7 @@ void set_kind(
 /**
  * @brief Append a locator with specified port or update the existing locator port.
  *
+ * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] port locator port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -284,6 +315,7 @@ void set_kind(
  * @throw BadParameter Exception if the index is not an integer.
  */
 void set_port(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement& xml_node,
         const std::string& port,
         const std::string& index);
@@ -292,6 +324,7 @@ void set_port(
  * @brief Append a locator with specified physical port or update the existing locator physical port
  *        (TCP only).
  *
+ * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] physical_port locator TCP physical port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -301,6 +334,7 @@ void set_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 void set_physical_port(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement& xml_node,
         const std::string& physical_port,
         const std::string& index);
@@ -308,6 +342,7 @@ void set_physical_port(
 /**
  * @brief Append a locator with specified IP address or update the existing locator IP address.
  *
+ * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] address locator IP address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -317,6 +352,7 @@ void set_physical_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 void set_address(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement& xml_node,
         const std::string& address,
         const std::string& index);
@@ -325,6 +361,7 @@ void set_address(
  * @brief Append a TCPv4 locator with specified unique LAN ID or update the existing locator unique
  *        LAN ID.
  *
+ * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] unique_lan_id TCPv4 locator unique LAN ID.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -334,6 +371,7 @@ void set_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 void set_unique_lan_id(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement& xml_node,
         const std::string& unique_lan_id,
         const std::string& index);
@@ -341,6 +379,7 @@ void set_unique_lan_id(
 /**
  * @brief Append a TCPv4 locator with specified WAN address or update the existing locator WAN address.
  *
+ * @param[in] manager Internal util manager to obtain and work with nodes
  * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] wan_address TCPv4 locator WAN address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -350,6 +389,7 @@ void set_unique_lan_id(
  * @throw BadParameter Exception if the index is not an integer.
  */
 void set_wan_address(
+        eprosima::qosprof::utils::ParseXML& manager,
         xercesc::DOMElement& xml_node,
         const std::string& wan_address,
         const std::string& index);

--- a/lib/src/cpp/domain_participant/DefaultExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/DefaultExternalUnicastLocators.cpp
@@ -198,9 +198,8 @@ void set_externality(
         xercesc::DOMElement* root_element = doc->getDocumentElement();
 
         // Add profiles
-        profiles_node =
-                (xercesc::DOMNode*) doc->createElement(xercesc::XMLString::transcode(eprosima::qosprof::utils::tag
-                                ::PROFILES));
+        profiles_node = static_cast<xercesc::DOMNode*>(doc->createElement(
+                        xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::PROFILES)));
         root_element->appendChild(profiles_node);
     }
 
@@ -222,7 +221,7 @@ void set_externality(
         participant_element->setAttribute(
             xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::PROFILE_NAME),
             xercesc::XMLString::transcode(profile_id.c_str()));
-        participant_node = (xercesc::DOMNode*)participant_element;
+        participant_node = static_cast<xercesc::DOMNode*>(participant_element);
 
     }
 
@@ -234,8 +233,8 @@ void set_externality(
     catch (const eprosima::qosprof::ElementNotFound& ex)
     {
         // create if not existent
-        rtps_node = (xercesc::DOMNode*) doc->createElement(xercesc::XMLString::transcode(
-                            eprosima::qosprof::utils::tag::RTPS));
+        rtps_node = static_cast<xercesc::DOMNode*>(doc->createElement(
+                            xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::RTPS)));
         participant_node->appendChild(rtps_node);
 
     }
@@ -249,8 +248,8 @@ void set_externality(
     catch (const eprosima::qosprof::ElementNotFound& ex)
     {
         // create if not existent
-        locator_list_node = (xercesc::DOMNode*) doc->createElement(xercesc::XMLString::transcode(
-                            eprosima::qosprof::utils::tag::DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST));
+        locator_list_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
+                            eprosima::qosprof::utils::tag::DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST)));
         rtps_node->appendChild(locator_list_node);
     }
 

--- a/lib/src/cpp/domain_participant/DefaultExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/DefaultExternalUnicastLocators.cpp
@@ -185,12 +185,13 @@ void set_externality(
     xercesc::DOMNode* locator_node = nullptr;
 
     // Create XML manager and initialize the document
-    eprosima::qosprof::utils::ParseXML* manager = new eprosima::qosprof::utils::ParseXML(doc, xml_file, true);
+    eprosima::qosprof::utils::ParseXML* manager = new eprosima::qosprof::utils::ParseXML(xml_file, true);
+    doc = manager->get_doc();
 
     // Obtain profiles node
     try
     {
-        profiles_node = manager->get_node(doc, eprosima::qosprof::utils::tag::PROFILES);
+        profiles_node = manager->get_node(eprosima::qosprof::utils::tag::PROFILES);
     }
     catch (const eprosima::qosprof::ElementNotFound& ex)
     {
@@ -199,7 +200,7 @@ void set_externality(
 
         // Add profiles
         profiles_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-                        xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::PROFILES)));
+                    xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::PROFILES)));
         root_element->appendChild(profiles_node);
     }
 
@@ -234,7 +235,7 @@ void set_externality(
     {
         // create if not existent
         rtps_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-                            xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::RTPS)));
+                    xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::RTPS)));
         participant_node->appendChild(rtps_node);
 
     }
@@ -249,7 +250,7 @@ void set_externality(
     {
         // create if not existent
         locator_list_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                            eprosima::qosprof::utils::tag::DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST)));
+                    eprosima::qosprof::utils::tag::DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST)));
         rtps_node->appendChild(locator_list_node);
     }
 
@@ -272,7 +273,7 @@ void set_externality(
         xercesc::XMLString::transcode(externality.c_str()));
 
     // Validate new XML element and save it
-    manager->validate_and_save_xml_document(doc);
+    manager->validate_and_save_xml_document();
 }
 
 void set_cost(

--- a/lib/src/cpp/domain_participant/DomainParticipant.cpp
+++ b/lib/src/cpp/domain_participant/DomainParticipant.cpp
@@ -334,8 +334,8 @@ void set_name(
         xercesc::DOMElement* root_element = doc->getDocumentElement();
 
         // Add profiles
-        profiles_node = (xercesc::DOMNode*) doc->createElement(
-            xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::PROFILES));
+        profiles_node = static_cast<xercesc::DOMNode*>(doc->createElement(
+            xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::PROFILES)));
         root_element->appendChild(profiles_node);
     }
     // Obtain participant node with the profile id
@@ -356,7 +356,7 @@ void set_name(
         participant_element->setAttribute(
             xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::PROFILE_NAME),
             xercesc::XMLString::transcode(profile_id.c_str()));
-        participant_node = (xercesc::DOMNode*)participant_element;
+        participant_node = static_cast<xercesc::DOMNode*>(participant_element);
     }
 
     // Obtain rtps node
@@ -367,8 +367,8 @@ void set_name(
     catch (const eprosima::qosprof::ElementNotFound& ex)
     {
         // create if not existent
-        rtps_node = (xercesc::DOMNode*) doc->createElement(
-            xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::RTPS));
+        rtps_node = static_cast<xercesc::DOMNode*>(doc->createElement(
+            xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::RTPS)));
         participant_node->appendChild(rtps_node);
     }
 
@@ -380,8 +380,8 @@ void set_name(
     catch (const eprosima::qosprof::ElementNotFound& ex)
     {
         // create if not existent
-        name_node = (xercesc::DOMNode*) doc->createElement(
-            xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::NAME));
+        name_node = static_cast<xercesc::DOMNode*>(doc->createElement(
+            xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::NAME)));
         rtps_node->appendChild(name_node);
     }
 
@@ -390,10 +390,6 @@ void set_name(
 
     // Validate new XML element and save it
     manager->validate_and_save_xml_document(doc);
-
-    // Close XML workspace
-    xercesc::XMLPlatformUtils::Terminate();
-    return;
 }
 
 void set_ignore_non_matching_locators(

--- a/lib/src/cpp/domain_participant/DomainParticipant.cpp
+++ b/lib/src/cpp/domain_participant/DomainParticipant.cpp
@@ -255,10 +255,11 @@ void set_default_profile(
     xercesc::DOMNode* default_profile_node = nullptr;
 
     // Create XML manager and initialize the document
-    eprosima::qosprof::utils::ParseXML* manager = new eprosima::qosprof::utils::ParseXML(doc, xml_file, true);
+    eprosima::qosprof::utils::ParseXML* manager = new eprosima::qosprof::utils::ParseXML(xml_file, true);
+    doc = manager->get_doc();
 
     // Obtain nodes
-    profiles_node = manager->get_node(doc, eprosima::qosprof::utils::tag::PROFILES);
+    profiles_node = manager->get_node(eprosima::qosprof::utils::tag::PROFILES);
     participant_node = manager->get_node(
         profiles_node,
         eprosima::qosprof::utils::tag::PARTICIPANT,
@@ -295,7 +296,7 @@ void set_default_profile(
         xercesc::XMLString::transcode("true"));
 
     // Validate new XML element and save it
-    manager->validate_and_save_xml_document(doc);
+    manager->validate_and_save_xml_document();
 }
 
 void set_domain_id(
@@ -321,12 +322,13 @@ void set_name(
     xercesc::DOMNode* name_node = nullptr;
 
     // Create XML manager and initialize the document
-    eprosima::qosprof::utils::ParseXML* manager = new eprosima::qosprof::utils::ParseXML(doc, xml_file, true);
+    eprosima::qosprof::utils::ParseXML* manager = new eprosima::qosprof::utils::ParseXML(xml_file, true);
+    doc = manager->get_doc();
 
     // Obtain profiles node
     try
     {
-        profiles_node = manager->get_node(doc, eprosima::qosprof::utils::tag::PROFILES);
+        profiles_node = manager->get_node(eprosima::qosprof::utils::tag::PROFILES);
     }
     catch (const eprosima::qosprof::ElementNotFound& ex)
     {
@@ -335,7 +337,7 @@ void set_name(
 
         // Add profiles
         profiles_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-            xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::PROFILES)));
+                    xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::PROFILES)));
         root_element->appendChild(profiles_node);
     }
     // Obtain participant node with the profile id
@@ -368,7 +370,7 @@ void set_name(
     {
         // create if not existent
         rtps_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-            xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::RTPS)));
+                    xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::RTPS)));
         participant_node->appendChild(rtps_node);
     }
 
@@ -381,15 +383,15 @@ void set_name(
     {
         // create if not existent
         name_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-            xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::NAME)));
+                    xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::NAME)));
         rtps_node->appendChild(name_node);
     }
 
     // Set the name node value
-    manager->set_value_to_node(doc, name_node, name);
+    manager->set_value_to_node(name_node, name);
 
     // Validate new XML element and save it
-    manager->validate_and_save_xml_document(doc);
+    manager->validate_and_save_xml_document();
 }
 
 void set_ignore_non_matching_locators(

--- a/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
@@ -187,12 +187,13 @@ void set_externality(
     xercesc::DOMNode* locator_node = nullptr;
 
     // Create XML manager and initialize the document
-    eprosima::qosprof::utils::ParseXML* manager = new eprosima::qosprof::utils::ParseXML(doc, xml_file, true);
+    eprosima::qosprof::utils::ParseXML* manager = new eprosima::qosprof::utils::ParseXML(xml_file, true);
+    doc = manager->get_doc();
 
     // Obtain profiles node
     try
     {
-        profiles_node = manager->get_node(doc, eprosima::qosprof::utils::tag::PROFILES);
+        profiles_node = manager->get_node(eprosima::qosprof::utils::tag::PROFILES);
     }
     catch (const eprosima::qosprof::ElementNotFound& ex)
     {
@@ -201,7 +202,7 @@ void set_externality(
 
         // Add profiles
         profiles_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-                                xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::PROFILES)));
+                    xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::PROFILES)));
         root_element->appendChild(profiles_node);
     }
 
@@ -235,7 +236,7 @@ void set_externality(
     {
         // create if not existent
         rtps_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                            eprosima::qosprof::utils::tag::RTPS)));
+                    eprosima::qosprof::utils::tag::RTPS)));
         participant_node->appendChild(rtps_node);
     }
 
@@ -248,7 +249,7 @@ void set_externality(
     {
         // create if not existent
         builtin_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                            eprosima::qosprof::utils::tag::BUILTIN)));
+                    eprosima::qosprof::utils::tag::BUILTIN)));
         rtps_node->appendChild(builtin_node);
     }
 
@@ -262,7 +263,7 @@ void set_externality(
     {
         // create if not existent
         locator_list_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                            eprosima::qosprof::utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST)));
+                    eprosima::qosprof::utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST)));
         builtin_node->appendChild(locator_list_node);
     }
 
@@ -285,7 +286,7 @@ void set_externality(
         xercesc::XMLString::transcode(externality.c_str()));
 
     // Validate new XML element and save it
-    manager->validate_and_save_xml_document(doc);
+    manager->validate_and_save_xml_document();
 }
 
 void set_cost(

--- a/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
@@ -200,9 +200,8 @@ void set_externality(
         xercesc::DOMElement* root_element = doc->getDocumentElement();
 
         // Add profiles
-        profiles_node =
-                (xercesc::DOMNode*) doc->createElement(xercesc::XMLString::transcode(eprosima::qosprof::utils::tag
-                                ::PROFILES));
+        profiles_node = static_cast<xercesc::DOMNode*>(doc->createElement(
+                                xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::PROFILES)));
         root_element->appendChild(profiles_node);
     }
 
@@ -224,7 +223,7 @@ void set_externality(
         participant_element->setAttribute(
             xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::PROFILE_NAME),
             xercesc::XMLString::transcode(profile_id.c_str()));
-        participant_node = (xercesc::DOMNode*)participant_element;
+        participant_node = static_cast<xercesc::DOMNode*>(participant_element);
     }
 
     // Obtain rtps node
@@ -235,8 +234,8 @@ void set_externality(
     catch (const eprosima::qosprof::ElementNotFound& ex)
     {
         // create if not existent
-        rtps_node = (xercesc::DOMNode*) doc->createElement(xercesc::XMLString::transcode(
-                            eprosima::qosprof::utils::tag::RTPS));
+        rtps_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
+                            eprosima::qosprof::utils::tag::RTPS)));
         participant_node->appendChild(rtps_node);
     }
 
@@ -248,8 +247,8 @@ void set_externality(
     catch (const eprosima::qosprof::ElementNotFound& ex)
     {
         // create if not existent
-        builtin_node = (xercesc::DOMNode*) doc->createElement(xercesc::XMLString::transcode(
-                            eprosima::qosprof::utils::tag::BUILTIN));
+        builtin_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
+                            eprosima::qosprof::utils::tag::BUILTIN)));
         rtps_node->appendChild(builtin_node);
     }
 
@@ -262,8 +261,8 @@ void set_externality(
     catch (const eprosima::qosprof::ElementNotFound& ex)
     {
         // create if not existent
-        locator_list_node = (xercesc::DOMNode*) doc->createElement(xercesc::XMLString::transcode(
-                            eprosima::qosprof::utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST));
+        locator_list_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
+                            eprosima::qosprof::utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST)));
         builtin_node->appendChild(locator_list_node);
     }
 

--- a/lib/src/cpp/utils/ParseXML.cpp
+++ b/lib/src/cpp/utils/ParseXML.cpp
@@ -30,7 +30,6 @@ namespace qosprof {
 namespace utils {
 
 ParseXML::ParseXML (
-        xercesc::DOMDocument*& doc,
         const std::string& file_name,
         bool create_file)
 {
@@ -130,6 +129,7 @@ ParseXML::~ParseXML()
 
     // Release resources
     delete config;
+    delete doc;
     delete implementation;
     delete output;
     delete parser;
@@ -138,17 +138,20 @@ ParseXML::~ParseXML()
     delete error_handler;
 }
 
-void ParseXML::validate_and_save_xml_document(
-        xercesc::DOMDocument*& doc)
+xercesc::DOMDocument* ParseXML::get_doc()
 {
-    if (validate_xml(doc))
+    return doc;
+}
+
+void ParseXML::validate_and_save_xml_document()
+{
+    if (validate_xml())
     {
-        save_xml(doc);
+        save_xml();
     }
 }
 
-bool ParseXML::validate_xml(
-        xercesc::DOMDocument*& doc)
+bool ParseXML::validate_xml()
 {
     // Set ElementInvalid error handler
     error_handler = new eprosima::qosprof::utils::ParseXMLErrorHandler(
@@ -170,8 +173,7 @@ bool ParseXML::validate_xml(
     return true;
 }
 
-bool ParseXML::save_xml(
-        xercesc::DOMDocument*& doc)
+bool ParseXML::save_xml()
 {
     // Config would configure serialized XML data
     config = serializer->getDomConfig();
@@ -378,7 +380,6 @@ void ParseXML::reset_node(
 }
 
 void ParseXML::set_value_to_node(
-        xercesc::DOMDocument*& doc,
         xercesc::DOMNode*& node,
         const std::string& value)
 {
@@ -449,34 +450,30 @@ std::unique_ptr<std::vector<uint>> ParseXML::get_real_index(
 }
 
 xercesc::DOMNode* ParseXML::get_node(
-        xercesc::DOMDocument*& doc,
         const std::string& tag_name)
 {
     // Try call main get_node function with remain empty values
-    return get_node(doc, tag_name, nullptr, "", "");
+    return get_node(tag_name, nullptr, "", "");
 }
 
 xercesc::DOMNode* ParseXML::get_node(
-        xercesc::DOMDocument*& doc,
         const std::string& tag_name,
         const std::string* index)
 {
     // Try call main get_node function with remain empty values
-    return get_node(doc, tag_name, index, "", "");
+    return get_node(tag_name, index, "", "");
 }
 
 xercesc::DOMNode* ParseXML::get_node(
-        xercesc::DOMDocument*& doc,
         const std::string& tag_name,
         const std::string& att_name,
         const std::string& att_value)
 {
     // Try call main get_node function with remain empty values
-    return get_node(doc, tag_name, nullptr, att_name, att_value);
+    return get_node(tag_name, nullptr, att_name, att_value);
 }
 
 xercesc::DOMNode* ParseXML::get_node(
-        xercesc::DOMDocument*& doc,
         const std::string& tag_name,
         const std::string* index,
         const std::string& att_name,

--- a/lib/src/cpp/utils/ParseXML.hpp
+++ b/lib/src/cpp/utils/ParseXML.hpp
@@ -50,14 +50,12 @@ public:
      * @brief Construct a new Parse XML object, which initializes Xerces required tools,
      *  and reads given xml_file document
      *
-     * @param[in out] doc DOMDocument* to be created
      * @param[in] xml_file string with the file path
      * @param[in] create_file bool (optional) create file if it does not exist flag
      *
      * @throw FileNotFound exception if Xerces XML workspace could not be initialized
      */
     ParseXML(
-            xercesc::DOMDocument*& doc,
             const std::string& xml_file,
             bool create_file = false);
 
@@ -70,12 +68,9 @@ public:
     /**
      * @brief Validate the document, and save to disk if valid
      *
-     * @param doc DOMDocument XML document with the parsed / created nodes
-     *
      * @throw ElementInvalid exception if document does not pass parser validation
      */
-    void validate_and_save_xml_document(
-            xercesc::DOMDocument*& doc);
+    void validate_and_save_xml_document();
 
     /**
      * @brief Remove the given node from the parent node
@@ -100,35 +95,36 @@ public:
     /**
      * @brief Set the value to node object
      *
-     * @param[in out] doc DOMDocument* document to use
      * @param node DOMNode node to be set
      * @param value to be set in the node
      */
     void set_value_to_node(
-            xercesc::DOMDocument*& doc,
             xercesc::DOMNode*& node,
             const std::string& value);
+
+    /**
+     * @brief Temporal function to get the doc object
+     *
+     * @return xercesc::DOMDocument* doc object
+     */
+    xercesc::DOMDocument* get_doc();
 
     /*
      * AUX get_node functions based on the implementation needs
      */
     xercesc::DOMNode* get_node(
-            xercesc::DOMDocument*& doc,
             const std::string& tag_name);
 
     xercesc::DOMNode* get_node(
-            xercesc::DOMDocument*& doc,
             const std::string& tag_name,
             const std::string* index);
 
     xercesc::DOMNode* get_node(
-            xercesc::DOMDocument*& doc,
             const std::string& tag_name,
             const std::string& att_name,
             const std::string& att_value);
 
     xercesc::DOMNode* get_node(
-            xercesc::DOMDocument*& doc,
             const std::string& tag_name,
             const std::string* index,
             const std::string& att_name,
@@ -176,26 +172,20 @@ private:
     /**
      * @brief Save the document as string and validate
      *
-     * @param doc DOMDocument XML document with the parsed / created nodes
-     *
      * @return true document passes parser validation
      * @return false document does not pass parser validation
      *
      * @throw ElementInvalid exception if document does not pass parser validation
      */
-    bool validate_xml(
-            xercesc::DOMDocument*& doc);
+    bool validate_xml();
 
     /**
      * @brief  Save the document in the target file path
      *
-     * @param doc DOMDocument XML document with the parsed / created nodes
-     *
      * @return true document saved
      * @return false failure saving document
      */
-    bool save_xml(
-            xercesc::DOMDocument*& doc);
+    bool save_xml();
 
     /**
      * @brief Get the absolute path of the given file name [POSIX only]
@@ -224,6 +214,7 @@ private:
 
     // Xerces tools required for node management
     xercesc::DOMConfiguration* config = nullptr;
+    xercesc::DOMDocument* doc = nullptr;
     xercesc::DOMImplementation* implementation = nullptr;
     xercesc::DOMLSOutput* output = nullptr;
     xercesc::XercesDOMParser* parser = nullptr;


### PR DESCRIPTION
**Note:**
In future PR, ParseXML method `get_doc` would be removed because DOMDocument object will no loger be used by any other method / class when `get_node` methods get refactor to include a flag to create node if not exist.

In that way, DOMDocument will not be defined in any public API method.
