### PR TITLE
[18047] Participant set_address & set_port

### DIFF
--- a/lib/src/cpp/common/LocatorList.cpp
+++ b/lib/src/cpp/common/LocatorList.cpp
@@ -29,7 +29,7 @@ namespace locator_list {
 
 std::string print(
         utils::ParseXML& manager,
-        xercesc::DOMElement*& xml_node,
+        const xercesc::DOMElement& xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -38,7 +38,7 @@ std::string print(
 
 std::string print_kind(
         utils::ParseXML& manager,
-        xercesc::DOMElement*& xml_node,
+        const xercesc::DOMElement& xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -47,7 +47,7 @@ std::string print_kind(
 
 std::string print_port(
         utils::ParseXML& manager,
-        xercesc::DOMElement*& xml_node,
+        const xercesc::DOMElement& xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -56,7 +56,7 @@ std::string print_port(
 
 std::string print_physical_port(
         utils::ParseXML& manager,
-        xercesc::DOMElement*& xml_node,
+        const xercesc::DOMElement& xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -65,7 +65,7 @@ std::string print_physical_port(
 
 std::string print_address(
         utils::ParseXML& manager,
-        xercesc::DOMElement*& xml_node,
+        const xercesc::DOMElement& xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -74,7 +74,7 @@ std::string print_address(
 
 std::string print_unique_lan_id(
         utils::ParseXML& manager,
-        xercesc::DOMElement*& xml_node,
+        const xercesc::DOMElement& xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -83,7 +83,7 @@ std::string print_unique_lan_id(
 
 std::string print_wan_address(
         utils::ParseXML& manager,
-        xercesc::DOMElement*& xml_node,
+        const xercesc::DOMElement& xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -92,14 +92,14 @@ std::string print_wan_address(
 
 uint32_t size(
         utils::ParseXML& manager,
-        xercesc::DOMElement*& xml_node)
+        const xercesc::DOMElement& xml_node)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear(
         utils::ParseXML& manager,
-        xercesc::DOMElement*& xml_node,
+        xercesc::DOMElement& xml_node,
         const std::string& index)
 {
     throw Unsupported("Unsupported");
@@ -107,7 +107,7 @@ void clear(
 
 void clear_port(
         utils::ParseXML& manager,
-        xercesc::DOMElement*& xml_node,
+        xercesc::DOMElement& xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -116,7 +116,7 @@ void clear_port(
 
 void clear_physical_port(
         utils::ParseXML& manager,
-        xercesc::DOMElement*& xml_node,
+        xercesc::DOMElement& xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -125,7 +125,7 @@ void clear_physical_port(
 
 void clear_address(
         utils::ParseXML& manager,
-        xercesc::DOMElement*& xml_node,
+        xercesc::DOMElement& xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -134,7 +134,7 @@ void clear_address(
 
 void clear_unique_lan_id(
         utils::ParseXML& manager,
-        xercesc::DOMElement*& xml_node,
+        xercesc::DOMElement& xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -143,7 +143,7 @@ void clear_unique_lan_id(
 
 void clear_wan_address(
         utils::ParseXML& manager,
-        xercesc::DOMElement*& xml_node,
+        xercesc::DOMElement& xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -152,7 +152,7 @@ void clear_wan_address(
 
 void set_kind(
         utils::ParseXML& manager,
-        xercesc::DOMElement*& xml_node,
+        xercesc::DOMElement& xml_node,
         const std::string& kind,
         const std::string& index,
         const bool is_external)
@@ -162,7 +162,7 @@ void set_kind(
 
 void set_port(
         utils::ParseXML& manager,
-        xercesc::DOMElement*& xml_node,
+        xercesc::DOMElement& xml_node,
         const std::string& port,
         const std::string& index,
         const bool is_external)
@@ -172,7 +172,7 @@ void set_port(
 
 void set_physical_port(
         utils::ParseXML& manager,
-        xercesc::DOMElement*& xml_node,
+        xercesc::DOMElement& xml_node,
         const std::string& physical_port,
         const std::string& index,
         const bool is_external)
@@ -182,7 +182,7 @@ void set_physical_port(
 
 void set_address(
         utils::ParseXML& manager,
-        xercesc::DOMElement*& xml_node,
+        xercesc::DOMElement& xml_node,
         const std::string& address,
         const std::string& index,
         const bool is_external)
@@ -192,7 +192,7 @@ void set_address(
 
 void set_unique_lan_id(
         utils::ParseXML& manager,
-        xercesc::DOMElement*& xml_node,
+        xercesc::DOMElement& xml_node,
         const std::string& unique_lan_id,
         const std::string& index,
         const bool is_external)
@@ -202,7 +202,7 @@ void set_unique_lan_id(
 
 void set_wan_address(
         utils::ParseXML& manager,
-        xercesc::DOMElement*& xml_node,
+        xercesc::DOMElement& xml_node,
         const std::string& wan_address,
         const std::string& index,
         const bool is_external)

--- a/lib/src/cpp/domain_participant/DefaultExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/DefaultExternalUnicastLocators.cpp
@@ -22,6 +22,7 @@
 
 #include <fastdds_qos_profiles_manager/exception/Exception.hpp>
 
+#include <common/LocatorList.hpp>
 #include <utils/ParseXML.hpp>
 #include <utils/ParseXMLTags.hpp>
 
@@ -156,7 +157,89 @@ void set_port(
         const std::string& port,
         const std::string& index)
 {
-    throw Unsupported("Unsupported");
+    // Xerces document manage XML elements
+    xercesc::DOMDocument* doc = nullptr;
+
+    // XML nodes and values
+    xercesc::DOMNode* profiles_node = nullptr;
+    xercesc::DOMNode* participant_node = nullptr;
+    xercesc::DOMNode* rtps_node = nullptr;
+    xercesc::DOMNode* locator_list_node = nullptr;
+    xercesc::DOMNode* locator_node = nullptr;
+
+    // Create XML manager and initialize the document
+    utils::ParseXML* manager = new utils::ParseXML(xml_file, true);
+    doc = manager->get_doc();
+
+    // Obtain profiles node
+    try
+    {
+        profiles_node = manager->get_node(utils::tag::PROFILES);
+    }
+    catch (const ElementNotFound& ex)
+    {
+        // Obtain root element
+        xercesc::DOMElement* root_element = doc->getDocumentElement();
+
+        // Add profiles
+        profiles_node = static_cast<xercesc::DOMNode*>(doc->createElement(
+                    xercesc::XMLString::transcode(utils::tag::PROFILES)));
+        root_element->appendChild(profiles_node);
+    }
+
+    // Obtain participant node with the profile id
+    try
+    {
+        participant_node = manager->get_node(
+            profiles_node,
+            utils::tag::PARTICIPANT,
+            utils::tag::PROFILE_NAME,
+            profile_id);
+    }
+    catch (const ElementNotFound& ex)
+    {
+        // create if not existent
+        xercesc::DOMElement* participant_element = doc->createElement(
+            xercesc::XMLString::transcode(utils::tag::PARTICIPANT));
+        profiles_node->appendChild(participant_element);
+        participant_element->setAttribute(
+            xercesc::XMLString::transcode(utils::tag::PROFILE_NAME),
+            xercesc::XMLString::transcode(profile_id.c_str()));
+        participant_node = static_cast<xercesc::DOMNode*>(participant_element);
+    }
+
+    // Obtain rtps node
+    try
+    {
+        rtps_node = manager->get_node(participant_node, utils::tag::RTPS);
+    }
+    catch (const ElementNotFound& ex)
+    {
+        // create if not existent
+        rtps_node = static_cast<xercesc::DOMNode*>(doc->createElement(
+                    xercesc::XMLString::transcode(utils::tag::RTPS)));
+        participant_node->appendChild(rtps_node);
+    }
+
+    // Obtain default external unicast locator list node
+    try
+    {
+        locator_list_node = manager->get_node(rtps_node,
+                        utils::tag::DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST);
+    }
+    catch (const ElementNotFound& ex)
+    {
+        // create if not existent
+        locator_list_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
+                    utils::tag::DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST)));
+        rtps_node->appendChild(locator_list_node);
+    }
+
+    common::locator_list::set_port(*manager, *dynamic_cast<xercesc::DOMElement*>(locator_list_node), port, index,
+            true);
+
+    // Validate new XML element and save it
+    manager->validate_and_save_xml_document();
 }
 
 void set_address(
@@ -165,7 +248,89 @@ void set_address(
         const std::string& address,
         const std::string& index)
 {
-    throw Unsupported("Unsupported");
+    // Xerces document manage XML elements
+    xercesc::DOMDocument* doc = nullptr;
+
+    // XML nodes and values
+    xercesc::DOMNode* profiles_node = nullptr;
+    xercesc::DOMNode* participant_node = nullptr;
+    xercesc::DOMNode* rtps_node = nullptr;
+    xercesc::DOMNode* locator_list_node = nullptr;
+    xercesc::DOMNode* locator_node = nullptr;
+
+    // Create XML manager and initialize the document
+    utils::ParseXML* manager = new utils::ParseXML(xml_file, true);
+    doc = manager->get_doc();
+
+    // Obtain profiles node
+    try
+    {
+        profiles_node = manager->get_node(utils::tag::PROFILES);
+    }
+    catch (const ElementNotFound& ex)
+    {
+        // Obtain root element
+        xercesc::DOMElement* root_element = doc->getDocumentElement();
+
+        // Add profiles
+        profiles_node = static_cast<xercesc::DOMNode*>(doc->createElement(
+                    xercesc::XMLString::transcode(utils::tag::PROFILES)));
+        root_element->appendChild(profiles_node);
+    }
+
+    // Obtain participant node with the profile id
+    try
+    {
+        participant_node = manager->get_node(
+            profiles_node,
+            utils::tag::PARTICIPANT,
+            utils::tag::PROFILE_NAME,
+            profile_id);
+    }
+    catch (const ElementNotFound& ex)
+    {
+        // create if not existent
+        xercesc::DOMElement* participant_element = doc->createElement(
+            xercesc::XMLString::transcode(utils::tag::PARTICIPANT));
+        profiles_node->appendChild(participant_element);
+        participant_element->setAttribute(
+            xercesc::XMLString::transcode(utils::tag::PROFILE_NAME),
+            xercesc::XMLString::transcode(profile_id.c_str()));
+        participant_node = static_cast<xercesc::DOMNode*>(participant_element);
+    }
+
+    // Obtain rtps node
+    try
+    {
+        rtps_node = manager->get_node(participant_node, utils::tag::RTPS);
+    }
+    catch (const ElementNotFound& ex)
+    {
+        // create if not existent
+        rtps_node = static_cast<xercesc::DOMNode*>(doc->createElement(
+                    xercesc::XMLString::transcode(utils::tag::RTPS)));
+        participant_node->appendChild(rtps_node);
+    }
+
+    // Obtain default external unicast locator list node
+    try
+    {
+        locator_list_node = manager->get_node(rtps_node,
+                        utils::tag::DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST);
+    }
+    catch (const ElementNotFound& ex)
+    {
+        // create if not existent
+        locator_list_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
+                    utils::tag::DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST)));
+        rtps_node->appendChild(locator_list_node);
+    }
+
+    common::locator_list::set_address(*manager, *dynamic_cast<xercesc::DOMElement*>(locator_list_node), address, index,
+            true);
+
+    // Validate new XML element and save it
+    manager->validate_and_save_xml_document();
 }
 
 void set_externality(
@@ -223,7 +388,6 @@ void set_externality(
             xercesc::XMLString::transcode(utils::tag::PROFILE_NAME),
             xercesc::XMLString::transcode(profile_id.c_str()));
         participant_node = static_cast<xercesc::DOMNode*>(participant_element);
-
     }
 
     // Obtain rtps node
@@ -237,7 +401,6 @@ void set_externality(
         rtps_node = static_cast<xercesc::DOMNode*>(doc->createElement(
                     xercesc::XMLString::transcode(utils::tag::RTPS)));
         participant_node->appendChild(rtps_node);
-
     }
 
     // Obtain default external unicast locator list node
@@ -253,7 +416,6 @@ void set_externality(
                     utils::tag::DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST)));
         rtps_node->appendChild(locator_list_node);
     }
-
 
     // Check if locator should be created
     if (index.empty())

--- a/lib/src/cpp/domain_participant/DefaultExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/DefaultExternalUnicastLocators.cpp
@@ -185,22 +185,22 @@ void set_externality(
     xercesc::DOMNode* locator_node = nullptr;
 
     // Create XML manager and initialize the document
-    eprosima::qosprof::utils::ParseXML* manager = new eprosima::qosprof::utils::ParseXML(xml_file, true);
+    utils::ParseXML* manager = new utils::ParseXML(xml_file, true);
     doc = manager->get_doc();
 
     // Obtain profiles node
     try
     {
-        profiles_node = manager->get_node(eprosima::qosprof::utils::tag::PROFILES);
+        profiles_node = manager->get_node(utils::tag::PROFILES);
     }
-    catch (const eprosima::qosprof::ElementNotFound& ex)
+    catch (const ElementNotFound& ex)
     {
         // Obtain root element
         xercesc::DOMElement* root_element = doc->getDocumentElement();
 
         // Add profiles
         profiles_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-                    xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::PROFILES)));
+                    xercesc::XMLString::transcode(utils::tag::PROFILES)));
         root_element->appendChild(profiles_node);
     }
 
@@ -209,18 +209,18 @@ void set_externality(
     {
         participant_node = manager->get_node(
             profiles_node,
-            eprosima::qosprof::utils::tag::PARTICIPANT,
-            eprosima::qosprof::utils::tag::PROFILE_NAME,
+            utils::tag::PARTICIPANT,
+            utils::tag::PROFILE_NAME,
             profile_id);
     }
-    catch (const eprosima::qosprof::ElementNotFound& ex)
+    catch (const ElementNotFound& ex)
     {
         // create if not existent
         xercesc::DOMElement* participant_element = doc->createElement(
-            xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::PARTICIPANT));
+            xercesc::XMLString::transcode(utils::tag::PARTICIPANT));
         profiles_node->appendChild(participant_element);
         participant_element->setAttribute(
-            xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::PROFILE_NAME),
+            xercesc::XMLString::transcode(utils::tag::PROFILE_NAME),
             xercesc::XMLString::transcode(profile_id.c_str()));
         participant_node = static_cast<xercesc::DOMNode*>(participant_element);
 
@@ -229,13 +229,13 @@ void set_externality(
     // Obtain rtps node
     try
     {
-        rtps_node = manager->get_node(participant_node, eprosima::qosprof::utils::tag::RTPS);
+        rtps_node = manager->get_node(participant_node, utils::tag::RTPS);
     }
-    catch (const eprosima::qosprof::ElementNotFound& ex)
+    catch (const ElementNotFound& ex)
     {
         // create if not existent
         rtps_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-                    xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::RTPS)));
+                    xercesc::XMLString::transcode(utils::tag::RTPS)));
         participant_node->appendChild(rtps_node);
 
     }
@@ -244,13 +244,13 @@ void set_externality(
     try
     {
         locator_list_node = manager->get_node(rtps_node,
-                        eprosima::qosprof::utils::tag::DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST);
+                        utils::tag::DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST);
     }
-    catch (const eprosima::qosprof::ElementNotFound& ex)
+    catch (const ElementNotFound& ex)
     {
         // create if not existent
         locator_list_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                    eprosima::qosprof::utils::tag::DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST)));
+                    utils::tag::DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST)));
         rtps_node->appendChild(locator_list_node);
     }
 
@@ -259,17 +259,17 @@ void set_externality(
     if (index.empty())
     {
         locator_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                    eprosima::qosprof::utils::tag::UDP_V4_LOCATOR)));
+                    utils::tag::UDP_V4_LOCATOR)));
         locator_list_node->appendChild(locator_node);
     }
     // Update the locator of the given index
     else
     {
-        locator_node = manager->get_node(locator_list_node, eprosima::qosprof::utils::tag::UDP_V4_LOCATOR, &index);
+        locator_node = manager->get_node(locator_list_node, utils::tag::UDP_V4_LOCATOR, &index);
     }
     // Set the externality value
     static_cast<xercesc::DOMElement*>(locator_node)->setAttribute(
-        xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::EXTERNALITY),
+        xercesc::XMLString::transcode(utils::tag::EXTERNALITY),
         xercesc::XMLString::transcode(externality.c_str()));
 
     // Validate new XML element and save it

--- a/lib/src/cpp/domain_participant/DomainParticipant.cpp
+++ b/lib/src/cpp/domain_participant/DomainParticipant.cpp
@@ -255,21 +255,21 @@ void set_default_profile(
     xercesc::DOMNode* default_profile_node = nullptr;
 
     // Create XML manager and initialize the document
-    eprosima::qosprof::utils::ParseXML* manager = new eprosima::qosprof::utils::ParseXML(xml_file, true);
+    utils::ParseXML* manager = new utils::ParseXML(xml_file, true);
     doc = manager->get_doc();
 
     // Obtain nodes
-    profiles_node = manager->get_node(eprosima::qosprof::utils::tag::PROFILES);
+    profiles_node = manager->get_node(utils::tag::PROFILES);
     participant_node = manager->get_node(
         profiles_node,
-        eprosima::qosprof::utils::tag::PARTICIPANT,
-        eprosima::qosprof::utils::tag::PROFILE_NAME,
+        utils::tag::PARTICIPANT,
+        utils::tag::PROFILE_NAME,
         profile_id);
 
 
     // Check if default profile already defined
     default_profile_node = participant_node->getAttributes()->getNamedItem(
-        xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::DEFAULT_PROFILE));
+        xercesc::XMLString::transcode(utils::tag::DEFAULT_PROFILE));
     if (default_profile_node != nullptr)
     {
         if (default_profile_node->getNodeValue() == xercesc::XMLString::transcode("true"))
@@ -281,18 +281,18 @@ void set_default_profile(
 
     // Set all participants as NOT default profile
     xercesc::DOMNodeList* participant_list = static_cast<xercesc::DOMElement*>(profiles_node)->getElementsByTagName(
-        xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::PARTICIPANT));
+        xercesc::XMLString::transcode(utils::tag::PARTICIPANT));
     // Iterate throw all the participants to set them as NOT default
     for (int i = 0, size = participant_list->getLength(); i < size; i++)
     {
         static_cast<xercesc::DOMElement*>(participant_list->item(i))->setAttribute(
-            xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::DEFAULT_PROFILE),
+            xercesc::XMLString::transcode(utils::tag::DEFAULT_PROFILE),
             xercesc::XMLString::transcode("false"));
     }
 
     // Set given participant as default profile
     static_cast<xercesc::DOMElement*>(participant_node)->setAttribute(
-        xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::DEFAULT_PROFILE),
+        xercesc::XMLString::transcode(utils::tag::DEFAULT_PROFILE),
         xercesc::XMLString::transcode("true"));
 
     // Validate new XML element and save it
@@ -322,22 +322,22 @@ void set_name(
     xercesc::DOMNode* name_node = nullptr;
 
     // Create XML manager and initialize the document
-    eprosima::qosprof::utils::ParseXML* manager = new eprosima::qosprof::utils::ParseXML(xml_file, true);
+    utils::ParseXML* manager = new utils::ParseXML(xml_file, true);
     doc = manager->get_doc();
 
     // Obtain profiles node
     try
     {
-        profiles_node = manager->get_node(eprosima::qosprof::utils::tag::PROFILES);
+        profiles_node = manager->get_node(utils::tag::PROFILES);
     }
-    catch (const eprosima::qosprof::ElementNotFound& ex)
+    catch (const ElementNotFound& ex)
     {
         // Obtain root element
         xercesc::DOMElement* root_element = doc->getDocumentElement();
 
         // Add profiles
         profiles_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-                    xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::PROFILES)));
+                    xercesc::XMLString::transcode(utils::tag::PROFILES)));
         root_element->appendChild(profiles_node);
     }
     // Obtain participant node with the profile id
@@ -345,18 +345,18 @@ void set_name(
     {
         participant_node = manager->get_node(
             profiles_node,
-            eprosima::qosprof::utils::tag::PARTICIPANT,
-            eprosima::qosprof::utils::tag::PROFILE_NAME,
+            utils::tag::PARTICIPANT,
+            utils::tag::PROFILE_NAME,
             profile_id);
     }
-    catch (const eprosima::qosprof::ElementNotFound& ex)
+    catch (const ElementNotFound& ex)
     {
         // create if not existent
         xercesc::DOMElement* participant_element = doc->createElement(
-            xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::PARTICIPANT));
+            xercesc::XMLString::transcode(utils::tag::PARTICIPANT));
         profiles_node->appendChild(participant_element);
         participant_element->setAttribute(
-            xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::PROFILE_NAME),
+            xercesc::XMLString::transcode(utils::tag::PROFILE_NAME),
             xercesc::XMLString::transcode(profile_id.c_str()));
         participant_node = static_cast<xercesc::DOMNode*>(participant_element);
     }
@@ -364,26 +364,26 @@ void set_name(
     // Obtain rtps node
     try
     {
-        rtps_node = manager->get_node(participant_node, eprosima::qosprof::utils::tag::RTPS);
+        rtps_node = manager->get_node(participant_node, utils::tag::RTPS);
     }
-    catch (const eprosima::qosprof::ElementNotFound& ex)
+    catch (const ElementNotFound& ex)
     {
         // create if not existent
         rtps_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-                    xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::RTPS)));
+                    xercesc::XMLString::transcode(utils::tag::RTPS)));
         participant_node->appendChild(rtps_node);
     }
 
     // Obtain name
     try
     {
-        name_node = manager->get_node(rtps_node, eprosima::qosprof::utils::tag::NAME);
+        name_node = manager->get_node(rtps_node, utils::tag::NAME);
     }
-    catch (const eprosima::qosprof::ElementNotFound& ex)
+    catch (const ElementNotFound& ex)
     {
         // create if not existent
         name_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-                    xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::NAME)));
+                    xercesc::XMLString::transcode(utils::tag::NAME)));
         rtps_node->appendChild(name_node);
     }
 

--- a/lib/src/cpp/domain_participant/builtin/InitialPeers.cpp
+++ b/lib/src/cpp/domain_participant/builtin/InitialPeers.cpp
@@ -249,7 +249,8 @@ void set_port(
         builtin_node->appendChild(locator_list_node);
     }
 
-    common::locator_list::set_port(*manager, *dynamic_cast<xercesc::DOMElement*>(locator_list_node), port, index, false);
+    common::locator_list::set_port(*manager, *dynamic_cast<xercesc::DOMElement*>(locator_list_node), port, index,
+            false);
 
     // Validate new XML element and save it
     manager->validate_and_save_xml_document();
@@ -361,7 +362,8 @@ void set_address(
         builtin_node->appendChild(locator_list_node);
     }
 
-    common::locator_list::set_address(*manager, *dynamic_cast<xercesc::DOMElement*>(locator_list_node), address, index, false);
+    common::locator_list::set_address(*manager, *dynamic_cast<xercesc::DOMElement*>(locator_list_node), address, index,
+            false);
 
     // Validate new XML element and save it
     manager->validate_and_save_xml_document();

--- a/lib/src/cpp/domain_participant/builtin/InitialPeers.cpp
+++ b/lib/src/cpp/domain_participant/builtin/InitialPeers.cpp
@@ -22,6 +22,10 @@
 
 #include <fastdds_qos_profiles_manager/exception/Exception.hpp>
 
+#include <common/LocatorList.hpp>
+#include <utils/ParseXML.hpp>
+#include <utils/ParseXMLTags.hpp>
+
 namespace eprosima {
 namespace qosprof {
 namespace domain_participant {
@@ -154,7 +158,101 @@ void set_port(
         const std::string& port,
         const std::string& index)
 {
-    throw Unsupported("Unsupported");
+    // Xerces document manage XML elements
+    xercesc::DOMDocument* doc = nullptr;
+
+    // XML nodes and values
+    xercesc::DOMNode* profiles_node = nullptr;
+    xercesc::DOMNode* participant_node = nullptr;
+    xercesc::DOMNode* rtps_node = nullptr;
+    xercesc::DOMNode* builtin_node = nullptr;
+    xercesc::DOMNode* locator_list_node = nullptr;
+    xercesc::DOMNode* locator_node = nullptr;
+
+    // Create XML manager and initialize the document
+    utils::ParseXML* manager = new utils::ParseXML(xml_file, true);
+    doc = manager->get_doc();
+
+    // Obtain profiles node
+    try
+    {
+        profiles_node = manager->get_node(utils::tag::PROFILES);
+    }
+    catch (const ElementNotFound& ex)
+    {
+        // Obtain root element
+        xercesc::DOMElement* root_element = doc->getDocumentElement();
+
+        // Add profiles
+        profiles_node = static_cast<xercesc::DOMNode*>(doc->createElement(
+                    xercesc::XMLString::transcode(utils::tag::PROFILES)));
+        root_element->appendChild(profiles_node);
+    }
+
+    // Obtain participant node with the profile id
+    try
+    {
+        participant_node = manager->get_node(
+            profiles_node,
+            utils::tag::PARTICIPANT,
+            utils::tag::PROFILE_NAME,
+            profile_id);
+    }
+    catch (const ElementNotFound& ex)
+    {
+        // create if not existent
+        xercesc::DOMElement* participant_element = doc->createElement(
+            xercesc::XMLString::transcode(utils::tag::PARTICIPANT));
+        profiles_node->appendChild(participant_element);
+        participant_element->setAttribute(
+            xercesc::XMLString::transcode(utils::tag::PROFILE_NAME),
+            xercesc::XMLString::transcode(profile_id.c_str()));
+        participant_node = static_cast<xercesc::DOMNode*>(participant_element);
+    }
+
+    // Obtain rtps node
+    try
+    {
+        rtps_node = manager->get_node(participant_node, utils::tag::RTPS);
+    }
+    catch (const ElementNotFound& ex)
+    {
+        // create if not existent
+        rtps_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
+                    utils::tag::RTPS)));
+        participant_node->appendChild(rtps_node);
+    }
+
+    // Obtain builtin node
+    try
+    {
+        builtin_node = manager->get_node(rtps_node, utils::tag::BUILTIN);
+    }
+    catch (const ElementNotFound& ex)
+    {
+        // create if not existent
+        builtin_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
+                    utils::tag::BUILTIN)));
+        rtps_node->appendChild(builtin_node);
+    }
+
+    // Obtain initial peers locator list node
+    try
+    {
+        locator_list_node = manager->get_node(builtin_node, utils::tag::INITIAL_PEERS_LIST);
+    }
+    catch (const ElementNotFound& ex)
+    {
+        // create if not existent
+        locator_list_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
+                    utils::tag::INITIAL_PEERS_LIST)));
+        builtin_node->appendChild(locator_list_node);
+    }
+
+    common::locator_list::set_port(*manager, *dynamic_cast<xercesc::DOMElement*>(locator_list_node), port, index, false);
+
+    // Validate new XML element and save it
+    manager->validate_and_save_xml_document();
 }
 
 void set_physical_port(
@@ -172,7 +270,101 @@ void set_address(
         const std::string& address,
         const std::string& index)
 {
-    throw Unsupported("Unsupported");
+    // Xerces document manage XML elements
+    xercesc::DOMDocument* doc = nullptr;
+
+    // XML nodes and values
+    xercesc::DOMNode* profiles_node = nullptr;
+    xercesc::DOMNode* participant_node = nullptr;
+    xercesc::DOMNode* rtps_node = nullptr;
+    xercesc::DOMNode* builtin_node = nullptr;
+    xercesc::DOMNode* locator_list_node = nullptr;
+    xercesc::DOMNode* locator_node = nullptr;
+
+    // Create XML manager and initialize the document
+    utils::ParseXML* manager = new utils::ParseXML(xml_file, true);
+    doc = manager->get_doc();
+
+    // Obtain profiles node
+    try
+    {
+        profiles_node = manager->get_node(utils::tag::PROFILES);
+    }
+    catch (const ElementNotFound& ex)
+    {
+        // Obtain root element
+        xercesc::DOMElement* root_element = doc->getDocumentElement();
+
+        // Add profiles
+        profiles_node = static_cast<xercesc::DOMNode*>(doc->createElement(
+                    xercesc::XMLString::transcode(utils::tag::PROFILES)));
+        root_element->appendChild(profiles_node);
+    }
+
+    // Obtain participant node with the profile id
+    try
+    {
+        participant_node = manager->get_node(
+            profiles_node,
+            utils::tag::PARTICIPANT,
+            utils::tag::PROFILE_NAME,
+            profile_id);
+    }
+    catch (const ElementNotFound& ex)
+    {
+        // create if not existent
+        xercesc::DOMElement* participant_element = doc->createElement(
+            xercesc::XMLString::transcode(utils::tag::PARTICIPANT));
+        profiles_node->appendChild(participant_element);
+        participant_element->setAttribute(
+            xercesc::XMLString::transcode(utils::tag::PROFILE_NAME),
+            xercesc::XMLString::transcode(profile_id.c_str()));
+        participant_node = static_cast<xercesc::DOMNode*>(participant_element);
+    }
+
+    // Obtain rtps node
+    try
+    {
+        rtps_node = manager->get_node(participant_node, utils::tag::RTPS);
+    }
+    catch (const ElementNotFound& ex)
+    {
+        // create if not existent
+        rtps_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
+                    utils::tag::RTPS)));
+        participant_node->appendChild(rtps_node);
+    }
+
+    // Obtain builtin node
+    try
+    {
+        builtin_node = manager->get_node(rtps_node, utils::tag::BUILTIN);
+    }
+    catch (const ElementNotFound& ex)
+    {
+        // create if not existent
+        builtin_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
+                    utils::tag::BUILTIN)));
+        rtps_node->appendChild(builtin_node);
+    }
+
+    // Obtain initial peers locator list node
+    try
+    {
+        locator_list_node = manager->get_node(builtin_node, utils::tag::INITIAL_PEERS_LIST);
+    }
+    catch (const ElementNotFound& ex)
+    {
+        // create if not existent
+        locator_list_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
+                    utils::tag::INITIAL_PEERS_LIST)));
+        builtin_node->appendChild(locator_list_node);
+    }
+
+    common::locator_list::set_address(*manager, *dynamic_cast<xercesc::DOMElement*>(locator_list_node), address, index, false);
+
+    // Validate new XML element and save it
+    manager->validate_and_save_xml_document();
 }
 
 void set_unique_lan_id(

--- a/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
@@ -254,7 +254,7 @@ void set_port(
             true);
 
     // Validate new XML element and save it
-    manager->validate_and_save_xml_document();    
+    manager->validate_and_save_xml_document();
 }
 
 void set_address(
@@ -359,7 +359,7 @@ void set_address(
             true);
 
     // Validate new XML element and save it
-    manager->validate_and_save_xml_document();    
+    manager->validate_and_save_xml_document();
 }
 
 void set_externality(

--- a/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
@@ -187,22 +187,22 @@ void set_externality(
     xercesc::DOMNode* locator_node = nullptr;
 
     // Create XML manager and initialize the document
-    eprosima::qosprof::utils::ParseXML* manager = new eprosima::qosprof::utils::ParseXML(xml_file, true);
+    utils::ParseXML* manager = new utils::ParseXML(xml_file, true);
     doc = manager->get_doc();
 
     // Obtain profiles node
     try
     {
-        profiles_node = manager->get_node(eprosima::qosprof::utils::tag::PROFILES);
+        profiles_node = manager->get_node(utils::tag::PROFILES);
     }
-    catch (const eprosima::qosprof::ElementNotFound& ex)
+    catch (const ElementNotFound& ex)
     {
         // Obtain root element
         xercesc::DOMElement* root_element = doc->getDocumentElement();
 
         // Add profiles
         profiles_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-                    xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::PROFILES)));
+                    xercesc::XMLString::transcode(utils::tag::PROFILES)));
         root_element->appendChild(profiles_node);
     }
 
@@ -211,18 +211,18 @@ void set_externality(
     {
         participant_node = manager->get_node(
             profiles_node,
-            eprosima::qosprof::utils::tag::PARTICIPANT,
-            eprosima::qosprof::utils::tag::PROFILE_NAME,
+            utils::tag::PARTICIPANT,
+            utils::tag::PROFILE_NAME,
             profile_id);
     }
-    catch (const eprosima::qosprof::ElementNotFound& ex)
+    catch (const ElementNotFound& ex)
     {
         // create if not existent
         xercesc::DOMElement* participant_element = doc->createElement(
-            xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::PARTICIPANT));
+            xercesc::XMLString::transcode(utils::tag::PARTICIPANT));
         profiles_node->appendChild(participant_element);
         participant_element->setAttribute(
-            xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::PROFILE_NAME),
+            xercesc::XMLString::transcode(utils::tag::PROFILE_NAME),
             xercesc::XMLString::transcode(profile_id.c_str()));
         participant_node = static_cast<xercesc::DOMNode*>(participant_element);
     }
@@ -230,26 +230,26 @@ void set_externality(
     // Obtain rtps node
     try
     {
-        rtps_node = manager->get_node(participant_node, eprosima::qosprof::utils::tag::RTPS);
+        rtps_node = manager->get_node(participant_node, utils::tag::RTPS);
     }
-    catch (const eprosima::qosprof::ElementNotFound& ex)
+    catch (const ElementNotFound& ex)
     {
         // create if not existent
         rtps_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                    eprosima::qosprof::utils::tag::RTPS)));
+                    utils::tag::RTPS)));
         participant_node->appendChild(rtps_node);
     }
 
     // Obtain builtin node
     try
     {
-        builtin_node = manager->get_node(rtps_node, eprosima::qosprof::utils::tag::BUILTIN);
+        builtin_node = manager->get_node(rtps_node, utils::tag::BUILTIN);
     }
-    catch (const eprosima::qosprof::ElementNotFound& ex)
+    catch (const ElementNotFound& ex)
     {
         // create if not existent
         builtin_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                    eprosima::qosprof::utils::tag::BUILTIN)));
+                    utils::tag::BUILTIN)));
         rtps_node->appendChild(builtin_node);
     }
 
@@ -257,13 +257,13 @@ void set_externality(
     try
     {
         locator_list_node = manager->get_node(builtin_node,
-                        eprosima::qosprof::utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST);
+                        utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST);
     }
-    catch (const eprosima::qosprof::ElementNotFound& ex)
+    catch (const ElementNotFound& ex)
     {
         // create if not existent
         locator_list_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                    eprosima::qosprof::utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST)));
+                    utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST)));
         builtin_node->appendChild(locator_list_node);
     }
 
@@ -272,17 +272,17 @@ void set_externality(
     if (index.empty())
     {
         locator_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                    eprosima::qosprof::utils::tag::UDP_V4_LOCATOR)));
+                    utils::tag::UDP_V4_LOCATOR)));
         locator_list_node->appendChild(locator_node);
     }
     // Update the locator of the given index
     else
     {
-        locator_node = manager->get_node(locator_list_node, eprosima::qosprof::utils::tag::UDP_V4_LOCATOR, &index);
+        locator_node = manager->get_node(locator_list_node, utils::tag::UDP_V4_LOCATOR, &index);
     }
     // Set the externality value
     static_cast<xercesc::DOMElement*>(locator_node)->setAttribute(
-        xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::EXTERNALITY),
+        xercesc::XMLString::transcode(utils::tag::EXTERNALITY),
         xercesc::XMLString::transcode(externality.c_str()));
 
     // Validate new XML element and save it

--- a/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
@@ -22,6 +22,7 @@
 
 #include <fastdds_qos_profiles_manager/exception/Exception.hpp>
 
+#include <common/LocatorList.hpp>
 #include <utils/ParseXML.hpp>
 #include <utils/ParseXMLTags.hpp>
 
@@ -157,7 +158,103 @@ void set_port(
         const std::string& port,
         const std::string& index)
 {
-    throw Unsupported("Unsupported");
+    // Xerces document manage XML elements
+    xercesc::DOMDocument* doc = nullptr;
+
+    // XML nodes and values
+    xercesc::DOMNode* profiles_node = nullptr;
+    xercesc::DOMNode* participant_node = nullptr;
+    xercesc::DOMNode* rtps_node = nullptr;
+    xercesc::DOMNode* builtin_node = nullptr;
+    xercesc::DOMNode* locator_list_node = nullptr;
+    xercesc::DOMNode* locator_node = nullptr;
+
+    // Create XML manager and initialize the document
+    utils::ParseXML* manager = new utils::ParseXML(xml_file, true);
+    doc = manager->get_doc();
+
+    // Obtain profiles node
+    try
+    {
+        profiles_node = manager->get_node(utils::tag::PROFILES);
+    }
+    catch (const ElementNotFound& ex)
+    {
+        // Obtain root element
+        xercesc::DOMElement* root_element = doc->getDocumentElement();
+
+        // Add profiles
+        profiles_node = static_cast<xercesc::DOMNode*>(doc->createElement(
+                    xercesc::XMLString::transcode(utils::tag::PROFILES)));
+        root_element->appendChild(profiles_node);
+    }
+
+    // Obtain participant node with the profile id
+    try
+    {
+        participant_node = manager->get_node(
+            profiles_node,
+            utils::tag::PARTICIPANT,
+            utils::tag::PROFILE_NAME,
+            profile_id);
+    }
+    catch (const ElementNotFound& ex)
+    {
+        // create if not existent
+        xercesc::DOMElement* participant_element = doc->createElement(
+            xercesc::XMLString::transcode(utils::tag::PARTICIPANT));
+        profiles_node->appendChild(participant_element);
+        participant_element->setAttribute(
+            xercesc::XMLString::transcode(utils::tag::PROFILE_NAME),
+            xercesc::XMLString::transcode(profile_id.c_str()));
+        participant_node = static_cast<xercesc::DOMNode*>(participant_element);
+    }
+
+    // Obtain rtps node
+    try
+    {
+        rtps_node = manager->get_node(participant_node, utils::tag::RTPS);
+    }
+    catch (const ElementNotFound& ex)
+    {
+        // create if not existent
+        rtps_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
+                    utils::tag::RTPS)));
+        participant_node->appendChild(rtps_node);
+    }
+
+    // Obtain builtin node
+    try
+    {
+        builtin_node = manager->get_node(rtps_node, utils::tag::BUILTIN);
+    }
+    catch (const ElementNotFound& ex)
+    {
+        // create if not existent
+        builtin_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
+                    utils::tag::BUILTIN)));
+        rtps_node->appendChild(builtin_node);
+    }
+
+    // Obtain meta-traffic external unicast locator list node
+    try
+    {
+        locator_list_node = manager->get_node(builtin_node,
+                        utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST);
+    }
+    catch (const ElementNotFound& ex)
+    {
+        // create if not existent
+        locator_list_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
+                    utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST)));
+        builtin_node->appendChild(locator_list_node);
+    }
+
+    common::locator_list::set_port(*manager, *dynamic_cast<xercesc::DOMElement*>(locator_list_node), port, index,
+            true);
+
+    // Validate new XML element and save it
+    manager->validate_and_save_xml_document();    
 }
 
 void set_address(
@@ -166,7 +263,103 @@ void set_address(
         const std::string& address,
         const std::string& index)
 {
-    throw Unsupported("Unsupported");
+    // Xerces document manage XML elements
+    xercesc::DOMDocument* doc = nullptr;
+
+    // XML nodes and values
+    xercesc::DOMNode* profiles_node = nullptr;
+    xercesc::DOMNode* participant_node = nullptr;
+    xercesc::DOMNode* rtps_node = nullptr;
+    xercesc::DOMNode* builtin_node = nullptr;
+    xercesc::DOMNode* locator_list_node = nullptr;
+    xercesc::DOMNode* locator_node = nullptr;
+
+    // Create XML manager and initialize the document
+    utils::ParseXML* manager = new utils::ParseXML(xml_file, true);
+    doc = manager->get_doc();
+
+    // Obtain profiles node
+    try
+    {
+        profiles_node = manager->get_node(utils::tag::PROFILES);
+    }
+    catch (const ElementNotFound& ex)
+    {
+        // Obtain root element
+        xercesc::DOMElement* root_element = doc->getDocumentElement();
+
+        // Add profiles
+        profiles_node = static_cast<xercesc::DOMNode*>(doc->createElement(
+                    xercesc::XMLString::transcode(utils::tag::PROFILES)));
+        root_element->appendChild(profiles_node);
+    }
+
+    // Obtain participant node with the profile id
+    try
+    {
+        participant_node = manager->get_node(
+            profiles_node,
+            utils::tag::PARTICIPANT,
+            utils::tag::PROFILE_NAME,
+            profile_id);
+    }
+    catch (const ElementNotFound& ex)
+    {
+        // create if not existent
+        xercesc::DOMElement* participant_element = doc->createElement(
+            xercesc::XMLString::transcode(utils::tag::PARTICIPANT));
+        profiles_node->appendChild(participant_element);
+        participant_element->setAttribute(
+            xercesc::XMLString::transcode(utils::tag::PROFILE_NAME),
+            xercesc::XMLString::transcode(profile_id.c_str()));
+        participant_node = static_cast<xercesc::DOMNode*>(participant_element);
+    }
+
+    // Obtain rtps node
+    try
+    {
+        rtps_node = manager->get_node(participant_node, utils::tag::RTPS);
+    }
+    catch (const ElementNotFound& ex)
+    {
+        // create if not existent
+        rtps_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
+                    utils::tag::RTPS)));
+        participant_node->appendChild(rtps_node);
+    }
+
+    // Obtain builtin node
+    try
+    {
+        builtin_node = manager->get_node(rtps_node, utils::tag::BUILTIN);
+    }
+    catch (const ElementNotFound& ex)
+    {
+        // create if not existent
+        builtin_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
+                    utils::tag::BUILTIN)));
+        rtps_node->appendChild(builtin_node);
+    }
+
+    // Obtain meta-traffic external unicast locator list node
+    try
+    {
+        locator_list_node = manager->get_node(builtin_node,
+                        utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST);
+    }
+    catch (const ElementNotFound& ex)
+    {
+        // create if not existent
+        locator_list_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
+                    utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST)));
+        builtin_node->appendChild(locator_list_node);
+    }
+
+    common::locator_list::set_address(*manager, *dynamic_cast<xercesc::DOMElement*>(locator_list_node), address, index,
+            true);
+
+    // Validate new XML element and save it
+    manager->validate_and_save_xml_document();    
 }
 
 void set_externality(

--- a/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
@@ -267,7 +267,6 @@ void set_externality(
         builtin_node->appendChild(locator_list_node);
     }
 
-
     // Check if locator should be created
     if (index.empty())
     {

--- a/lib/src/cpp/utils/ParseXML.cpp
+++ b/lib/src/cpp/utils/ParseXML.cpp
@@ -70,8 +70,8 @@ ParseXML::ParseXML (
     parser = new xercesc::XercesDOMParser();
 
     // Error handler would receive the exception from the parser, and report it as a FileNotFound expected exception
-    error_handler = new eprosima::qosprof::utils::ParseXMLErrorHandler(
-        eprosima::qosprof::utils::ParseXMLErrorHandler::Kind::FileNotFound);
+    error_handler = new utils::ParseXMLErrorHandler(
+        utils::ParseXMLErrorHandler::Kind::FileNotFound);
     parser->setErrorHandler(error_handler);
 
     // Read XML file and obtain the doc object
@@ -83,18 +83,18 @@ ParseXML::ParseXML (
         doc = parser->getDocument();
     }
     // Given file does not exist
-    catch (const eprosima::qosprof::FileNotFound& ex)
+    catch (const FileNotFound& ex)
     {
         // Create new document if required
         if (create_file && !file_exists)
         {
             // Implementation would create an empty document
             doc = implementation->createDocument(0, xercesc::XMLString::transcode(
-                                eprosima::qosprof::utils::tag::ROOT), 0);
+                                utils::tag::ROOT), 0);
             // The root element would be <dds>, with the 'xmlns' att.
             doc->getDocumentElement()->setAttribute(
-                xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::XMLNS),
-                xercesc::XMLString::transcode(eprosima::qosprof::utils::tag::EPROSIMA_URL));
+                xercesc::XMLString::transcode(utils::tag::XMLNS),
+                xercesc::XMLString::transcode(utils::tag::EPROSIMA_URL));
         }
         // Propagate the exception
         else
@@ -106,7 +106,7 @@ ParseXML::ParseXML (
     // Set up Validation parameters: XSD pash
     std::string xsd_file_path = FASTDDS_QOS_PROFILES_MANAGER_XML_SCHEMA;
     // Set as namespace location both URL and the path to the XML schema
-    std::string namespace_schema_location = eprosima::qosprof::utils::tag::EPROSIMA_URL;
+    std::string namespace_schema_location = utils::tag::EPROSIMA_URL;
     namespace_schema_location += " " + xsd_file_path;
     // Load the schema as part of the grammar of the parser
     parser->loadGrammar(xsd_file_path.c_str(), xercesc::Grammar::SchemaGrammarType, true);
@@ -154,12 +154,12 @@ void ParseXML::validate_and_save_xml_document()
 bool ParseXML::validate_xml()
 {
     // Set ElementInvalid error handler
-    error_handler = new eprosima::qosprof::utils::ParseXMLErrorHandler(
-        eprosima::qosprof::utils::ParseXMLErrorHandler::Kind::ElementInvalid);
+    error_handler = new utils::ParseXMLErrorHandler(
+        utils::ParseXMLErrorHandler::Kind::ElementInvalid);
     parser->setErrorHandler(error_handler);
 
     // Create a XML string buffer for validation
-    eprosima::qosprof::utils::ParseXMLString* xml_string = new eprosima::qosprof::utils::ParseXMLString();
+    utils::ParseXMLString* xml_string = new utils::ParseXMLString();
 
     // Save XML document in the XML string buffer
     output->setByteStream(xml_string);
@@ -204,7 +204,7 @@ xercesc::DOMNode* ParseXML::get_node(
     // Throw exception if no nodes
     if (node_list->getLength() == 0)
     {
-        // Throw eprosima::qosprof::ElementNotFound exception
+        // Throw ElementNotFound exception
         throw ElementNotFound("non-existent " + tag_name + " element\n");
     }
     // Complex element Node
@@ -254,14 +254,14 @@ xercesc::DOMNode* ParseXML::get_node(
                             }
                             else
                             {
-                                // Throw eprosima::qosprof::ElementNotFound exception
+                                // Throw ElementNotFound exception
                                 throw ElementNotFound(
                                           tag_name + " does not have the attribute " + att_name + "\n");
                             }
                         }
                         else
                         {
-                            // Throw eprosima::qosprof::ElementNotFound exception
+                            // Throw ElementNotFound exception
                             throw ElementNotFound(
                                       tag_name + " does not have the attribute " + att_name + "\n");
                         }
@@ -303,7 +303,7 @@ xercesc::DOMNode* ParseXML::get_node(
                             // Check bounds
                             if (real_index < 0 || real_index >= index_list->size())
                             {
-                                // Throw eprosima::qosprof::ElementNotFound exception
+                                // Throw ElementNotFound exception
                                 throw ElementNotFound(
                                           tag_name + " does not have an element in position " +
                                           std::to_string(real_index) + "\n");

--- a/lib/src/cpp/utils/ParseXML.hpp
+++ b/lib/src/cpp/utils/ParseXML.hpp
@@ -225,7 +225,7 @@ private:
     std::string xml_file;
 
     // Custom utils
-    eprosima::qosprof::utils::ParseXMLErrorHandler* error_handler = nullptr;
+    utils::ParseXMLErrorHandler* error_handler = nullptr;
 };
 
 } /* parse */

--- a/lib/src/cpp/utils/ParseXMLTags.hpp
+++ b/lib/src/cpp/utils/ParseXMLTags.hpp
@@ -25,32 +25,32 @@ namespace utils {
 namespace tag {
 
 // HEADER TAGS
-constexpr const char* XMLNS = "xmlns";
 constexpr const char* EPROSIMA_URL = "http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles";
+constexpr const char* XMLNS = "xmlns";
 
 // MAIN ROOT TAGS
-constexpr const char* ROOT = "dds";
 constexpr const char* PROFILES = "profiles";
+constexpr const char* ROOT = "dds";
 
 // PROFILE TAGS
-constexpr const char* PROFILE_NAME = "profile_name";
 constexpr const char* DEFAULT_PROFILE = "is_default_profile";
 constexpr const char* PARTICIPANT = "participant";
+constexpr const char* PROFILE_NAME = "profile_name";
 
 /// PARTICIPANT
 constexpr const char* RTPS = "rtps";
 
 /// RTPS PARTICIPANT
-constexpr const char* NAME = "name";
 constexpr const char* BUILTIN = "builtin";
 constexpr const char* DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST = "default_external_unicast_locators";
 constexpr const char* METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST = "metatraffic_external_unicast_locators";
+constexpr const char* NAME = "name";
 
 // COMMONS
 /// LOCATOR
+constexpr const char* EXTERNALITY = "externality";
 constexpr const char* UDP_V4_LOCATOR = "udpv4";
 constexpr const char* UDP_V6_LOCATOR = "udpv6";
-constexpr const char* EXTERNALITY = "externality";
 
 } /* tag */
 } /* utils */

--- a/lib/src/cpp/utils/ParseXMLTags.hpp
+++ b/lib/src/cpp/utils/ParseXMLTags.hpp
@@ -43,6 +43,7 @@ constexpr const char* RTPS = "rtps";
 /// RTPS PARTICIPANT
 constexpr const char* BUILTIN = "builtin";
 constexpr const char* DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST = "default_external_unicast_locators";
+constexpr const char* INITIAL_PEERS_LIST = "initialPeersList";
 constexpr const char* METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST = "metatraffic_external_unicast_locators";
 constexpr const char* NAME = "name";
 


### PR DESCRIPTION
This PR includes the implementation of the functions `set_address` and `set_port` for the DomainParticipant:

* Initial Peers
* Default External Unicast Locators
* Metatraffic External Unicast Locators