### PR TITLE
[18109] Implement transport set methods

### DIFF
--- a/lib/src/cpp/transport_descriptor/TransportDescriptor.cpp
+++ b/lib/src/cpp/transport_descriptor/TransportDescriptor.cpp
@@ -36,17 +36,23 @@ namespace transport_descriptor {
  * @param[in] manager utils::XMLManager to obtain the base node position in the XML document
  * @param[in] transport_id Transport descriptor profile identifier
  * @param[in] create_if_not_existent flag that enables the creation of the  element if it does not exist
+ * @param[in] additional_tag additional tag to obtain node
  *
  * @throw ElementNotFound exception if expected node was not found and node creation was not required
  */
 void initialize_namespace(
         utils::XMLManager& manager,
         const std::string& transport_id,
-        const bool create_if_not_existent)
+        const bool create_if_not_existent,
+        const std::string& additional_tag)
 {
     // Iterate through required elements, and create them if not existent
     manager.get_node(utils::tag::PROFILES, create_if_not_existent);
     manager.get_transport_node(transport_id, create_if_not_existent);
+    if (!additional_tag.empty())
+    {
+        manager.get_node(additional_tag, create_if_not_existent);
+    }
 }
 
 std::string print(
@@ -640,10 +646,7 @@ void set_kind(
     utils::XMLManager manager(xml_file, true);
 
     // Obtain base node position
-    initialize_namespace(manager, transport_descriptor_id, true);
-
-    // Obtain kind node
-    manager.get_node(utils::tag::TRANSPORT_KIND, true);
+    initialize_namespace(manager, transport_descriptor_id, true, utils::tag::TRANSPORT_KIND);
 
     // Set the node value
     manager.set_value_to_node(kind);
@@ -902,10 +905,7 @@ void set_interface_whitelist(
     utils::XMLManager manager(xml_file, true);
 
     // Obtain base node position
-    initialize_namespace(manager, transport_descriptor_id, true);
-
-    // Obtain interface whitelist node
-    manager.get_node(utils::tag::INTERFACE_WHITELIST, true);
+    initialize_namespace(manager, transport_descriptor_id, true, utils::tag::INTERFACE_WHITELIST);
 
     // Obtain the address located in the index position
     manager.get_node(index, utils::tag::ADDRESS, true);

--- a/lib/src/cpp/transport_descriptor/TransportDescriptor.cpp
+++ b/lib/src/cpp/transport_descriptor/TransportDescriptor.cpp
@@ -23,9 +23,31 @@
 
 #include <fastdds_qos_profiles_manager/exception/Exception.hpp>
 
+#include <utils/TagsXMLManager.hpp>
+#include <utils/XMLManager.hpp>
+
 namespace eprosima {
 namespace qosprof {
 namespace transport_descriptor {
+
+/**
+ * @brief Private common method for all the functions that belong to this namespace to obtain base node position.
+ *
+ * @param[in] manager utils::XMLManager to obtain the base node position in the XML document
+ * @param[in] transport_id Transport descriptor profile identifier
+ * @param[in] create_if_not_existent flag that enables the creation of the  element if it does not exist
+ *
+ * @throw ElementNotFound exception if expected node was not found and node creation was not required
+ */
+void initialize_namespace(
+        utils::XMLManager& manager,
+        const std::string& transport_id,
+        const bool create_if_not_existent)
+{
+    // Iterate through required elements, and create them if not existent
+    manager.get_node(utils::tag::PROFILES, create_if_not_existent);
+    manager.get_transport_node(transport_id, create_if_not_existent);
+}
 
 std::string print(
         const std::string& xml_file,
@@ -614,7 +636,20 @@ void set_kind(
         const std::string& transport_descriptor_id,
         const std::string& kind)
 {
-    throw Unsupported("Unsupported");
+    // Create XML manager and initialize the document
+    utils::XMLManager manager(xml_file, true);
+
+    // Obtain base node position
+    initialize_namespace(manager, transport_descriptor_id, true);
+
+    // Obtain kind node
+    manager.get_node(utils::tag::TRANSPORT_KIND, true);
+
+    // Set the node value
+    manager.set_value_to_node(kind);
+
+    // Validate new XML element and save it
+    manager.validate_and_save_document();
 }
 
 void set_send_buffer_size(
@@ -863,7 +898,23 @@ void set_interface_whitelist(
         const std::string& ip_address,
         const std::string& index)
 {
-    throw Unsupported("Unsupported");
+    // Create XML manager and initialize the document
+    utils::XMLManager manager(xml_file, true);
+
+    // Obtain base node position
+    initialize_namespace(manager, transport_descriptor_id, true);
+
+    // Obtain interface whitelist node
+    manager.get_node(utils::tag::INTERFACE_WHITELIST, true);
+
+    // Obtain the address located in the index position
+    manager.get_node(index, utils::tag::ADDRESS, true);
+
+    // Set the node value
+    manager.set_value_to_node(ip_address);
+
+    // Validate new XML element and save it
+    manager.validate_and_save_document();
 }
 
 void set_listening_ports(

--- a/lib/src/cpp/utils/TagsXMLManager.hpp
+++ b/lib/src/cpp/utils/TagsXMLManager.hpp
@@ -36,6 +36,7 @@ constexpr const char* ROOT = "dds";
 constexpr const char* DEFAULT_PROFILE = "is_default_profile";
 constexpr const char* PARTICIPANT = "participant";
 constexpr const char* PROFILE_NAME = "profile_name";
+constexpr const char* TRANSPORT_DESCRIPTOR_LIST = "transport_descriptors";
 
 /// PARTICIPANT
 constexpr const char* RTPS = "rtps";
@@ -46,6 +47,12 @@ constexpr const char* DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST = "default_external_
 constexpr const char* INITIAL_PEERS_LIST = "initialPeersList";
 constexpr const char* METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST = "metatraffic_external_unicast_locators";
 constexpr const char* NAME = "name";
+
+/// TRANSPORT DESCRIPTOR LIST
+constexpr const char* INTERFACE_WHITELIST = "interfaceWhiteList";
+constexpr const char* TRANSPORT_DESCRIPTOR = "transport_descriptor";
+constexpr const char* TRANSPORT_ID = "transport_id";
+constexpr const char* TRANSPORT_KIND = "type";
 
 // COMMONS
 /// LOCATOR

--- a/lib/src/cpp/utils/XMLManager.cpp
+++ b/lib/src/cpp/utils/XMLManager.cpp
@@ -579,10 +579,6 @@ void XMLManager::get_transport_node(
             xercesc::DOMNode* child = node_list->item(index_list->at(i));
             xercesc::DOMNodeList* child_node_list = static_cast<xercesc::DOMElement*>(child)->getElementsByTagName(
                 xercesc::XMLString::transcode(utils::tag::TRANSPORT_ID));
-            if (child_node_list->getLength() == 0)
-            {
-                continue; // keep iterating
-            }
             std::string identifier = xercesc::XMLString::transcode(child_node_list->item(0)->getNodeValue());
 
             // Check if the identifier is the required

--- a/lib/src/cpp/utils/XMLManager.hpp
+++ b/lib/src/cpp/utils/XMLManager.hpp
@@ -188,6 +188,18 @@ public:
             const bool is_external,
             const bool create_if_not_existent);
 
+    /**
+     * @brief Get the transport node object associated to the given identifier. New node is created if required.
+     *
+     * @param[in] transport_id string with the node identifier
+     * @param[in] create_if_not_existent flag to create node if it is not found
+     *
+     * @throw ElementNotFound exception if expected node was not found and node creation was not required
+     */
+    void get_transport_node(
+            const std::string& transport_id,
+            const bool create_if_not_existent);
+
 private:
 
     /**


### PR DESCRIPTION
**This Pull Request may be reviewed and merged righ after the #40 refactor gets merged**

The implemented set methods are:
- set kind
- set whitelist address 

To do so, new utils method has been created to check each transport descriptor id and return the required.