### PR TITLE
[18026] Refactor utils infraestructure

### DIFF
--- a/lib/src/cpp/common/LocatorList.cpp
+++ b/lib/src/cpp/common/LocatorList.cpp
@@ -32,7 +32,6 @@ namespace locator_list {
 
 std::string print(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -41,7 +40,6 @@ std::string print(
 
 std::string print_kind(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -50,7 +48,6 @@ std::string print_kind(
 
 std::string print_port(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -59,7 +56,6 @@ std::string print_port(
 
 std::string print_physical_port(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -68,7 +64,6 @@ std::string print_physical_port(
 
 std::string print_address(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -77,7 +72,6 @@ std::string print_address(
 
 std::string print_unique_lan_id(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -86,7 +80,6 @@ std::string print_unique_lan_id(
 
 std::string print_wan_address(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -102,7 +95,6 @@ uint32_t size(
 
 void clear(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& index)
 {
     throw Unsupported("Unsupported");
@@ -110,7 +102,6 @@ void clear(
 
 void clear_port(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -119,7 +110,6 @@ void clear_port(
 
 void clear_physical_port(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -128,7 +118,6 @@ void clear_physical_port(
 
 void clear_address(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -137,7 +126,6 @@ void clear_address(
 
 void clear_unique_lan_id(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -146,7 +134,6 @@ void clear_unique_lan_id(
 
 void clear_wan_address(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -155,7 +142,6 @@ void clear_wan_address(
 
 void set_kind(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& kind,
         const std::string& index,
         const bool is_external)
@@ -165,90 +151,30 @@ void set_kind(
 
 void set_port(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& port,
         const std::string& index,
         const bool is_external)
 {
-    xercesc::DOMDocument* doc = manager.get_doc();
-    xercesc::DOMNode* locator_node = nullptr;
-    xercesc::DOMNode* kind_node = nullptr;
-    xercesc::DOMNode* port_node = nullptr;
-
-    // Create new locator and push it in the list
-    if (index.empty())
+    // append the new kind node directly to the given parent
+    if (is_external)
     {
-        // create default udp v4 kind
-        kind_node = static_cast<xercesc::DOMNode*> (doc->createElement(
-                    xercesc::XMLString::transcode(utils::tag::UDP_V4_LOCATOR)));
-
-        // append the new kind node directly to the given parent
-        if (is_external)
-        {
-            xml_node->appendChild(kind_node);
-        }
-        // create <locator> tag if required
-        else
-        {
-            locator_node = static_cast<xercesc::DOMNode*> (doc->createElement(
-                        xercesc::XMLString::transcode(utils::tag::LOCATOR)));
-            xml_node->appendChild(locator_node);
-            locator_node->appendChild(kind_node);
-        }
-
-        // add port node to the kind node
-        port_node = static_cast<xercesc::DOMNode*> (doc->createElement(
-                    xercesc::XMLString::transcode(utils::tag::PORT)));
-        kind_node->appendChild(port_node);
+        manager.get_locator_node(index, utils::tag::UDP_V4_LOCATOR, true);
     }
-    // set the port value in the locator defined by the index
+    // create <locator> tag if required
     else
     {
-        std::string* ind = new std::string();
-        ind->append(index);
-
-        // obtain the locator kind directly
-        if (is_external)
-        {
-            // TODO update this and the infraestructure
-            kind_node = manager.get_node(xml_node, utils::tag::UDP_V4_LOCATOR, ind);
-        }
-        // obtain kind from <locator> tag
-        else
-        {
-            locator_node = manager.get_node(xml_node, utils::tag::LOCATOR, ind);
-
-            xercesc::DOMNodeList* kind_list = locator_node->getChildNodes();
-            for (int i = 0, size = kind_list->getLength(); i < size; i++)
-            {
-                if (kind_list->item(i)->getNodeType() == xercesc::DOMNode::NodeType::ELEMENT_NODE)
-                {
-                    kind_node = kind_list->item(i);
-                    break;
-                }
-            }
-        }
-
-        // obtain the port of the given locator
-        try
-        {
-            port_node = manager.get_node(kind_node, utils::tag::PORT);
-        }
-        // create the port node in the given locator
-        catch (const ElementNotFound& ex)
-        {
-            port_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-                        xercesc::XMLString::transcode(utils::tag::PORT)));
-            kind_node->appendChild(port_node);
-        }
+        manager.get_locator_node(index, utils::tag::LOCATOR, true);
     }
+
+    // add port node to the kind node
+    manager.get_node(utils::tag::PORT, true);
+
     // set port node value
-    manager.set_value_to_node(port_node, port);
+    manager.set_value_to_node(port);
 }
 
 void set_physical_port(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& physical_port,
         const std::string& index,
         const bool is_external)
@@ -258,90 +184,30 @@ void set_physical_port(
 
 void set_address(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& address,
         const std::string& index,
         const bool is_external)
 {
-    xercesc::DOMDocument* doc = manager.get_doc();
-    xercesc::DOMNode* locator_node = nullptr;
-    xercesc::DOMNode* kind_node = nullptr;
-    xercesc::DOMNode* address_node = nullptr;
-
-    // Create new locator and push it in the list
-    if (index.empty())
+    // append the new kind node directly to the given parent
+    if (is_external)
     {
-        // create default udp v4 kind
-        kind_node = static_cast<xercesc::DOMNode*> (doc->createElement(
-                    xercesc::XMLString::transcode(utils::tag::UDP_V4_LOCATOR)));
-
-        // append the new kind node directly to the given parent
-        if (is_external)
-        {
-            xml_node->appendChild(kind_node);
-        }
-        // create <locator> tag if required
-        else
-        {
-            locator_node = static_cast<xercesc::DOMNode*> (doc->createElement(
-                        xercesc::XMLString::transcode(utils::tag::LOCATOR)));
-            xml_node->appendChild(locator_node);
-            locator_node->appendChild(kind_node);
-        }
-
-        // add address node to the kind node
-        address_node = static_cast<xercesc::DOMNode*> (doc->createElement(
-                    xercesc::XMLString::transcode(utils::tag::ADDRESS)));
-        kind_node->appendChild(address_node);
+        manager.get_locator_node(index, utils::tag::UDP_V4_LOCATOR, true);
     }
-    // set the address value in the locator defined by the index
+    // create <locator> tag if required
     else
     {
-        std::string* ind = new std::string();
-        ind->append(index);
-
-        // obtain the locator kind directly
-        if (is_external)
-        {
-            // TODO update this and the infraestructure
-            kind_node = manager.get_node(xml_node, utils::tag::UDP_V4_LOCATOR, ind);
-        }
-        // obtain kind from <locator> tag
-        else
-        {
-            locator_node = manager.get_node(xml_node, utils::tag::LOCATOR, ind);
-
-            xercesc::DOMNodeList* kind_list = locator_node->getChildNodes();
-            for (int i = 0, size = kind_list->getLength(); i < size; i++)
-            {
-                if (kind_list->item(i)->getNodeType() == xercesc::DOMNode::NodeType::ELEMENT_NODE)
-                {
-                    kind_node = kind_list->item(i);
-                    break;
-                }
-            }
-        }
-
-        // obtain the address of the given locator
-        try
-        {
-            address_node = manager.get_node(kind_node, utils::tag::ADDRESS);
-        }
-        // create the address node in the given locator
-        catch (const ElementNotFound& ex)
-        {
-            address_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-                        xercesc::XMLString::transcode(utils::tag::ADDRESS)));
-            kind_node->appendChild(address_node);
-        }
+        manager.get_locator_node(index, utils::tag::LOCATOR, true);
     }
-    // set port node value
-    manager.set_value_to_node(address_node, address);
+
+    // add address node to the kind node
+    manager.get_node(utils::tag::ADDRESS, true);
+
+    // set address node value
+    manager.set_value_to_node(address);
 }
 
 void set_unique_lan_id(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& unique_lan_id,
         const std::string& index,
         const bool is_external)
@@ -351,7 +217,6 @@ void set_unique_lan_id(
 
 void set_wan_address(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& wan_address,
         const std::string& index,
         const bool is_external)

--- a/lib/src/cpp/common/LocatorList.cpp
+++ b/lib/src/cpp/common/LocatorList.cpp
@@ -87,8 +87,7 @@ std::string print_wan_address(
 }
 
 uint32_t size(
-        utils::XMLManager& manager,
-        const xercesc::DOMElement& xml_node)
+        utils::XMLManager& manager)
 {
     throw Unsupported("Unsupported");
 }
@@ -155,16 +154,8 @@ void set_port(
         const std::string& index,
         const bool is_external)
 {
-    // append the new kind node directly to the given parent
-    if (is_external)
-    {
-        manager.get_locator_node(index, utils::tag::UDP_V4_LOCATOR, true);
-    }
-    // create <locator> tag if required
-    else
-    {
-        manager.get_locator_node(index, utils::tag::LOCATOR, true);
-    }
+    // get the kind node
+    manager.get_locator_node(index, is_external, true);
 
     // add port node to the kind node
     manager.get_node(utils::tag::PORT, true);
@@ -188,16 +179,8 @@ void set_address(
         const std::string& index,
         const bool is_external)
 {
-    // append the new kind node directly to the given parent
-    if (is_external)
-    {
-        manager.get_locator_node(index, utils::tag::UDP_V4_LOCATOR, true);
-    }
-    // create <locator> tag if required
-    else
-    {
-        manager.get_locator_node(index, utils::tag::LOCATOR, true);
-    }
+    // get the kind node
+    manager.get_locator_node(index, is_external, true);
 
     // add address node to the kind node
     manager.get_node(utils::tag::ADDRESS, true);

--- a/lib/src/cpp/common/LocatorList.cpp
+++ b/lib/src/cpp/common/LocatorList.cpp
@@ -32,7 +32,7 @@ namespace locator_list {
 
 std::string print(
         utils::XMLManager& manager,
-        const xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -41,7 +41,7 @@ std::string print(
 
 std::string print_kind(
         utils::XMLManager& manager,
-        const xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -50,7 +50,7 @@ std::string print_kind(
 
 std::string print_port(
         utils::XMLManager& manager,
-        const xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -59,7 +59,7 @@ std::string print_port(
 
 std::string print_physical_port(
         utils::XMLManager& manager,
-        const xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -68,7 +68,7 @@ std::string print_physical_port(
 
 std::string print_address(
         utils::XMLManager& manager,
-        const xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -77,7 +77,7 @@ std::string print_address(
 
 std::string print_unique_lan_id(
         utils::XMLManager& manager,
-        const xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -86,7 +86,7 @@ std::string print_unique_lan_id(
 
 std::string print_wan_address(
         utils::XMLManager& manager,
-        const xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -102,7 +102,7 @@ uint32_t size(
 
 void clear(
         utils::XMLManager& manager,
-        xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& index)
 {
     throw Unsupported("Unsupported");
@@ -110,7 +110,7 @@ void clear(
 
 void clear_port(
         utils::XMLManager& manager,
-        xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -119,7 +119,7 @@ void clear_port(
 
 void clear_physical_port(
         utils::XMLManager& manager,
-        xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -128,7 +128,7 @@ void clear_physical_port(
 
 void clear_address(
         utils::XMLManager& manager,
-        xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -137,7 +137,7 @@ void clear_address(
 
 void clear_unique_lan_id(
         utils::XMLManager& manager,
-        xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -146,7 +146,7 @@ void clear_unique_lan_id(
 
 void clear_wan_address(
         utils::XMLManager& manager,
-        xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external)
 {
@@ -155,7 +155,7 @@ void clear_wan_address(
 
 void set_kind(
         utils::XMLManager& manager,
-        xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& kind,
         const std::string& index,
         const bool is_external)
@@ -248,7 +248,7 @@ void set_port(
 
 void set_physical_port(
         utils::XMLManager& manager,
-        xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& physical_port,
         const std::string& index,
         const bool is_external)
@@ -341,7 +341,7 @@ void set_address(
 
 void set_unique_lan_id(
         utils::XMLManager& manager,
-        xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& unique_lan_id,
         const std::string& index,
         const bool is_external)
@@ -351,7 +351,7 @@ void set_unique_lan_id(
 
 void set_wan_address(
         utils::XMLManager& manager,
-        xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& wan_address,
         const std::string& index,
         const bool is_external)

--- a/lib/src/cpp/common/LocatorList.hpp
+++ b/lib/src/cpp/common/LocatorList.hpp
@@ -175,8 +175,7 @@ std::string print_wan_address(
  * @throw ElementNotFound Exception if the list has not been set.
  */
 uint32_t size(
-        utils::XMLManager& manager,
-        const xercesc::DOMElement& xml_node);
+        utils::XMLManager& manager);
 
 /************************************************************************/
 /* Clear functions                                                      */

--- a/lib/src/cpp/common/LocatorList.hpp
+++ b/lib/src/cpp/common/LocatorList.hpp
@@ -48,7 +48,7 @@ namespace locator_list {
  */
 std::string print(
         utils::XMLManager& manager,
-        const xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external);
 
@@ -68,7 +68,7 @@ std::string print(
  */
 std::string print_kind(
         utils::XMLManager& manager,
-        const xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external);
 
@@ -88,7 +88,7 @@ std::string print_kind(
  */
 std::string print_port(
         utils::XMLManager& manager,
-        const xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external);
 
@@ -109,7 +109,7 @@ std::string print_port(
  */
 std::string print_physical_port(
         utils::XMLManager& manager,
-        const xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external);
 
@@ -129,7 +129,7 @@ std::string print_physical_port(
  */
 std::string print_address(
         utils::XMLManager& manager,
-        const xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external);
 
@@ -150,7 +150,7 @@ std::string print_address(
  */
 std::string print_unique_lan_id(
         utils::XMLManager& manager,
-        const xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external);
 
@@ -171,7 +171,7 @@ std::string print_unique_lan_id(
  */
 std::string print_wan_address(
         utils::XMLManager& manager,
-        const xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external);
 
@@ -211,7 +211,7 @@ uint32_t size(
  */
 void clear(
         utils::XMLManager& manager,
-        xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& index);
 
 /**
@@ -228,7 +228,7 @@ void clear(
  */
 void clear_port(
         utils::XMLManager& manager,
-        xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external);
 
@@ -246,7 +246,7 @@ void clear_port(
  */
 void clear_physical_port(
         utils::XMLManager& manager,
-        xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external);
 
@@ -264,7 +264,7 @@ void clear_physical_port(
  */
 void clear_address(
         utils::XMLManager& manager,
-        xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external);
 
@@ -282,7 +282,7 @@ void clear_address(
  */
 void clear_unique_lan_id(
         utils::XMLManager& manager,
-        xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external);
 
@@ -300,7 +300,7 @@ void clear_unique_lan_id(
  */
 void clear_wan_address(
         utils::XMLManager& manager,
-        xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external);
 
@@ -323,7 +323,7 @@ void clear_wan_address(
  */
 void set_kind(
         utils::XMLManager& manager,
-        xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& kind,
         const std::string& index,
         const bool is_external);
@@ -364,7 +364,7 @@ void set_port(
  */
 void set_physical_port(
         utils::XMLManager& manager,
-        xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& physical_port,
         const std::string& index,
         const bool is_external);
@@ -405,7 +405,7 @@ void set_address(
  */
 void set_unique_lan_id(
         utils::XMLManager& manager,
-        xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& unique_lan_id,
         const std::string& index,
         const bool is_external);
@@ -425,7 +425,7 @@ void set_unique_lan_id(
  */
 void set_wan_address(
         utils::XMLManager& manager,
-        xercesc::DOMElement& xml_node,
+        xercesc::DOMNode* xml_node,
         const std::string& wan_address,
         const std::string& index,
         const bool is_external);

--- a/lib/src/cpp/common/LocatorList.hpp
+++ b/lib/src/cpp/common/LocatorList.hpp
@@ -36,7 +36,6 @@ namespace locator_list {
  * @brief Parse XML node and print the locator.
  *
  * @param[in] manager Internal util manager to obtain and work with nodes
- * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be printed. If empty, the complete list is printed.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
@@ -48,7 +47,6 @@ namespace locator_list {
  */
 std::string print(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external);
 
@@ -56,7 +54,6 @@ std::string print(
  * @brief Parse XML node and print the locator kind.
  *
  * @param[in] manager Internal util manager to obtain and work with nodes
- * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be printed.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
@@ -68,7 +65,6 @@ std::string print(
  */
 std::string print_kind(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external);
 
@@ -76,7 +72,6 @@ std::string print_kind(
  * @brief Parse XML node and print the locator port.
  *
  * @param[in] manager Internal util manager to obtain and work with nodes
- * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be printed.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
@@ -88,7 +83,6 @@ std::string print_kind(
  */
 std::string print_port(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external);
 
@@ -97,7 +91,6 @@ std::string print_port(
  *        TCP only.
  *
  * @param[in] manager Internal util manager to obtain and work with nodes
- * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be printed.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
@@ -109,7 +102,6 @@ std::string print_port(
  */
 std::string print_physical_port(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external);
 
@@ -117,7 +109,6 @@ std::string print_physical_port(
  * @brief Parse XML node and print the locator IP address.
  *
  * @param[in] manager Internal util manager to obtain and work with nodes
- * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be printed.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
@@ -129,7 +120,6 @@ std::string print_physical_port(
  */
 std::string print_address(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external);
 
@@ -138,7 +128,6 @@ std::string print_address(
  *        TCPv4 only.
  *
  * @param[in] manager Internal util manager to obtain and work with nodes
- * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be printed.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
@@ -150,7 +139,6 @@ std::string print_address(
  */
 std::string print_unique_lan_id(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external);
 
@@ -159,7 +147,6 @@ std::string print_unique_lan_id(
  *        TCPv4 only.
  *
  * @param[in] manager Internal util manager to obtain and work with nodes
- * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be printed.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
@@ -171,7 +158,6 @@ std::string print_unique_lan_id(
  */
 std::string print_wan_address(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external);
 
@@ -183,7 +169,6 @@ std::string print_wan_address(
  * @brief Number of locators defined.
  *
  * @param[in] manager Internal util manager to obtain and work with nodes
- * @param[in] xml_node Locator list node where all locators are uploaded.
  *
  * @return uint32_t Number of locators in the list.
  *
@@ -202,7 +187,6 @@ uint32_t size(
  *       locator list would be removed. If provided, then the corresponding locator would be removed.
  *
  * @param[in] manager Internal util manager to obtain and work with nodes
- * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be removed. If empty, the complete list is removed.
  *
  * @throw ElementNotFound Exception if the element does not exist in the collection if an index is
@@ -211,14 +195,12 @@ uint32_t size(
  */
 void clear(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& index);
 
 /**
  * @brief Remove locator port.
  *
  * @param[in] manager Internal util manager to obtain and work with nodes
- * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be modified.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
@@ -228,7 +210,6 @@ void clear(
  */
 void clear_port(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external);
 
@@ -236,7 +217,6 @@ void clear_port(
  * @brief Remove locator physical port.
  *
  * @param[in] manager Internal util manager to obtain and work with nodes
- * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be modified.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
@@ -246,7 +226,6 @@ void clear_port(
  */
 void clear_physical_port(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external);
 
@@ -254,7 +233,6 @@ void clear_physical_port(
  * @brief Remove locator IP address.
  *
  * @param[in] manager Internal util manager to obtain and work with nodes
- * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be modified.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
@@ -264,7 +242,6 @@ void clear_physical_port(
  */
 void clear_address(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external);
 
@@ -272,7 +249,6 @@ void clear_address(
  * @brief Remove locator unique LAN ID.
  *
  * @param[in] manager Internal util manager to obtain and work with nodes
- * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be modified.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
@@ -282,7 +258,6 @@ void clear_address(
  */
 void clear_unique_lan_id(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external);
 
@@ -290,7 +265,6 @@ void clear_unique_lan_id(
  * @brief Remove locator WAN IP address.
  *
  * @param[in] manager Internal util manager to obtain and work with nodes
- * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] index Collection element to be modified.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
@@ -300,7 +274,6 @@ void clear_unique_lan_id(
  */
 void clear_wan_address(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& index,
         const bool is_external);
 
@@ -312,7 +285,6 @@ void clear_wan_address(
  * @brief Append a locator with specified kind or update the existing locator kind.
  *
  * @param[in] manager Internal util manager to obtain and work with nodes
- * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] kind locator kind.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
@@ -323,7 +295,6 @@ void clear_wan_address(
  */
 void set_kind(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& kind,
         const std::string& index,
         const bool is_external);
@@ -332,7 +303,6 @@ void set_kind(
  * @brief Append a locator with specified port or update the existing locator port.
  *
  * @param[in] manager Internal util manager to obtain and work with nodes
- * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] port locator port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
@@ -343,7 +313,6 @@ void set_kind(
  */
 void set_port(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& port,
         const std::string& index,
         const bool is_external);
@@ -353,7 +322,6 @@ void set_port(
  *        (TCP only).
  *
  * @param[in] manager Internal util manager to obtain and work with nodes
- * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] physical_port locator TCP physical port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
@@ -364,7 +332,6 @@ void set_port(
  */
 void set_physical_port(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& physical_port,
         const std::string& index,
         const bool is_external);
@@ -373,7 +340,6 @@ void set_physical_port(
  * @brief Append a locator with specified IP address or update the existing locator IP address.
  *
  * @param[in] manager Internal util manager to obtain and work with nodes
- * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] address locator IP address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
@@ -384,7 +350,6 @@ void set_physical_port(
  */
 void set_address(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& address,
         const std::string& index,
         const bool is_external);
@@ -394,7 +359,6 @@ void set_address(
  *        LAN ID.
  *
  * @param[in] manager Internal util manager to obtain and work with nodes
- * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] unique_lan_id TCPv4 locator unique LAN ID.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
@@ -405,7 +369,6 @@ void set_address(
  */
 void set_unique_lan_id(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& unique_lan_id,
         const std::string& index,
         const bool is_external);
@@ -414,7 +377,6 @@ void set_unique_lan_id(
  * @brief Append a TCPv4 locator with specified WAN address or update the existing locator WAN address.
  *
  * @param[in] manager Internal util manager to obtain and work with nodes
- * @param[in] xml_node Locator list node where all locators are uploaded.
  * @param[in] wan_address TCPv4 locator WAN address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
@@ -425,7 +387,6 @@ void set_unique_lan_id(
  */
 void set_wan_address(
         utils::XMLManager& manager,
-        xercesc::DOMNode* xml_node,
         const std::string& wan_address,
         const std::string& index,
         const bool is_external);

--- a/lib/src/cpp/domain_participant/DefaultExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/DefaultExternalUnicastLocators.cpp
@@ -31,6 +31,27 @@ namespace qosprof {
 namespace domain_participant {
 namespace default_external_unicast_locators {
 
+/**
+ * @brief Private common method for all the functions that belong this namespace to obtain base node position.
+ *
+ * @param[in] manager utils::XMLManager to obtain the base node position in the XML document
+ * @param[in] profile_id Domain participant profile identifier
+ * @param[in] create_if_not_existent flag that enables the creation of the  element if it does not exist
+ *
+ * @throw ElementNotFound exception if expected node was not found and node creation not required
+ */
+void initialize_namespace(
+        utils::XMLManager& manager,
+        const std::string& profile_id,
+        const bool& create_if_not_existent)
+{
+    // Iterate through required elements, and create them if not existent
+    manager.get_node(utils::tag::PROFILES, create_if_not_existent);
+    manager.get_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
+    manager.get_node(utils::tag::RTPS, create_if_not_existent);
+    manager.get_node(utils::tag::DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST, create_if_not_existent);
+}
+
 std::string print(
         const std::string& xml_file,
         const std::string& profile_id,
@@ -160,11 +181,8 @@ void set_port(
     // Create XML manager and initialize the document
     utils::XMLManager manager(xml_file, true);
 
-    // Iterate through required elements, and create them if not existent
-    manager.get_node(utils::tag::PROFILES, true);
-    manager.get_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, true);
-    manager.get_node(utils::tag::RTPS, true);
-    manager.get_node(utils::tag::DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST, true);
+    // Obtain base node position
+    initialize_namespace(manager, profile_id, true);
 
     // Set the port using commons
     common::locator_list::set_port(manager, port, index, true);
@@ -182,11 +200,8 @@ void set_address(
     // Create XML manager and initialize the document
     utils::XMLManager manager(xml_file, true);
 
-    // Iterate through required elements, and create them if not existent
-    manager.get_node(utils::tag::PROFILES, true);
-    manager.get_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, true);
-    manager.get_node(utils::tag::RTPS, true);
-    manager.get_node(utils::tag::DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST, true);
+    // Obtain base node position
+    initialize_namespace(manager, profile_id, true);
 
     // Set the address using commons
     common::locator_list::set_address(manager, address, index, true);
@@ -204,11 +219,10 @@ void set_externality(
     // Create XML manager and initialize the document
     utils::XMLManager manager(xml_file, true);
 
+    // Obtain base node position
+    initialize_namespace(manager, profile_id, true);
+
     // Iterate through required elements, and create them if not existent
-    manager.get_node(utils::tag::PROFILES, true);
-    manager.get_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, true);
-    manager.get_node(utils::tag::RTPS, true);
-    manager.get_node(utils::tag::DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST, true);
     manager.get_locator_node(index, utils::tag::UDP_V4_LOCATOR, true);
 
     // Set the externality value

--- a/lib/src/cpp/domain_participant/DefaultExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/DefaultExternalUnicastLocators.cpp
@@ -157,85 +157,20 @@ void set_port(
         const std::string& port,
         const std::string& index)
 {
-    // Xerces document manage XML elements
-    xercesc::DOMDocument* doc = nullptr;
-
-    // XML nodes and values
-    xercesc::DOMNode* profiles_node = nullptr;
-    xercesc::DOMNode* participant_node = nullptr;
-    xercesc::DOMNode* rtps_node = nullptr;
-    xercesc::DOMNode* locator_list_node = nullptr;
-    xercesc::DOMNode* locator_node = nullptr;
-
     // Create XML manager and initialize the document
-    utils::XMLManager* manager = new utils::XMLManager(xml_file, true);
-    doc = manager->get_doc();
+    utils::XMLManager manager(xml_file, true);
 
-    // Obtain profiles node
-    try
-    {
-        profiles_node = manager->get_node(utils::tag::PROFILES);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // Obtain root element
-        xercesc::DOMElement* root_element = doc->getDocumentElement();
+    // Iterate through required elements, and create them if not existent
+    manager.get_node(utils::tag::PROFILES, true);
+    manager.get_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, true);
+    manager.get_node(utils::tag::RTPS, true);
+    manager.get_node(utils::tag::DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST, true);
 
-        // Add profiles
-        profiles_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-                    xercesc::XMLString::transcode(utils::tag::PROFILES)));
-        root_element->appendChild(profiles_node);
-    }
-
-    // Obtain participant node with the profile id
-    try
-    {
-        participant_node = manager->get_node(
-            profiles_node,
-            utils::tag::PARTICIPANT,
-            utils::tag::PROFILE_NAME,
-            profile_id);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        participant_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-            xercesc::XMLString::transcode(utils::tag::PARTICIPANT)));
-        manager->set_attribute_to_node(participant_node, utils::tag::PROFILE_NAME, profile_id);
-        profiles_node->appendChild(participant_node);
-    }
-
-    // Obtain rtps node
-    try
-    {
-        rtps_node = manager->get_node(participant_node, utils::tag::RTPS);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        rtps_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-                    xercesc::XMLString::transcode(utils::tag::RTPS)));
-        participant_node->appendChild(rtps_node);
-    }
-
-    // Obtain default external unicast locator list node
-    try
-    {
-        locator_list_node = manager->get_node(rtps_node,
-                        utils::tag::DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        locator_list_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                    utils::tag::DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST)));
-        rtps_node->appendChild(locator_list_node);
-    }
-
-    common::locator_list::set_port(*manager, locator_list_node, port, index, true);
+    // Set the port using commons
+    common::locator_list::set_port(manager, port, index, true);
 
     // Validate new XML element and save it
-    manager->validate_and_save_document();
+    manager.validate_and_save_document();
 }
 
 void set_address(
@@ -244,85 +179,20 @@ void set_address(
         const std::string& address,
         const std::string& index)
 {
-    // Xerces document manage XML elements
-    xercesc::DOMDocument* doc = nullptr;
-
-    // XML nodes and values
-    xercesc::DOMNode* profiles_node = nullptr;
-    xercesc::DOMNode* participant_node = nullptr;
-    xercesc::DOMNode* rtps_node = nullptr;
-    xercesc::DOMNode* locator_list_node = nullptr;
-    xercesc::DOMNode* locator_node = nullptr;
-
     // Create XML manager and initialize the document
-    utils::XMLManager* manager = new utils::XMLManager(xml_file, true);
-    doc = manager->get_doc();
+    utils::XMLManager manager(xml_file, true);
 
-    // Obtain profiles node
-    try
-    {
-        profiles_node = manager->get_node(utils::tag::PROFILES);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // Obtain root element
-        xercesc::DOMElement* root_element = doc->getDocumentElement();
+    // Iterate through required elements, and create them if not existent
+    manager.get_node(utils::tag::PROFILES, true);
+    manager.get_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, true);
+    manager.get_node(utils::tag::RTPS, true);
+    manager.get_node(utils::tag::DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST, true);
 
-        // Add profiles
-        profiles_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-                    xercesc::XMLString::transcode(utils::tag::PROFILES)));
-        root_element->appendChild(profiles_node);
-    }
-
-    // Obtain participant node with the profile id
-    try
-    {
-        participant_node = manager->get_node(
-            profiles_node,
-            utils::tag::PARTICIPANT,
-            utils::tag::PROFILE_NAME,
-            profile_id);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        participant_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-            xercesc::XMLString::transcode(utils::tag::PARTICIPANT)));
-        manager->set_attribute_to_node(participant_node, utils::tag::PROFILE_NAME, profile_id);
-        profiles_node->appendChild(participant_node);
-    }
-
-    // Obtain rtps node
-    try
-    {
-        rtps_node = manager->get_node(participant_node, utils::tag::RTPS);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        rtps_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-                    xercesc::XMLString::transcode(utils::tag::RTPS)));
-        participant_node->appendChild(rtps_node);
-    }
-
-    // Obtain default external unicast locator list node
-    try
-    {
-        locator_list_node = manager->get_node(rtps_node,
-                        utils::tag::DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        locator_list_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                    utils::tag::DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST)));
-        rtps_node->appendChild(locator_list_node);
-    }
-
-    common::locator_list::set_address(*manager, locator_list_node, address, index, true);
+    // Set the address using commons
+    common::locator_list::set_address(manager, address, index, true);
 
     // Validate new XML element and save it
-    manager->validate_and_save_document();
+    manager.validate_and_save_document();
 }
 
 void set_externality(
@@ -331,98 +201,21 @@ void set_externality(
         const std::string& externality,
         const std::string& index)
 {
-    // Xerces document manage XML elements
-    xercesc::DOMDocument* doc = nullptr;
-
-    // XML nodes and values
-    xercesc::DOMNode* profiles_node = nullptr;
-    xercesc::DOMNode* participant_node = nullptr;
-    xercesc::DOMNode* rtps_node = nullptr;
-    xercesc::DOMNode* locator_list_node = nullptr;
-    xercesc::DOMNode* locator_node = nullptr;
-
     // Create XML manager and initialize the document
-    utils::XMLManager* manager = new utils::XMLManager(xml_file, true);
-    doc = manager->get_doc();
+    utils::XMLManager manager(xml_file, true);
 
-    // Obtain profiles node
-    try
-    {
-        profiles_node = manager->get_node(utils::tag::PROFILES);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // Obtain root element
-        xercesc::DOMElement* root_element = doc->getDocumentElement();
+    // Iterate through required elements, and create them if not existent
+    manager.get_node(utils::tag::PROFILES, true);
+    manager.get_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, true);
+    manager.get_node(utils::tag::RTPS, true);
+    manager.get_node(utils::tag::DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST, true);
+    manager.get_locator_node(index, utils::tag::UDP_V4_LOCATOR, true);
 
-        // Add profiles
-        profiles_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-                    xercesc::XMLString::transcode(utils::tag::PROFILES)));
-        root_element->appendChild(profiles_node);
-    }
-
-    // Obtain participant node with the profile id
-    try
-    {
-        participant_node = manager->get_node(
-            profiles_node,
-            utils::tag::PARTICIPANT,
-            utils::tag::PROFILE_NAME,
-            profile_id);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        participant_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-            xercesc::XMLString::transcode(utils::tag::PARTICIPANT)));
-        manager->set_attribute_to_node(participant_node, utils::tag::PROFILE_NAME, profile_id);
-        profiles_node->appendChild(participant_node);
-    }
-
-    // Obtain rtps node
-    try
-    {
-        rtps_node = manager->get_node(participant_node, utils::tag::RTPS);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        rtps_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-                    xercesc::XMLString::transcode(utils::tag::RTPS)));
-        participant_node->appendChild(rtps_node);
-    }
-
-    // Obtain default external unicast locator list node
-    try
-    {
-        locator_list_node = manager->get_node(rtps_node,
-                        utils::tag::DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        locator_list_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                    utils::tag::DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST)));
-        rtps_node->appendChild(locator_list_node);
-    }
-
-    // Check if locator should be created
-    if (index.empty())
-    {
-        locator_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                    utils::tag::UDP_V4_LOCATOR)));
-        locator_list_node->appendChild(locator_node);
-    }
-    // Update the locator of the given index
-    else
-    {
-        locator_node = manager->get_node(locator_list_node, utils::tag::UDP_V4_LOCATOR, &index);
-    }
     // Set the externality value
-    manager->set_attribute_to_node(locator_node, utils::tag::EXTERNALITY, externality);
+    manager.set_attribute_to_node(utils::tag::EXTERNALITY, externality);
 
     // Validate new XML element and save it
-    manager->validate_and_save_document();
+    manager.validate_and_save_document();
 }
 
 void set_cost(

--- a/lib/src/cpp/domain_participant/DefaultExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/DefaultExternalUnicastLocators.cpp
@@ -32,18 +32,18 @@ namespace domain_participant {
 namespace default_external_unicast_locators {
 
 /**
- * @brief Private common method for all the functions that belong this namespace to obtain base node position.
+ * @brief Private common method for all the functions that belong to this namespace to obtain base node position.
  *
  * @param[in] manager utils::XMLManager to obtain the base node position in the XML document
  * @param[in] profile_id Domain participant profile identifier
  * @param[in] create_if_not_existent flag that enables the creation of the  element if it does not exist
  *
- * @throw ElementNotFound exception if expected node was not found and node creation not required
+ * @throw ElementNotFound exception if expected node was not found and node creation was not required
  */
 void initialize_namespace(
         utils::XMLManager& manager,
         const std::string& profile_id,
-        const bool& create_if_not_existent)
+        const bool create_if_not_existent)
 {
     // Iterate through required elements, and create them if not existent
     manager.get_node(utils::tag::PROFILES, create_if_not_existent);
@@ -223,7 +223,7 @@ void set_externality(
     initialize_namespace(manager, profile_id, true);
 
     // Iterate through required elements, and create them if not existent
-    manager.get_locator_node(index, utils::tag::UDP_V4_LOCATOR, true);
+    manager.get_locator_node(index, true, true);
 
     // Set the externality value
     manager.set_attribute_to_node(utils::tag::EXTERNALITY, externality);

--- a/lib/src/cpp/domain_participant/DefaultExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/DefaultExternalUnicastLocators.cpp
@@ -199,13 +199,10 @@ void set_port(
     catch (const ElementNotFound& ex)
     {
         // create if not existent
-        xercesc::DOMElement* participant_element = doc->createElement(
-            xercesc::XMLString::transcode(utils::tag::PARTICIPANT));
-        profiles_node->appendChild(participant_element);
-        participant_element->setAttribute(
-            xercesc::XMLString::transcode(utils::tag::PROFILE_NAME),
-            xercesc::XMLString::transcode(profile_id.c_str()));
-        participant_node = static_cast<xercesc::DOMNode*>(participant_element);
+        participant_node = static_cast<xercesc::DOMNode*>(doc->createElement(
+            xercesc::XMLString::transcode(utils::tag::PARTICIPANT)));
+        manager->set_attribute_to_node(participant_node, utils::tag::PROFILE_NAME, profile_id);
+        profiles_node->appendChild(participant_node);
     }
 
     // Obtain rtps node
@@ -289,13 +286,10 @@ void set_address(
     catch (const ElementNotFound& ex)
     {
         // create if not existent
-        xercesc::DOMElement* participant_element = doc->createElement(
-            xercesc::XMLString::transcode(utils::tag::PARTICIPANT));
-        profiles_node->appendChild(participant_element);
-        participant_element->setAttribute(
-            xercesc::XMLString::transcode(utils::tag::PROFILE_NAME),
-            xercesc::XMLString::transcode(profile_id.c_str()));
-        participant_node = static_cast<xercesc::DOMNode*>(participant_element);
+        participant_node = static_cast<xercesc::DOMNode*>(doc->createElement(
+            xercesc::XMLString::transcode(utils::tag::PARTICIPANT)));
+        manager->set_attribute_to_node(participant_node, utils::tag::PROFILE_NAME, profile_id);
+        profiles_node->appendChild(participant_node);
     }
 
     // Obtain rtps node
@@ -379,13 +373,10 @@ void set_externality(
     catch (const ElementNotFound& ex)
     {
         // create if not existent
-        xercesc::DOMElement* participant_element = doc->createElement(
-            xercesc::XMLString::transcode(utils::tag::PARTICIPANT));
-        profiles_node->appendChild(participant_element);
-        participant_element->setAttribute(
-            xercesc::XMLString::transcode(utils::tag::PROFILE_NAME),
-            xercesc::XMLString::transcode(profile_id.c_str()));
-        participant_node = static_cast<xercesc::DOMNode*>(participant_element);
+        participant_node = static_cast<xercesc::DOMNode*>(doc->createElement(
+            xercesc::XMLString::transcode(utils::tag::PARTICIPANT)));
+        manager->set_attribute_to_node(participant_node, utils::tag::PROFILE_NAME, profile_id);
+        profiles_node->appendChild(participant_node);
     }
 
     // Obtain rtps node
@@ -428,9 +419,7 @@ void set_externality(
         locator_node = manager->get_node(locator_list_node, utils::tag::UDP_V4_LOCATOR, &index);
     }
     // Set the externality value
-    static_cast<xercesc::DOMElement*>(locator_node)->setAttribute(
-        xercesc::XMLString::transcode(utils::tag::EXTERNALITY),
-        xercesc::XMLString::transcode(externality.c_str()));
+    manager->set_attribute_to_node(locator_node, utils::tag::EXTERNALITY, externality);
 
     // Validate new XML element and save it
     manager->validate_and_save_document();

--- a/lib/src/cpp/domain_participant/DomainParticipant.cpp
+++ b/lib/src/cpp/domain_participant/DomainParticipant.cpp
@@ -257,15 +257,12 @@ void set_default_profile(
     // Iterate throw all the participants to set them as NOT default
     for (int i = 0, size = participant_list->getLength(); i < size; i++)
     {
-        static_cast<xercesc::DOMElement*>(participant_list->item(i))->setAttribute(
-            xercesc::XMLString::transcode(utils::tag::DEFAULT_PROFILE),
-            xercesc::XMLString::transcode("false"));
+        xercesc::DOMNode* temp_part_node = participant_list->item(i);
+        manager->set_attribute_to_node(temp_part_node, utils::tag::DEFAULT_PROFILE, "false");
     }
 
     // Set given participant as default profile
-    static_cast<xercesc::DOMElement*>(participant_node)->setAttribute(
-        xercesc::XMLString::transcode(utils::tag::DEFAULT_PROFILE),
-        xercesc::XMLString::transcode("true"));
+    manager->set_attribute_to_node(participant_node, utils::tag::DEFAULT_PROFILE, "true");
 
     // Validate new XML element and save it
     manager->validate_and_save_document();
@@ -324,13 +321,10 @@ void set_name(
     catch (const ElementNotFound& ex)
     {
         // create if not existent
-        xercesc::DOMElement* participant_element = doc->createElement(
-            xercesc::XMLString::transcode(utils::tag::PARTICIPANT));
-        profiles_node->appendChild(participant_element);
-        participant_element->setAttribute(
-            xercesc::XMLString::transcode(utils::tag::PROFILE_NAME),
-            xercesc::XMLString::transcode(profile_id.c_str()));
-        participant_node = static_cast<xercesc::DOMNode*>(participant_element);
+        participant_node = static_cast<xercesc::DOMNode*>(doc->createElement(
+            xercesc::XMLString::transcode(utils::tag::PARTICIPANT)));
+        manager->set_attribute_to_node(participant_node, utils::tag::PROFILE_NAME, profile_id);
+        profiles_node->appendChild(participant_node);
     }
 
     // Obtain rtps node

--- a/lib/src/cpp/domain_participant/DomainParticipant.cpp
+++ b/lib/src/cpp/domain_participant/DomainParticipant.cpp
@@ -30,6 +30,25 @@ namespace eprosima {
 namespace qosprof {
 namespace domain_participant {
 
+/**
+ * @brief Private common method for all the functions that belong this namespace to obtain base node position.
+ *
+ * @param[in] manager utils::XMLManager to obtain the base node position in the XML document
+ * @param[in] profile_id Domain participant profile identifier
+ * @param[in] create_if_not_existent flag that enables the creation of the  element if it does not exist
+ *
+ * @throw ElementNotFound exception if expected node was not found and node creation not required
+ */
+void initialize_namespace(
+        utils::XMLManager& manager,
+        const std::string& profile_id,
+        const bool& create_if_not_existent)
+{
+    // Iterate through required elements, and create them if not existent
+    manager.get_node(utils::tag::PROFILES, create_if_not_existent);
+    manager.get_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
+}
+
 std::string print(
         const std::string& xml_file,
         const std::string& profile_id)
@@ -218,15 +237,11 @@ void set_default_profile(
         const std::string& xml_file,
         const std::string& profile_id)
 {
-    // Define a default_profile node
-    xercesc::DOMNode* default_profile_node = nullptr;
-
     // Create XML manager and initialize the document
     utils::XMLManager manager(xml_file, false);
 
-    // Iterate through required elements, and create them if not existent
-    manager.get_node(utils::tag::PROFILES, false);
-    manager.get_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, false);
+    // Obtain base node position
+    initialize_namespace(manager, profile_id, false);
 
     // Check if default profile already defined
     try
@@ -268,9 +283,10 @@ void set_name(
     // Create XML manager and initialize the document
     utils::XMLManager manager(xml_file, true);
 
+    // Obtain base node position
+    initialize_namespace(manager, profile_id, true);
+
     // Iterate through required elements, and create them if not existent
-    manager.get_node(utils::tag::PROFILES, true);
-    manager.get_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, true);
     manager.get_node(utils::tag::RTPS, true);
     manager.get_node(utils::tag::NAME, true);
 

--- a/lib/src/cpp/domain_participant/DomainParticipant.cpp
+++ b/lib/src/cpp/domain_participant/DomainParticipant.cpp
@@ -31,22 +31,31 @@ namespace qosprof {
 namespace domain_participant {
 
 /**
- * @brief Private common method for all the functions that belong this namespace to obtain base node position.
+ * @brief Private common method for all the functions that belong to this namespace to obtain base node position.
  *
  * @param[in] manager utils::XMLManager to obtain the base node position in the XML document
  * @param[in] profile_id Domain participant profile identifier
  * @param[in] create_if_not_existent flag that enables the creation of the  element if it does not exist
+ * @param[in] additional_RTPS_tag additional RTPS tag to initialize directly
  *
- * @throw ElementNotFound exception if expected node was not found and node creation not required
+ * @throw ElementNotFound exception if expected node was not found and node creation was not required
  */
 void initialize_namespace(
         utils::XMLManager& manager,
         const std::string& profile_id,
-        const bool& create_if_not_existent)
+        const bool create_if_not_existent,
+        const std::string& additional_RTPS_tag)
 {
     // Iterate through required elements, and create them if not existent
     manager.get_node(utils::tag::PROFILES, create_if_not_existent);
     manager.get_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
+
+    // there are additional tags to obtain
+    if (!additional_RTPS_tag.empty())
+    {
+        manager.get_node(utils::tag::RTPS, create_if_not_existent);
+        manager.get_node(additional_RTPS_tag, create_if_not_existent);
+    }
 }
 
 std::string print(
@@ -241,7 +250,7 @@ void set_default_profile(
     utils::XMLManager manager(xml_file, false);
 
     // Obtain base node position
-    initialize_namespace(manager, profile_id, false);
+    initialize_namespace(manager, profile_id, false, "");
 
     // Check if default profile already defined
     try
@@ -284,11 +293,7 @@ void set_name(
     utils::XMLManager manager(xml_file, true);
 
     // Obtain base node position
-    initialize_namespace(manager, profile_id, true);
-
-    // Iterate through required elements, and create them if not existent
-    manager.get_node(utils::tag::RTPS, true);
-    manager.get_node(utils::tag::NAME, true);
+    initialize_namespace(manager, profile_id, true, utils::tag::NAME);
 
     // Set the name node value
     manager.set_value_to_node(name);

--- a/lib/src/cpp/domain_participant/builtin/InitialPeers.cpp
+++ b/lib/src/cpp/domain_participant/builtin/InitialPeers.cpp
@@ -201,13 +201,10 @@ void set_port(
     catch (const ElementNotFound& ex)
     {
         // create if not existent
-        xercesc::DOMElement* participant_element = doc->createElement(
-            xercesc::XMLString::transcode(utils::tag::PARTICIPANT));
-        profiles_node->appendChild(participant_element);
-        participant_element->setAttribute(
-            xercesc::XMLString::transcode(utils::tag::PROFILE_NAME),
-            xercesc::XMLString::transcode(profile_id.c_str()));
-        participant_node = static_cast<xercesc::DOMNode*>(participant_element);
+        participant_node = static_cast<xercesc::DOMNode*>(doc->createElement(
+            xercesc::XMLString::transcode(utils::tag::PARTICIPANT)));
+        manager->set_attribute_to_node(participant_node, utils::tag::PROFILE_NAME, profile_id);
+        profiles_node->appendChild(participant_node);
     }
 
     // Obtain rtps node
@@ -313,13 +310,10 @@ void set_address(
     catch (const ElementNotFound& ex)
     {
         // create if not existent
-        xercesc::DOMElement* participant_element = doc->createElement(
-            xercesc::XMLString::transcode(utils::tag::PARTICIPANT));
-        profiles_node->appendChild(participant_element);
-        participant_element->setAttribute(
-            xercesc::XMLString::transcode(utils::tag::PROFILE_NAME),
-            xercesc::XMLString::transcode(profile_id.c_str()));
-        participant_node = static_cast<xercesc::DOMNode*>(participant_element);
+        participant_node = static_cast<xercesc::DOMNode*>(doc->createElement(
+            xercesc::XMLString::transcode(utils::tag::PARTICIPANT)));
+        manager->set_attribute_to_node(participant_node, utils::tag::PROFILE_NAME, profile_id);
+        profiles_node->appendChild(participant_node);
     }
 
     // Obtain rtps node

--- a/lib/src/cpp/domain_participant/builtin/InitialPeers.cpp
+++ b/lib/src/cpp/domain_participant/builtin/InitialPeers.cpp
@@ -158,98 +158,21 @@ void set_port(
         const std::string& port,
         const std::string& index)
 {
-    // Xerces document manage XML elements
-    xercesc::DOMDocument* doc = nullptr;
-
-    // XML nodes and values
-    xercesc::DOMNode* profiles_node = nullptr;
-    xercesc::DOMNode* participant_node = nullptr;
-    xercesc::DOMNode* rtps_node = nullptr;
-    xercesc::DOMNode* builtin_node = nullptr;
-    xercesc::DOMNode* locator_list_node = nullptr;
-    xercesc::DOMNode* locator_node = nullptr;
-
     // Create XML manager and initialize the document
-    utils::XMLManager* manager = new utils::XMLManager(xml_file, true);
-    doc = manager->get_doc();
+    utils::XMLManager manager(xml_file, true);
 
-    // Obtain profiles node
-    try
-    {
-        profiles_node = manager->get_node(utils::tag::PROFILES);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // Obtain root element
-        xercesc::DOMElement* root_element = doc->getDocumentElement();
+    // Iterate through required elements, and create them if not existent
+    manager.get_node(utils::tag::PROFILES, true);
+    manager.get_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, true);
+    manager.get_node(utils::tag::RTPS, true);
+    manager.get_node(utils::tag::BUILTIN, true);
+    manager.get_node(utils::tag::INITIAL_PEERS_LIST, true);
 
-        // Add profiles
-        profiles_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-                    xercesc::XMLString::transcode(utils::tag::PROFILES)));
-        root_element->appendChild(profiles_node);
-    }
-
-    // Obtain participant node with the profile id
-    try
-    {
-        participant_node = manager->get_node(
-            profiles_node,
-            utils::tag::PARTICIPANT,
-            utils::tag::PROFILE_NAME,
-            profile_id);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        participant_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-            xercesc::XMLString::transcode(utils::tag::PARTICIPANT)));
-        manager->set_attribute_to_node(participant_node, utils::tag::PROFILE_NAME, profile_id);
-        profiles_node->appendChild(participant_node);
-    }
-
-    // Obtain rtps node
-    try
-    {
-        rtps_node = manager->get_node(participant_node, utils::tag::RTPS);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        rtps_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                    utils::tag::RTPS)));
-        participant_node->appendChild(rtps_node);
-    }
-
-    // Obtain builtin node
-    try
-    {
-        builtin_node = manager->get_node(rtps_node, utils::tag::BUILTIN);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        builtin_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                    utils::tag::BUILTIN)));
-        rtps_node->appendChild(builtin_node);
-    }
-
-    // Obtain initial peers locator list node
-    try
-    {
-        locator_list_node = manager->get_node(builtin_node, utils::tag::INITIAL_PEERS_LIST);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        locator_list_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                    utils::tag::INITIAL_PEERS_LIST)));
-        builtin_node->appendChild(locator_list_node);
-    }
-
-    common::locator_list::set_port(*manager, locator_list_node, port, index, false);
+    // Set the port using commons
+    common::locator_list::set_port(manager, port, index, false);
 
     // Validate new XML element and save it
-    manager->validate_and_save_document();
+    manager.validate_and_save_document();
 }
 
 void set_physical_port(
@@ -267,98 +190,21 @@ void set_address(
         const std::string& address,
         const std::string& index)
 {
-    // Xerces document manage XML elements
-    xercesc::DOMDocument* doc = nullptr;
-
-    // XML nodes and values
-    xercesc::DOMNode* profiles_node = nullptr;
-    xercesc::DOMNode* participant_node = nullptr;
-    xercesc::DOMNode* rtps_node = nullptr;
-    xercesc::DOMNode* builtin_node = nullptr;
-    xercesc::DOMNode* locator_list_node = nullptr;
-    xercesc::DOMNode* locator_node = nullptr;
-
     // Create XML manager and initialize the document
-    utils::XMLManager* manager = new utils::XMLManager(xml_file, true);
-    doc = manager->get_doc();
+    utils::XMLManager manager(xml_file, true);
 
-    // Obtain profiles node
-    try
-    {
-        profiles_node = manager->get_node(utils::tag::PROFILES);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // Obtain root element
-        xercesc::DOMElement* root_element = doc->getDocumentElement();
+    // Iterate through required elements, and create them if not existent
+    manager.get_node(utils::tag::PROFILES, true);
+    manager.get_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, true);
+    manager.get_node(utils::tag::RTPS, true);
+    manager.get_node(utils::tag::BUILTIN, true);
+    manager.get_node(utils::tag::INITIAL_PEERS_LIST, true);
 
-        // Add profiles
-        profiles_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-                    xercesc::XMLString::transcode(utils::tag::PROFILES)));
-        root_element->appendChild(profiles_node);
-    }
-
-    // Obtain participant node with the profile id
-    try
-    {
-        participant_node = manager->get_node(
-            profiles_node,
-            utils::tag::PARTICIPANT,
-            utils::tag::PROFILE_NAME,
-            profile_id);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        participant_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-            xercesc::XMLString::transcode(utils::tag::PARTICIPANT)));
-        manager->set_attribute_to_node(participant_node, utils::tag::PROFILE_NAME, profile_id);
-        profiles_node->appendChild(participant_node);
-    }
-
-    // Obtain rtps node
-    try
-    {
-        rtps_node = manager->get_node(participant_node, utils::tag::RTPS);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        rtps_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                    utils::tag::RTPS)));
-        participant_node->appendChild(rtps_node);
-    }
-
-    // Obtain builtin node
-    try
-    {
-        builtin_node = manager->get_node(rtps_node, utils::tag::BUILTIN);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        builtin_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                    utils::tag::BUILTIN)));
-        rtps_node->appendChild(builtin_node);
-    }
-
-    // Obtain initial peers locator list node
-    try
-    {
-        locator_list_node = manager->get_node(builtin_node, utils::tag::INITIAL_PEERS_LIST);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        locator_list_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                    utils::tag::INITIAL_PEERS_LIST)));
-        builtin_node->appendChild(locator_list_node);
-    }
-
-    common::locator_list::set_address(*manager, locator_list_node, address, index, false);
+    // Set the address using commons
+    common::locator_list::set_address(manager, address, index, false);
 
     // Validate new XML element and save it
-    manager->validate_and_save_document();
+    manager.validate_and_save_document();
 }
 
 void set_unique_lan_id(

--- a/lib/src/cpp/domain_participant/builtin/InitialPeers.cpp
+++ b/lib/src/cpp/domain_participant/builtin/InitialPeers.cpp
@@ -32,6 +32,28 @@ namespace domain_participant {
 namespace builtin {
 namespace initial_peers {
 
+/**
+ * @brief Private common method for all the functions that belong this namespace to obtain base node position.
+ *
+ * @param[in] manager utils::XMLManager to obtain the base node position in the XML document
+ * @param[in] profile_id Domain participant profile identifier
+ * @param[in] create_if_not_existent flag that enables the creation of the  element if it does not exist
+ *
+ * @throw ElementNotFound exception if expected node was not found and node creation not required
+ */
+void initialize_namespace(
+        utils::XMLManager& manager,
+        const std::string& profile_id,
+        const bool& create_if_not_existent)
+{
+    // Iterate through required elements, and create them if not existent
+    manager.get_node(utils::tag::PROFILES, create_if_not_existent);
+    manager.get_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
+    manager.get_node(utils::tag::RTPS, create_if_not_existent);
+    manager.get_node(utils::tag::BUILTIN, create_if_not_existent);
+    manager.get_node(utils::tag::INITIAL_PEERS_LIST, create_if_not_existent);
+}
+
 std::string print(
         const std::string& xml_file,
         const std::string& profile_id,
@@ -161,12 +183,8 @@ void set_port(
     // Create XML manager and initialize the document
     utils::XMLManager manager(xml_file, true);
 
-    // Iterate through required elements, and create them if not existent
-    manager.get_node(utils::tag::PROFILES, true);
-    manager.get_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, true);
-    manager.get_node(utils::tag::RTPS, true);
-    manager.get_node(utils::tag::BUILTIN, true);
-    manager.get_node(utils::tag::INITIAL_PEERS_LIST, true);
+    // Obtain base node position
+    initialize_namespace(manager, profile_id, true);
 
     // Set the port using commons
     common::locator_list::set_port(manager, port, index, false);
@@ -193,12 +211,8 @@ void set_address(
     // Create XML manager and initialize the document
     utils::XMLManager manager(xml_file, true);
 
-    // Iterate through required elements, and create them if not existent
-    manager.get_node(utils::tag::PROFILES, true);
-    manager.get_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, true);
-    manager.get_node(utils::tag::RTPS, true);
-    manager.get_node(utils::tag::BUILTIN, true);
-    manager.get_node(utils::tag::INITIAL_PEERS_LIST, true);
+    // Obtain base node position
+    initialize_namespace(manager, profile_id, true);
 
     // Set the address using commons
     common::locator_list::set_address(manager, address, index, false);

--- a/lib/src/cpp/domain_participant/builtin/InitialPeers.cpp
+++ b/lib/src/cpp/domain_participant/builtin/InitialPeers.cpp
@@ -33,18 +33,18 @@ namespace builtin {
 namespace initial_peers {
 
 /**
- * @brief Private common method for all the functions that belong this namespace to obtain base node position.
+ * @brief Private common method for all the functions that belong to this namespace to obtain base node position.
  *
  * @param[in] manager utils::XMLManager to obtain the base node position in the XML document
  * @param[in] profile_id Domain participant profile identifier
  * @param[in] create_if_not_existent flag that enables the creation of the  element if it does not exist
  *
- * @throw ElementNotFound exception if expected node was not found and node creation not required
+ * @throw ElementNotFound exception if expected node was not found and node creation was not required
  */
 void initialize_namespace(
         utils::XMLManager& manager,
         const std::string& profile_id,
-        const bool& create_if_not_existent)
+        const bool create_if_not_existent)
 {
     // Iterate through required elements, and create them if not existent
     manager.get_node(utils::tag::PROFILES, create_if_not_existent);

--- a/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
@@ -32,6 +32,28 @@ namespace domain_participant {
 namespace builtin {
 namespace metatraffic_external_unicast_locators {
 
+/**
+ * @brief Private common method for all the functions that belong this namespace to obtain base node position.
+ *
+ * @param[in] manager utils::XMLManager to obtain the base node position in the XML document
+ * @param[in] profile_id Domain participant profile identifier
+ * @param[in] create_if_not_existent flag that enables the creation of the  element if it does not exist
+ *
+ * @throw ElementNotFound exception if expected node was not found and node creation not required
+ */
+void initialize_namespace(
+        utils::XMLManager& manager,
+        const std::string& profile_id,
+        const bool& create_if_not_existent)
+{
+    // Iterate through required elements, and create them if not existent
+    manager.get_node(utils::tag::PROFILES, create_if_not_existent);
+    manager.get_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
+    manager.get_node(utils::tag::RTPS, create_if_not_existent);
+    manager.get_node(utils::tag::BUILTIN, create_if_not_existent);
+    manager.get_node(utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST, create_if_not_existent);
+}
+
 std::string print(
         const std::string& xml_file,
         const std::string& profile_id,
@@ -161,12 +183,8 @@ void set_port(
     // Create XML manager and initialize the document
     utils::XMLManager manager(xml_file, true);
 
-    // Iterate through required elements, and create them if not existent
-    manager.get_node(utils::tag::PROFILES, true);
-    manager.get_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, true);
-    manager.get_node(utils::tag::RTPS, true);
-    manager.get_node(utils::tag::BUILTIN, true);
-    manager.get_node(utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST, true);
+    // Obtain base node position
+    initialize_namespace(manager, profile_id, true);
 
     // Set the port using commons
     common::locator_list::set_port(manager, port, index, true);
@@ -184,12 +202,8 @@ void set_address(
     // Create XML manager and initialize the document
     utils::XMLManager manager(xml_file, true);
 
-    // Iterate through required elements, and create them if not existent
-    manager.get_node(utils::tag::PROFILES, true);
-    manager.get_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, true);
-    manager.get_node(utils::tag::RTPS, true);
-    manager.get_node(utils::tag::BUILTIN, true);
-    manager.get_node(utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST, true);
+    // Obtain base node position
+    initialize_namespace(manager, profile_id, true);
 
     // Set the address using commons
     common::locator_list::set_address(manager, address, index, true);
@@ -207,12 +221,10 @@ void set_externality(
     // Create XML manager and initialize the document
     utils::XMLManager manager(xml_file, true);
 
+    // Obtain base node position
+    initialize_namespace(manager, profile_id, true);
+
     // Iterate through required elements, and create them if not existent
-    manager.get_node(utils::tag::PROFILES, true);
-    manager.get_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, true);
-    manager.get_node(utils::tag::RTPS, true);
-    manager.get_node(utils::tag::BUILTIN, true);
-    manager.get_node(utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST, true);
     manager.get_locator_node(index, utils::tag::UDP_V4_LOCATOR, true);
 
     // Set the externality value

--- a/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
@@ -201,13 +201,10 @@ void set_port(
     catch (const ElementNotFound& ex)
     {
         // create if not existent
-        xercesc::DOMElement* participant_element = doc->createElement(
-            xercesc::XMLString::transcode(utils::tag::PARTICIPANT));
-        profiles_node->appendChild(participant_element);
-        participant_element->setAttribute(
-            xercesc::XMLString::transcode(utils::tag::PROFILE_NAME),
-            xercesc::XMLString::transcode(profile_id.c_str()));
-        participant_node = static_cast<xercesc::DOMNode*>(participant_element);
+        participant_node = static_cast<xercesc::DOMNode*>(doc->createElement(
+            xercesc::XMLString::transcode(utils::tag::PARTICIPANT)));
+        manager->set_attribute_to_node(participant_node, utils::tag::PROFILE_NAME, profile_id);
+        profiles_node->appendChild(participant_node);
     }
 
     // Obtain rtps node
@@ -305,13 +302,10 @@ void set_address(
     catch (const ElementNotFound& ex)
     {
         // create if not existent
-        xercesc::DOMElement* participant_element = doc->createElement(
-            xercesc::XMLString::transcode(utils::tag::PARTICIPANT));
-        profiles_node->appendChild(participant_element);
-        participant_element->setAttribute(
-            xercesc::XMLString::transcode(utils::tag::PROFILE_NAME),
-            xercesc::XMLString::transcode(profile_id.c_str()));
-        participant_node = static_cast<xercesc::DOMNode*>(participant_element);
+        participant_node = static_cast<xercesc::DOMNode*>(doc->createElement(
+            xercesc::XMLString::transcode(utils::tag::PARTICIPANT)));
+        manager->set_attribute_to_node(participant_node, utils::tag::PROFILE_NAME, profile_id);
+        profiles_node->appendChild(participant_node);
     }
 
     // Obtain rtps node
@@ -409,13 +403,10 @@ void set_externality(
     catch (const ElementNotFound& ex)
     {
         // create if not existent
-        xercesc::DOMElement* participant_element = doc->createElement(
-            xercesc::XMLString::transcode(utils::tag::PARTICIPANT));
-        profiles_node->appendChild(participant_element);
-        participant_element->setAttribute(
-            xercesc::XMLString::transcode(utils::tag::PROFILE_NAME),
-            xercesc::XMLString::transcode(profile_id.c_str()));
-        participant_node = static_cast<xercesc::DOMNode*>(participant_element);
+        participant_node = static_cast<xercesc::DOMNode*>(doc->createElement(
+            xercesc::XMLString::transcode(utils::tag::PARTICIPANT)));
+        manager->set_attribute_to_node(participant_node, utils::tag::PROFILE_NAME, profile_id);
+        profiles_node->appendChild(participant_node);
     }
 
     // Obtain rtps node
@@ -471,9 +462,7 @@ void set_externality(
         locator_node = manager->get_node(locator_list_node, utils::tag::UDP_V4_LOCATOR, &index);
     }
     // Set the externality value
-    static_cast<xercesc::DOMElement*>(locator_node)->setAttribute(
-        xercesc::XMLString::transcode(utils::tag::EXTERNALITY),
-        xercesc::XMLString::transcode(externality.c_str()));
+    manager->set_attribute_to_node(locator_node, utils::tag::EXTERNALITY, externality);
 
     // Validate new XML element and save it
     manager->validate_and_save_document();

--- a/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
@@ -33,18 +33,18 @@ namespace builtin {
 namespace metatraffic_external_unicast_locators {
 
 /**
- * @brief Private common method for all the functions that belong this namespace to obtain base node position.
+ * @brief Private common method for all the functions that belong to this namespace to obtain base node position.
  *
  * @param[in] manager utils::XMLManager to obtain the base node position in the XML document
  * @param[in] profile_id Domain participant profile identifier
  * @param[in] create_if_not_existent flag that enables the creation of the  element if it does not exist
  *
- * @throw ElementNotFound exception if expected node was not found and node creation not required
+ * @throw ElementNotFound exception if expected node was not found and node creation was not required
  */
 void initialize_namespace(
         utils::XMLManager& manager,
         const std::string& profile_id,
-        const bool& create_if_not_existent)
+        const bool create_if_not_existent)
 {
     // Iterate through required elements, and create them if not existent
     manager.get_node(utils::tag::PROFILES, create_if_not_existent);
@@ -225,7 +225,7 @@ void set_externality(
     initialize_namespace(manager, profile_id, true);
 
     // Iterate through required elements, and create them if not existent
-    manager.get_locator_node(index, utils::tag::UDP_V4_LOCATOR, true);
+    manager.get_locator_node(index, true, true);
 
     // Set the externality value
     manager.set_attribute_to_node(utils::tag::EXTERNALITY, externality);

--- a/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
@@ -158,99 +158,21 @@ void set_port(
         const std::string& port,
         const std::string& index)
 {
-    // Xerces document manage XML elements
-    xercesc::DOMDocument* doc = nullptr;
-
-    // XML nodes and values
-    xercesc::DOMNode* profiles_node = nullptr;
-    xercesc::DOMNode* participant_node = nullptr;
-    xercesc::DOMNode* rtps_node = nullptr;
-    xercesc::DOMNode* builtin_node = nullptr;
-    xercesc::DOMNode* locator_list_node = nullptr;
-    xercesc::DOMNode* locator_node = nullptr;
-
     // Create XML manager and initialize the document
-    utils::XMLManager* manager = new utils::XMLManager(xml_file, true);
-    doc = manager->get_doc();
+    utils::XMLManager manager(xml_file, true);
 
-    // Obtain profiles node
-    try
-    {
-        profiles_node = manager->get_node(utils::tag::PROFILES);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // Obtain root element
-        xercesc::DOMElement* root_element = doc->getDocumentElement();
+    // Iterate through required elements, and create them if not existent
+    manager.get_node(utils::tag::PROFILES, true);
+    manager.get_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, true);
+    manager.get_node(utils::tag::RTPS, true);
+    manager.get_node(utils::tag::BUILTIN, true);
+    manager.get_node(utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST, true);
 
-        // Add profiles
-        profiles_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-                    xercesc::XMLString::transcode(utils::tag::PROFILES)));
-        root_element->appendChild(profiles_node);
-    }
-
-    // Obtain participant node with the profile id
-    try
-    {
-        participant_node = manager->get_node(
-            profiles_node,
-            utils::tag::PARTICIPANT,
-            utils::tag::PROFILE_NAME,
-            profile_id);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        participant_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-            xercesc::XMLString::transcode(utils::tag::PARTICIPANT)));
-        manager->set_attribute_to_node(participant_node, utils::tag::PROFILE_NAME, profile_id);
-        profiles_node->appendChild(participant_node);
-    }
-
-    // Obtain rtps node
-    try
-    {
-        rtps_node = manager->get_node(participant_node, utils::tag::RTPS);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        rtps_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                    utils::tag::RTPS)));
-        participant_node->appendChild(rtps_node);
-    }
-
-    // Obtain builtin node
-    try
-    {
-        builtin_node = manager->get_node(rtps_node, utils::tag::BUILTIN);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        builtin_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                    utils::tag::BUILTIN)));
-        rtps_node->appendChild(builtin_node);
-    }
-
-    // Obtain meta-traffic external unicast locator list node
-    try
-    {
-        locator_list_node = manager->get_node(builtin_node,
-                        utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        locator_list_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                    utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST)));
-        builtin_node->appendChild(locator_list_node);
-    }
-
-    common::locator_list::set_port(*manager, locator_list_node, port, index, true);
+    // Set the port using commons
+    common::locator_list::set_port(manager, port, index, true);
 
     // Validate new XML element and save it
-    manager->validate_and_save_document();
+    manager.validate_and_save_document();
 }
 
 void set_address(
@@ -259,99 +181,21 @@ void set_address(
         const std::string& address,
         const std::string& index)
 {
-    // Xerces document manage XML elements
-    xercesc::DOMDocument* doc = nullptr;
-
-    // XML nodes and values
-    xercesc::DOMNode* profiles_node = nullptr;
-    xercesc::DOMNode* participant_node = nullptr;
-    xercesc::DOMNode* rtps_node = nullptr;
-    xercesc::DOMNode* builtin_node = nullptr;
-    xercesc::DOMNode* locator_list_node = nullptr;
-    xercesc::DOMNode* locator_node = nullptr;
-
     // Create XML manager and initialize the document
-    utils::XMLManager* manager = new utils::XMLManager(xml_file, true);
-    doc = manager->get_doc();
+    utils::XMLManager manager(xml_file, true);
 
-    // Obtain profiles node
-    try
-    {
-        profiles_node = manager->get_node(utils::tag::PROFILES);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // Obtain root element
-        xercesc::DOMElement* root_element = doc->getDocumentElement();
+    // Iterate through required elements, and create them if not existent
+    manager.get_node(utils::tag::PROFILES, true);
+    manager.get_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, true);
+    manager.get_node(utils::tag::RTPS, true);
+    manager.get_node(utils::tag::BUILTIN, true);
+    manager.get_node(utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST, true);
 
-        // Add profiles
-        profiles_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-                    xercesc::XMLString::transcode(utils::tag::PROFILES)));
-        root_element->appendChild(profiles_node);
-    }
-
-    // Obtain participant node with the profile id
-    try
-    {
-        participant_node = manager->get_node(
-            profiles_node,
-            utils::tag::PARTICIPANT,
-            utils::tag::PROFILE_NAME,
-            profile_id);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        participant_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-            xercesc::XMLString::transcode(utils::tag::PARTICIPANT)));
-        manager->set_attribute_to_node(participant_node, utils::tag::PROFILE_NAME, profile_id);
-        profiles_node->appendChild(participant_node);
-    }
-
-    // Obtain rtps node
-    try
-    {
-        rtps_node = manager->get_node(participant_node, utils::tag::RTPS);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        rtps_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                    utils::tag::RTPS)));
-        participant_node->appendChild(rtps_node);
-    }
-
-    // Obtain builtin node
-    try
-    {
-        builtin_node = manager->get_node(rtps_node, utils::tag::BUILTIN);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        builtin_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                    utils::tag::BUILTIN)));
-        rtps_node->appendChild(builtin_node);
-    }
-
-    // Obtain meta-traffic external unicast locator list node
-    try
-    {
-        locator_list_node = manager->get_node(builtin_node,
-                        utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        locator_list_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                    utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST)));
-        builtin_node->appendChild(locator_list_node);
-    }
-
-    common::locator_list::set_address(*manager, locator_list_node, address, index, true);
+    // Set the address using commons
+    common::locator_list::set_address(manager, address, index, true);
 
     // Validate new XML element and save it
-    manager->validate_and_save_document();
+    manager.validate_and_save_document();
 }
 
 void set_externality(
@@ -360,112 +204,22 @@ void set_externality(
         const std::string& externality,
         const std::string& index)
 {
-    // Xerces document manage XML elements
-    xercesc::DOMDocument* doc = nullptr;
-
-    // XML nodes and values
-    xercesc::DOMNode* profiles_node = nullptr;
-    xercesc::DOMNode* participant_node = nullptr;
-    xercesc::DOMNode* rtps_node = nullptr;
-    xercesc::DOMNode* builtin_node = nullptr;
-    xercesc::DOMNode* locator_list_node = nullptr;
-    xercesc::DOMNode* locator_node = nullptr;
-
     // Create XML manager and initialize the document
-    utils::XMLManager* manager = new utils::XMLManager(xml_file, true);
-    doc = manager->get_doc();
+    utils::XMLManager manager(xml_file, true);
 
-    // Obtain profiles node
-    try
-    {
-        profiles_node = manager->get_node(utils::tag::PROFILES);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // Obtain root element
-        xercesc::DOMElement* root_element = doc->getDocumentElement();
+    // Iterate through required elements, and create them if not existent
+    manager.get_node(utils::tag::PROFILES, true);
+    manager.get_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, true);
+    manager.get_node(utils::tag::RTPS, true);
+    manager.get_node(utils::tag::BUILTIN, true);
+    manager.get_node(utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST, true);
+    manager.get_locator_node(index, utils::tag::UDP_V4_LOCATOR, true);
 
-        // Add profiles
-        profiles_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-                    xercesc::XMLString::transcode(utils::tag::PROFILES)));
-        root_element->appendChild(profiles_node);
-    }
-
-    // Obtain participant node with the profile id
-    try
-    {
-        participant_node = manager->get_node(
-            profiles_node,
-            utils::tag::PARTICIPANT,
-            utils::tag::PROFILE_NAME,
-            profile_id);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        participant_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-            xercesc::XMLString::transcode(utils::tag::PARTICIPANT)));
-        manager->set_attribute_to_node(participant_node, utils::tag::PROFILE_NAME, profile_id);
-        profiles_node->appendChild(participant_node);
-    }
-
-    // Obtain rtps node
-    try
-    {
-        rtps_node = manager->get_node(participant_node, utils::tag::RTPS);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        rtps_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                    utils::tag::RTPS)));
-        participant_node->appendChild(rtps_node);
-    }
-
-    // Obtain builtin node
-    try
-    {
-        builtin_node = manager->get_node(rtps_node, utils::tag::BUILTIN);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        builtin_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                    utils::tag::BUILTIN)));
-        rtps_node->appendChild(builtin_node);
-    }
-
-    // Obtain meta-traffic external unicast locator list node
-    try
-    {
-        locator_list_node = manager->get_node(builtin_node,
-                        utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST);
-    }
-    catch (const ElementNotFound& ex)
-    {
-        // create if not existent
-        locator_list_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                    utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST)));
-        builtin_node->appendChild(locator_list_node);
-    }
-
-    // Check if locator should be created
-    if (index.empty())
-    {
-        locator_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(
-                    utils::tag::UDP_V4_LOCATOR)));
-        locator_list_node->appendChild(locator_node);
-    }
-    // Update the locator of the given index
-    else
-    {
-        locator_node = manager->get_node(locator_list_node, utils::tag::UDP_V4_LOCATOR, &index);
-    }
     // Set the externality value
-    manager->set_attribute_to_node(locator_node, utils::tag::EXTERNALITY, externality);
+    manager.set_attribute_to_node(utils::tag::EXTERNALITY, externality);
 
     // Validate new XML element and save it
-    manager->validate_and_save_document();
+    manager.validate_and_save_document();
 }
 
 void set_cost(

--- a/lib/src/cpp/utils/XMLManager.cpp
+++ b/lib/src/cpp/utils/XMLManager.cpp
@@ -561,7 +561,7 @@ void XMLManager::get_locator_node(
 
 std::string XMLManager::get_absolute_path(
         const std::string& xml_file,
-        bool file_exists)
+        bool& file_exists)
 {
     std::string absolute_xml_file;
 

--- a/lib/src/cpp/utils/XMLManager.cpp
+++ b/lib/src/cpp/utils/XMLManager.cpp
@@ -132,13 +132,13 @@ XMLManager::~XMLManager()
 
     // Release resources
     /*delete config;
-    delete doc;
-    delete error_handler;
-    delete implementation;
-    delete output;
-    delete parser;
-    delete serializer;
-    delete target;*/
+       delete doc;
+       delete error_handler;
+       delete implementation;
+       delete output;
+       delete parser;
+       delete serializer;
+       delete target;*/
 }
 
 void XMLManager::validate_and_save_document()
@@ -323,7 +323,7 @@ void XMLManager::get_node(
 {
     // Obtain list of nodes based on the target tag
     xercesc::DOMNodeList* node_list = static_cast<xercesc::DOMElement*>(last_node)->getElementsByTagName(
-                xercesc::XMLString::transcode(tag_name.c_str()));
+        xercesc::XMLString::transcode(tag_name.c_str()));
     // Check for expected node
     if (node_list->getLength() == 1)
     {
@@ -436,7 +436,7 @@ void XMLManager::get_node(
 {
     // Obtain list of nodes based on the target tag
     xercesc::DOMNodeList* node_list = static_cast<xercesc::DOMElement*>(last_node)->getElementsByTagName(
-                xercesc::XMLString::transcode(tag_name.c_str()));
+        xercesc::XMLString::transcode(tag_name.c_str()));
 
     // Iterate through the nodes
     for (int i = 0, size = node_list->getLength(); i < size; i++)
@@ -448,7 +448,7 @@ void XMLManager::get_node(
         {
             // Obtain the attribute that matches the name
             xercesc::DOMNode* attribute_item = node_attributes->getNamedItem(
-                    xercesc::XMLString::transcode(name.c_str()));
+                xercesc::XMLString::transcode(name.c_str()));
             if (attribute_item != nullptr)
             {
                 // If the value of the attribute match
@@ -480,7 +480,9 @@ void XMLManager::get_node(
     // Throw ElementNotFound exception
     else
     {
-        throw ElementNotFound("non-existent " + tag_name + " element with attribute " + name + " and value " + value + "\n");
+        throw ElementNotFound(
+                  "non-existent " + tag_name + " element with attribute " + name + " and value " + value +
+                  "\n");
     }
 }
 

--- a/lib/src/cpp/utils/XMLManager.cpp
+++ b/lib/src/cpp/utils/XMLManager.cpp
@@ -143,10 +143,10 @@ void XMLManager::transform_standalone_to_rooted_structure()
     {
         // Create new ROOT node
         xercesc::DOMNode* new_root_node = static_cast<xercesc::DOMNode*>(doc->createElement(
-                xercesc::XMLString::transcode(utils::tag::ROOT)));
+                    xercesc::XMLString::transcode(utils::tag::ROOT)));
         static_cast<xercesc::DOMElement*>(new_root_node)->setAttribute(
-                xercesc::XMLString::transcode(utils::tag::XMLNS),
-                xercesc::XMLString::transcode(utils::tag::EPROSIMA_URL));
+            xercesc::XMLString::transcode(utils::tag::XMLNS),
+            xercesc::XMLString::transcode(utils::tag::EPROSIMA_URL));
 
         // Create copy of node
         xercesc::DOMNode* copy_node = static_cast<xercesc::DOMNode*>(doc->createElement(last_node->getNodeName()));

--- a/lib/src/cpp/utils/XMLManager.cpp
+++ b/lib/src/cpp/utils/XMLManager.cpp
@@ -450,13 +450,10 @@ void XMLManager::get_node(
     {
         create_node(default_tag_name);
     }
-    // Throw ElementNotFound exception
+    // Throw BadParameter exception
     else
     {
-        // Set up exception message to be thrown if node should not be created
-        std::string exception_message = xercesc::XMLString::transcode(last_node->getNodeName());
-        exception_message += " does not have an element in position " + index + "\n";
-        throw ElementNotFound(exception_message);
+        throw BadParameter("could not obtain collection element with empty index\n");
     }
 }
 

--- a/lib/src/cpp/utils/XMLManager.cpp
+++ b/lib/src/cpp/utils/XMLManager.cpp
@@ -391,6 +391,17 @@ void XMLManager::set_value_to_node(
     node->appendChild(name_value);
 }
 
+void XMLManager::set_attribute_to_node(
+        xercesc::DOMNode*& node,
+        const std::string& name,
+        const std::string& value)
+{
+    // Set the attribute value
+    static_cast<xercesc::DOMElement*>(node)->setAttribute(
+        xercesc::XMLString::transcode(name.c_str()),
+        xercesc::XMLString::transcode(value.c_str()));
+}
+
 std::string XMLManager::get_absolute_path(
         const std::string& xml_file,
         bool& file_exists)

--- a/lib/src/cpp/utils/XMLManager.hpp
+++ b/lib/src/cpp/utils/XMLManager.hpp
@@ -98,6 +98,38 @@ public:
             const std::string& value);
 
     /**
+     * @brief Set the attribute value of all node siblings to the given value associated to given name.
+     *
+     * @param[in] name to set the node attribute
+     * @param[in] value to be set in the node
+     */
+    void set_siblings_attribute(
+            const std::string& name,
+            const std::string& value);
+
+
+    /**
+     * @brief Get the node value (only for simple cases)
+     *
+     * @throw ElementNotFound exception if could not obtain node value
+     *
+     * @return std::string node value (Empty string if error)
+     */
+    std::string get_node_value();
+
+    /**
+     * @brief Get the node attribute value of the given attribute name
+     *
+     * @param[in] name attribute name
+     *
+     * @throw ElementNotFound exception if could not obtain node attribute value
+     *
+     * @return std::string node attribute value (Empty string if error)
+     */
+    std::string get_node_attribute_value(
+            const std::string& name);
+
+    /**
      * @brief Get the (unique) child node object that matches the given tag name.
      *
      * @param[in] tag_name string with the node (<tag>) name

--- a/lib/src/cpp/utils/XMLManager.hpp
+++ b/lib/src/cpp/utils/XMLManager.hpp
@@ -113,7 +113,7 @@ public:
      *
      * @throw ElementNotFound exception if the node value could not be obtained
      *
-     * @return std::string node value (Empty string if error)
+     * @return std::string node value
      */
     std::string get_node_value();
 
@@ -149,6 +149,7 @@ public:
      * @param[in] create_if_not_existent flag to create node if it is not found
      *
      * @throw ElementNotFound exception if expected node was not found and node creation was not required
+     * @throw BadParameter exception if expected node could not be found by using the given index.
      */
     void get_node(
             const std::string& index,
@@ -180,6 +181,7 @@ public:
      * @param[in] create_if_not_existent flag to create node if it is not found
      *
      * @throw ElementNotFound exception if expected node was not found and node creation was not required
+     * @throw BadParameter exception if expected node could not be found by using the given index.
      */
     void get_locator_node(
             const std::string& index,
@@ -190,7 +192,6 @@ private:
 
     /**
      * @brief Transforms standalone XML document structure to rooted.
-     *
      */
     void transform_standalone_to_rooted_structure();
 

--- a/lib/src/cpp/utils/XMLManager.hpp
+++ b/lib/src/cpp/utils/XMLManager.hpp
@@ -189,6 +189,12 @@ public:
 private:
 
     /**
+     * @brief Transforms standalone XML document structure to rooted.
+     *
+     */
+    void transform_standalone_to_rooted_structure();
+
+    /**
      * @brief Save the document as string and validate.
      *
      * @throw ElementInvalid exception if document does not pass parser validation

--- a/lib/src/cpp/utils/XMLManager.hpp
+++ b/lib/src/cpp/utils/XMLManager.hpp
@@ -51,9 +51,9 @@ public:
      *  and reads given xml_file document.
      *
      * @param[in] xml_file string with the file path
-     * @param[in] create_file bool (optional) create file if it does not exist flag
+     * @param[in] create_file bool (optional) create file if the flag is set
      *
-     * @throw FileNotFound exception if Xerces XML workspace could not be initialized
+     * @throw Error exception if Xerces XML workspace could not be initialized
      */
     XMLManager(
             const std::string& xml_file,
@@ -88,20 +88,20 @@ public:
             const std::string& value);
 
     /**
-     * @brief Set the attribute value associated to the attribute name to node object.
+     * @brief Set the attribute value associated to the attribute name attached to the node object.
      *
-     * @param[in] name to set the node attribute
-     * @param[in] value to be set in the node
+     * @param[in] name of the attribute to be set
+     * @param[in] value to be set in the node attribute
      */
     void set_attribute_to_node(
             const std::string& name,
             const std::string& value);
 
     /**
-     * @brief Set the attribute value of all node siblings to the given value associated to given name.
+     * @brief Set the specific attribute of all node siblings to the given value.
      *
-     * @param[in] name to set the node attribute
-     * @param[in] value to be set in the node
+     * @param[in] name of the node attribute to be set
+     * @param[in] value to be set in the node attribute
      */
     void set_siblings_attribute(
             const std::string& name,
@@ -111,7 +111,7 @@ public:
     /**
      * @brief Get the node value (only for simple cases)
      *
-     * @throw ElementNotFound exception if could not obtain node value
+     * @throw ElementNotFound exception if the node value could not be obtained
      *
      * @return std::string node value (Empty string if error)
      */
@@ -122,7 +122,7 @@ public:
      *
      * @param[in] name attribute name
      *
-     * @throw ElementNotFound exception if could not obtain node attribute value
+     * @throw ElementNotFound exception if the attribute value could not be obtained from the node
      *
      * @return std::string node attribute value (Empty string if error)
      */
@@ -133,27 +133,27 @@ public:
      * @brief Get the (unique) child node object that matches the given tag name.
      *
      * @param[in] tag_name string with the node (<tag>) name
-     * @param[in] create_if_not_existent flag to create node if was not found
+     * @param[in] create_if_not_existent flag to create node if it is not found
      *
-     * @throw ElementNotFound exception if expected node was not found and node creation not required
+     * @throw ElementNotFound exception if expected node was not found and node creation was not required
      */
     void get_node(
             const std::string& tag_name,
-            const bool& create_if_not_existent);
+            const bool create_if_not_existent);
 
     /**
      * @brief Get the node object located in the index position. If empty index, current node is kept.
      *
      * @param[in] index string index of the node element
-     * @param[in] default_tag_name string with the default node (<tag>) name
-     * @param[in] create_if_not_existent flag to create node if was not found
+     * @param[in] default_tag_name string with the default node (<tag>) name required to create the node if required.
+     * @param[in] create_if_not_existent flag to create node if it is not found
      *
-     * @throw ElementNotFound exception if expected node was not found and node creation not required
+     * @throw ElementNotFound exception if expected node was not found and node creation was not required
      */
     void get_node(
             const std::string& index,
             const std::string& default_tag_name,
-            const bool& create_if_not_existent);
+            const bool create_if_not_existent);
 
     /**
      * @brief Get the node object that matches the given tag name, and has the same attribute key-value pair
@@ -162,29 +162,29 @@ public:
      * @param[in] tag_name string with the node (<tag>) name
      * @param[in] name string key (attribute) name of the node element
      * @param[in] value string value (attribute) value of the node element
-     * @param[in] create_if_not_existent flag to create node if was not found
+     * @param[in] create_if_not_existent flag to create node if it is not found
      *
-     * @throw ElementNotFound exception if expected node was not found and node creation not required
+     * @throw ElementNotFound exception if expected node was not found and node creation was not required
      */
     void get_node(
             const std::string& tag_name,
             const std::string& name,
             const std::string& value,
-            const bool& create_if_not_existent);
+            const bool create_if_not_existent);
 
     /**
      * @brief Get the locator node object found at index position. If empty index, current node is kept.
      *
      * @param[in] index string index of the node element
-     * @param[in] default_tag_name string with the default node (<tag>) name
-     * @param[in] create_if_not_existent flag to create node if was not found
+     * @param[in] is_external flag to determine if the locator node is external or common
+     * @param[in] create_if_not_existent flag to create node if it is not found
      *
-     * @throw ElementNotFound exception if expected node was not found and node creation not required
+     * @throw ElementNotFound exception if expected node was not found and node creation was not required
      */
     void get_locator_node(
             const std::string& index,
-            const std::string& default_tag_name,
-            const bool& create_if_not_existent);
+            const bool is_external,
+            const bool create_if_not_existent);
 
 private:
 
@@ -207,6 +207,14 @@ private:
     bool save_xml();
 
     /**
+     * @brief Auxiliar method that creates a new node with the given tag and appends it to the last node.
+     *
+     * @param tag_name string with the new node (<tag>) name
+     */
+    void create_node(
+            const std::string& tag_name);
+
+    /**
      * @brief Get the absolute path of the given file name (POSIX only).
      *
      * @param[in]  xml_file string with the given file name
@@ -216,7 +224,7 @@ private:
      */
     std::string get_absolute_path(
             const std::string& xml_file,
-            bool& file_exists);
+            bool file_exists);
 
     /**
      * @brief Get the real index of the listed nodes (avoid empty nodes).

--- a/lib/src/cpp/utils/XMLManager.hpp
+++ b/lib/src/cpp/utils/XMLManager.hpp
@@ -230,7 +230,7 @@ private:
      */
     std::string get_absolute_path(
             const std::string& xml_file,
-            bool file_exists);
+            bool& file_exists);
 
     /**
      * @brief Get the real index of the listed nodes (avoid empty nodes).

--- a/lib/src/cpp/utils/XMLManager.hpp
+++ b/lib/src/cpp/utils/XMLManager.hpp
@@ -95,6 +95,18 @@ public:
             const std::string& value);
 
     /**
+     * @brief Set the attribute value associated to the attribute name to node object
+     *
+     * @param node DOMNode node which attribute would be set
+     * @param name to set the node attribute
+     * @param value to be set in the node
+     */
+    void set_attribute_to_node(
+            xercesc::DOMNode*& node,
+            const std::string& name,
+            const std::string& value);
+
+    /**
      * @brief Temporal function to get the doc object
      *
      * @return xercesc::DOMDocument* doc object

--- a/lib/src/cpp/utils/XMLManager.hpp
+++ b/lib/src/cpp/utils/XMLManager.hpp
@@ -48,7 +48,7 @@ public:
 
     /**
      * @brief Construct a new Parse XML object, which initializes Xerces required tools,
-     *  and reads given xml_file document
+     *  and reads given xml_file document.
      *
      * @param[in] xml_file string with the file path
      * @param[in] create_file bool (optional) create file if it does not exist flag
@@ -66,125 +66,108 @@ public:
     ~XMLManager();
 
     /**
-     * @brief Validate the document, and save to disk if valid
+     * @brief Validate the document, and save to disk if valid.
      *
      * @throw ElementInvalid exception if document does not pass parser validation
      */
     void validate_and_save_document();
 
     /**
-     * @brief Remove the given node from the parent node
-     *
-     * @param parent_node DOMNode parent node which should contain the node to be deleted
-     * @param node_to_be_deleted DOMNode node to be deleted
+     * @brief Remove the selected node.
      *
      * @throw ElementInvalid exception if node is the last node element (could not be deleted)
      */
-    void clear_node(
-            xercesc::DOMNode*& parent_node,
-            xercesc::DOMNode*& node_to_be_deleted);
+    void clear_node();
 
     /**
-     * @brief Set the value to node object
+     * @brief Set the value to node object.
      *
-     * @param node DOMNode node to be set
-     * @param value to be set in the node
+     * @param[in] value to be set in the node
      */
     void set_value_to_node(
-            xercesc::DOMNode*& node,
             const std::string& value);
 
     /**
-     * @brief Set the attribute value associated to the attribute name to node object
+     * @brief Set the attribute value associated to the attribute name to node object.
      *
-     * @param node DOMNode node which attribute would be set
-     * @param name to set the node attribute
-     * @param value to be set in the node
+     * @param[in] name to set the node attribute
+     * @param[in] value to be set in the node
      */
     void set_attribute_to_node(
-            xercesc::DOMNode*& node,
             const std::string& name,
             const std::string& value);
 
     /**
-     * @brief Temporal function to get the doc object
+     * @brief Get the (unique) child node object that matches the given tag name.
      *
-     * @return xercesc::DOMDocument* doc object
+     * @param[in] tag_name string with the node (<tag>) name
+     * @param[in] create_if_not_existent flag to create node if was not found
+     *
+     * @throw ElementNotFound exception if expected node was not found and node creation not required
      */
-    xercesc::DOMDocument* get_doc();
-
-    /*
-     * AUX get_node functions based on the implementation needs
-     */
-    xercesc::DOMNode* get_node(
-            const std::string& tag_name);
-
-    xercesc::DOMNode* get_node(
+    void get_node(
             const std::string& tag_name,
-            const std::string* index);
-
-    xercesc::DOMNode* get_node(
-            const std::string& tag_name,
-            const std::string& att_name,
-            const std::string& att_value);
-
-    xercesc::DOMNode* get_node(
-            const std::string& tag_name,
-            const std::string* index,
-            const std::string& att_name,
-            const std::string& att_value);
-
-    xercesc::DOMNode* get_node(
-            xercesc::DOMNode*& parent_node,
-            const std::string& tag_name);
-
-    xercesc::DOMNode* get_node(
-            xercesc::DOMNode*& parent_node,
-            const std::string& tag_name,
-            const std::string* index);
-
-    xercesc::DOMNode* get_node(
-            xercesc::DOMNode*& parent_node,
-            const std::string& tag_name,
-            const std::string& att_name,
-            const std::string& att_value);
+            const bool& create_if_not_existent);
 
     /**
-     * @brief  MAIN get_node function.
-     *   Obtain the node in the list that matches tag name and
-     *   the given index or the given name-value attribute pair
+     * @brief Get the node object located in the index position. If empty index, current node is kept.
      *
-     * @param parent_node DOMNode with the parent node
-     * @param tag_name string with the node (<tag>) name
-     * @param index string index of the node element in LIST cases
-     * @param att_name string key (attribute) name of the node element in MAP cases
-     * @param att_value string key (attribute) value of the node element in MAP cases
+     * @param[in] index string index of the node element
+     * @param[in] default_tag_name string with the default node (<tag>) name
+     * @param[in] create_if_not_existent flag to create node if was not found
      *
-     * @return xercesc::DOMNode* with the found node
-     *
-     * @throw ElementNotFound exception if expected node was not found
+     * @throw ElementNotFound exception if expected node was not found and node creation not required
      */
-    xercesc::DOMNode* get_node(
-            xercesc::DOMNode*& parent_node,
+    void get_node(
+            const std::string& index,
+            const std::string& default_tag_name,
+            const bool& create_if_not_existent);
+
+    /**
+     * @brief Get the node object that matches the given tag name, and has the same attribute key-value pair
+     *        set as the given name-value pair.
+     *
+     * @param[in] tag_name string with the node (<tag>) name
+     * @param[in] name string key (attribute) name of the node element
+     * @param[in] value string value (attribute) value of the node element
+     * @param[in] create_if_not_existent flag to create node if was not found
+     *
+     * @throw ElementNotFound exception if expected node was not found and node creation not required
+     */
+    void get_node(
             const std::string& tag_name,
-            const std::string* index,
-            const std::string& att_name,
-            const std::string& att_value);
+            const std::string& name,
+            const std::string& value,
+            const bool& create_if_not_existent);
+
+    /**
+     * @brief Get the locator node object found at index position. If empty index, current node is kept.
+     *
+     * @param[in] index string index of the node element
+     * @param[in] default_tag_name string with the default node (<tag>) name
+     * @param[in] create_if_not_existent flag to create node if was not found
+     *
+     * @throw ElementNotFound exception if expected node was not found and node creation not required
+     */
+    void get_locator_node(
+            const std::string& index,
+            const std::string& default_tag_name,
+            const bool& create_if_not_existent);
 
 private:
 
     /**
-     * @brief Save the document as string and validate
+     * @brief Save the document as string and validate.
+     *
+     * @throw ElementInvalid exception if document does not pass parser validation
      *
      * @return true document passes parser validation
      * @return false document does not pass parser validation
-     *
-     * @throw ElementInvalid exception if document does not pass parser validation
      */
     bool validate_xml();
 
     /**
-     * @brief  Save the document in the target file path
+     * @brief  Save the document in the target file path.
      *
      * @return true document saved
      * @return false failure saving document
@@ -192,10 +175,11 @@ private:
     bool save_xml();
 
     /**
-     * @brief Get the absolute path of the given file name [POSIX only]
+     * @brief Get the absolute path of the given file name (POSIX only).
      *
      * @param[in]  xml_file string with the given file name
      * @param[out] file_exists bool reference to save file existence status
+     *
      * @return std::string with the absolute path
      */
     std::string get_absolute_path(
@@ -203,21 +187,20 @@ private:
             bool& file_exists);
 
     /**
-     * @brief Get the real index of the listed nodes (avoid empty nodes)
+     * @brief Get the real index of the listed nodes (avoid empty nodes).
      *
      * @param[in]  node_list with the nodes to be filtered
+     *
      * @return std::unique_ptr<std::vector<uint>> with the indexes of the non-empty nodes
      */
     std::unique_ptr<std::vector<uint>>  get_real_index(
             xercesc::DOMNodeList*& node_list);
 
     /**
-     * @brief Clear node. Usage: remove all DOMText children from node
+     * @brief Clear node. Usage: remove all DOMText children from node.
      *
-     * @param node DOMNode to be reset
      */
-    void reset_node(
-            xercesc::DOMNode*& node);
+    void reset_node();
 
     // CONSTANT CHAR USED BY XERCES
     constexpr static const char* CORE = "Core";
@@ -238,6 +221,9 @@ private:
 
     // Custom utils
     utils::ErrorHandlerXMLManager* error_handler = nullptr;
+
+    // Latest node navigated to
+    xercesc::DOMNode* last_node = nullptr;
 };
 
 } /* parse */


### PR DESCRIPTION
This Pull Request includes the following changes:

- Add new utils functions to please the API requirements as `set_attribute_to_node`, `set_siblings_attribute`, `get_node_value` and `get_node_attribute_value`
- Refactor `get_node` functions to improve their functionality, and add a `get_locator_node` to abstract the difference between an external locator and a "common" locator.
- Add a private method in each namespace to initialize base node to be used along the methods.
- **NEW!** Add a method to detect if loaded XML file has standalone structure, and transform it to rooted if required.