### PR TITLE
[18209] Refactor API library to admit CLI complex calls

### DIFF
--- a/cli/src/cpp/fastdds_qos_profiles_manager_cli.cpp
+++ b/cli/src/cpp/fastdds_qos_profiles_manager_cli.cpp
@@ -55,7 +55,7 @@ int main(
         // Set command requires at least one more follow-up arguments: element being set
         if (0 < args[PARSER_ARGS].asStringList().size())
         {
-            main_element_parser(CommonCommands::SET, args[PARSER_FILE].asString(), argc - 2, argv + 2);
+            main_element_parser(CommonCommands::SET, argc - 2, argv + 2);
         }
         else
         {
@@ -86,7 +86,7 @@ int main(
         }
         else if (1 == args[PARSER_ARGS].asStringList().size())
         {
-            main_element_parser(CommonCommands::PRINT, args[PARSER_FILE].asString(), argc - 2, argv + 2);
+            main_element_parser(CommonCommands::PRINT, argc - 2, argv + 2);
         }
         else
         {
@@ -113,7 +113,7 @@ int main(
         // Clear command requires only one follow-up argument: element to be cleared
         if (1 == args[PARSER_ARGS].asStringList().size())
         {
-            main_element_parser(CommonCommands::CLEAR, args[PARSER_FILE].asString(), argc - 2, argv + 2);
+            main_element_parser(CommonCommands::CLEAR, argc - 2, argv + 2);
         }
         else
         {

--- a/cli/src/cpp/fastdds_qos_profiles_manager_cli.cpp
+++ b/cli/src/cpp/fastdds_qos_profiles_manager_cli.cpp
@@ -17,6 +17,8 @@
 #include <string>
 
 #include <docopt/docopt.h>
+#include <fastdds_qos_profiles_manager_lib/QoSProfileManager.hpp>
+#include <fastdds_qos_profiles_manager_lib/exception/Exception.hpp>
 
 #include <config.h>
 #include <parser_constants.hpp>
@@ -37,6 +39,10 @@ int main(
         true);                                                      // options first
 
     std::string command = args[PARSER_COMMAND].asString();
+
+    // Open XML workspace
+    eprosima::qosprof::initialize(args[PARSER_FILE].asString(), command == SET_COMMAND);
+
     if (command == SET_COMMAND)
     {
         // Set command requires at least one more follow-up arguments: element being set
@@ -139,6 +145,9 @@ int main(
         std::cout << "ERROR: " << command << " command not recognized" << std::endl;
         std::cout << USAGE << std::endl;
     }
+
+    // Close XML workspace
+    eprosima::qosprof::terminate();
 
     return 0;
 }

--- a/cli/src/cpp/fastdds_qos_profiles_manager_cli.cpp
+++ b/cli/src/cpp/fastdds_qos_profiles_manager_cli.cpp
@@ -41,7 +41,14 @@ int main(
     std::string command = args[PARSER_COMMAND].asString();
 
     // Open XML workspace
-    eprosima::qosprof::initialize(args[PARSER_FILE].asString(), command == SET_COMMAND);
+    try
+    {
+        eprosima::qosprof::initialize(args[PARSER_FILE].asString(), command == SET_COMMAND);
+    }
+    catch (const eprosima::qosprof::Exception& e)
+    {
+        std::cout << "Fast DDS QoS Profiles Manager exception caught: " << e.what() << std::endl;
+    }
 
     if (command == SET_COMMAND)
     {

--- a/cli/src/cpp/fastdds_qos_profiles_manager_cli.cpp
+++ b/cli/src/cpp/fastdds_qos_profiles_manager_cli.cpp
@@ -43,7 +43,7 @@ int main(
     // Open XML workspace
     try
     {
-        eprosima::qosprof::initialize(args[PARSER_FILE].asString(), command == SET_COMMAND);
+        eprosima::qosprof::initialize(args[PARSER_FILE].asString());
     }
     catch (const eprosima::qosprof::Exception& e)
     {

--- a/cli/src/cpp/fastdds_qos_profiles_manager_cli.cpp
+++ b/cli/src/cpp/fastdds_qos_profiles_manager_cli.cpp
@@ -17,7 +17,7 @@
 #include <string>
 
 #include <docopt/docopt.h>
-#include <fastdds_qos_profiles_manager_lib/QoSProfileManager.hpp>
+#include <fastdds_qos_profiles_manager_lib/QoSProfilesManager.hpp>
 #include <fastdds_qos_profiles_manager_lib/exception/Exception.hpp>
 
 #include <config.h>

--- a/cli/src/cpp/utils/builtin_parser.cpp
+++ b/cli/src/cpp/utils/builtin_parser.cpp
@@ -26,7 +26,6 @@ namespace qosprof_cli {
 
 void builtin_discovery_config_parser(
         CommonCommands command,
-        const std::string& filename,
         const std::string& profile_name,
         std::string& element,
         const std::vector<std::string>& values)
@@ -61,7 +60,7 @@ void builtin_discovery_config_parser(
                         DISCOVERY_CONFIG_SUBELEMENT, subelement, subsubelement, values, message);
         if (!print_usage)
         {
-            duration_type_parser(duration_type, command, filename, profile_name, subsubelement, values, message);
+            duration_type_parser(duration_type, command, profile_name, subsubelement, values, message);
         }
         else
         {
@@ -159,7 +158,6 @@ bool builtin_locator_parser(
 
 void builtin_parser(
         CommonCommands command,
-        const std::string& filename,
         const std::string& profile_name,
         std::string& element,
         const std::vector<std::string>& values)
@@ -186,7 +184,7 @@ void builtin_parser(
 
         if (!print_usage)
         {
-            builtin_discovery_config_parser(command, filename, profile_name, subelement, values);
+            builtin_discovery_config_parser(command, profile_name, subelement, values);
         }
         else
         {
@@ -215,8 +213,8 @@ void builtin_parser(
 
         if (!print_usage)
         {
-            external_locators_parser(ExternalLocatorsList::PARTICIPANT_METATRAFFIC_UNICAST, command, filename,
-                    profile_name, subelement, values);
+            external_locators_parser(ExternalLocatorsList::PARTICIPANT_METATRAFFIC_UNICAST, command, profile_name,
+                    subelement, values);
         }
         else
         {
@@ -252,7 +250,7 @@ void builtin_parser(
 
         if (!print_usage)
         {
-            locators_parser(locator_list, command, filename, profile_name, subsubelement, key, values, message);
+            locators_parser(locator_list, command, profile_name, subsubelement, key, values, message);
         }
         else
         {

--- a/cli/src/cpp/utils/duration_type_parser.cpp
+++ b/cli/src/cpp/utils/duration_type_parser.cpp
@@ -108,7 +108,6 @@ bool duration_type_selector(
 void duration_type_parser(
         DurationTypeList duration_type,
         CommonCommands command,
-        const std::string& filename,
         const std::string& profile_name,
         std::string& element,
         const std::vector<std::string>& values,
@@ -192,20 +191,18 @@ void duration_type_parser(
                             // TODO
                             break;
                         case DurationTypeList::PARTICIPANT_ANNOUNCEMENT_PERIOD:
-                            qosprof::domain_participant::builtin::discovery_config::clear_lease_announcement(filename,
-                                    profile_name);
+                            qosprof::domain_participant::builtin::discovery_config::clear_lease_announcement(                                    profile_name);
                             break;
                         case DurationTypeList::PARTICIPANT_CLIENT_ANNOUNCEMENT_PERIOD:
                             qosprof::domain_participant::builtin::discovery_config::clear_client_announcement_period(
-                                filename, profile_name);
+                                profile_name);
                             break;
                         case DurationTypeList::PARTICIPANT_INITIAL_ANNOUNCEMENTS_PERIOD:
                             qosprof::domain_participant::builtin::discovery_config::clear_initial_announcements_period(
-                                filename, profile_name);
+                                profile_name);
                             break;
                         case DurationTypeList::PARTICIPANT_LEASE_DURATION:
-                            qosprof::domain_participant::builtin::discovery_config::clear_lease_duration(filename,
-                                    profile_name);
+                            qosprof::domain_participant::builtin::discovery_config::clear_lease_duration(                                    profile_name);
                             break;
                     }
                     break;
@@ -273,20 +270,18 @@ void duration_type_parser(
                             // TODO
                             break;
                         case DurationTypeList::PARTICIPANT_ANNOUNCEMENT_PERIOD:
-                            qosprof::domain_participant::builtin::discovery_config::print_lease_announcement(filename,
-                                    profile_name);
+                            qosprof::domain_participant::builtin::discovery_config::print_lease_announcement(                                    profile_name);
                             break;
                         case DurationTypeList::PARTICIPANT_CLIENT_ANNOUNCEMENT_PERIOD:
                             qosprof::domain_participant::builtin::discovery_config::print_client_announcement_period(
-                                filename, profile_name);
+                                profile_name);
                             break;
                         case DurationTypeList::PARTICIPANT_INITIAL_ANNOUNCEMENTS_PERIOD:
                             qosprof::domain_participant::builtin::discovery_config::print_initial_announcements_period(
-                                filename, profile_name);
+                                profile_name);
                             break;
                         case DurationTypeList::PARTICIPANT_LEASE_DURATION:
-                            qosprof::domain_participant::builtin::discovery_config::print_lease_duration(filename,
-                                    profile_name);
+                            qosprof::domain_participant::builtin::discovery_config::print_lease_duration(                                    profile_name);
                             break;
                     }
                     break;
@@ -404,19 +399,19 @@ void duration_type_parser(
                                     break;
                                 case DurationTypeList::PARTICIPANT_ANNOUNCEMENT_PERIOD:
                                     qosprof::domain_participant::builtin::discovery_config::
-                                            clear_lease_announcement_sec(filename, profile_name);
+                                            clear_lease_announcement_sec(profile_name);
                                     break;
                                 case DurationTypeList::PARTICIPANT_CLIENT_ANNOUNCEMENT_PERIOD:
                                     qosprof::domain_participant::builtin::discovery_config::
-                                            clear_client_announcement_period_sec(filename, profile_name);
+                                            clear_client_announcement_period_sec(profile_name);
                                     break;
                                 case DurationTypeList::PARTICIPANT_INITIAL_ANNOUNCEMENTS_PERIOD:
                                     qosprof::domain_participant::builtin::discovery_config::
-                                            clear_initial_announcements_period_sec(filename, profile_name);
+                                            clear_initial_announcements_period_sec(profile_name);
                                     break;
                                 case DurationTypeList::PARTICIPANT_LEASE_DURATION:
                                     qosprof::domain_participant::builtin::discovery_config::clear_lease_duration_sec(
-                                        filename, profile_name);
+                                        profile_name);
                                     break;
                             }
                             break;
@@ -485,19 +480,19 @@ void duration_type_parser(
                                     break;
                                 case DurationTypeList::PARTICIPANT_ANNOUNCEMENT_PERIOD:
                                     qosprof::domain_participant::builtin::discovery_config::
-                                            print_lease_announcement_sec(filename, profile_name);
+                                            print_lease_announcement_sec(profile_name);
                                     break;
                                 case DurationTypeList::PARTICIPANT_CLIENT_ANNOUNCEMENT_PERIOD:
                                     qosprof::domain_participant::builtin::discovery_config::
-                                            print_client_announcement_period_sec(filename, profile_name);
+                                            print_client_announcement_period_sec(profile_name);
                                     break;
                                 case DurationTypeList::PARTICIPANT_INITIAL_ANNOUNCEMENTS_PERIOD:
                                     qosprof::domain_participant::builtin::discovery_config::
-                                            print_initial_announcements_period_sec(filename, profile_name);
+                                            print_initial_announcements_period_sec(profile_name);
                                     break;
                                 case DurationTypeList::PARTICIPANT_LEASE_DURATION:
                                     qosprof::domain_participant::builtin::discovery_config::print_lease_duration_sec(
-                                        filename, profile_name);
+                                        profile_name);
                                     break;
                             }
                             break;
@@ -534,8 +529,7 @@ void duration_type_parser(
                                     // TODO
                                     break;
                                 case DurationTypeList::DATAREADER_QOS_RELIABILITY_MAX_BLOCKING_TIME:
-                                    qosprof::data_reader::qos::set_reliability_max_blocking_time_sec(filename,
-                                            profile_name, seconds);
+                                    qosprof::data_reader::qos::set_reliability_max_blocking_time_sec(                                            profile_name, seconds);
                                     break;
                                 case DurationTypeList::DATAWRITER_HEARTBEAT_PERIOD:
                                     // TODO
@@ -568,24 +562,23 @@ void duration_type_parser(
                                     // TODO
                                     break;
                                 case DurationTypeList::DATAWRITER_QOS_RELIABILITY_MAX_BLOCKING_TIME:
-                                    qosprof::data_writer::qos::set_reliability_max_blocking_time_sec(filename,
-                                            profile_name, seconds);
+                                    qosprof::data_writer::qos::set_reliability_max_blocking_time_sec(                                            profile_name, seconds);
                                     break;
                                 case DurationTypeList::PARTICIPANT_ANNOUNCEMENT_PERIOD:
                                     qosprof::domain_participant::builtin::discovery_config::
-                                            set_lease_announcement_sec(filename, profile_name, seconds);
+                                            set_lease_announcement_sec(profile_name, seconds);
                                     break;
                                 case DurationTypeList::PARTICIPANT_CLIENT_ANNOUNCEMENT_PERIOD:
                                     qosprof::domain_participant::builtin::discovery_config::
-                                            set_client_announcement_period_sec(filename, profile_name, seconds);
+                                            set_client_announcement_period_sec(profile_name, seconds);
                                     break;
                                 case DurationTypeList::PARTICIPANT_INITIAL_ANNOUNCEMENTS_PERIOD:
                                     qosprof::domain_participant::builtin::discovery_config::
-                                            set_initial_announcements_period_sec(filename, profile_name, seconds);
+                                            set_initial_announcements_period_sec(profile_name, seconds);
                                     break;
                                 case DurationTypeList::PARTICIPANT_LEASE_DURATION:
                                     qosprof::domain_participant::builtin::discovery_config::set_lease_duration_sec(
-                                        filename, profile_name, seconds);
+                                        profile_name, seconds);
                                     break;
                             }
                             break;
@@ -661,19 +654,19 @@ void duration_type_parser(
                                     break;
                                 case DurationTypeList::PARTICIPANT_ANNOUNCEMENT_PERIOD:
                                     qosprof::domain_participant::builtin::discovery_config::
-                                            clear_lease_announcement_nanosec(filename, profile_name);
+                                            clear_lease_announcement_nanosec(profile_name);
                                     break;
                                 case DurationTypeList::PARTICIPANT_CLIENT_ANNOUNCEMENT_PERIOD:
                                     qosprof::domain_participant::builtin::discovery_config::
-                                            clear_client_announcement_period_nanosec(filename, profile_name);
+                                            clear_client_announcement_period_nanosec(profile_name);
                                     break;
                                 case DurationTypeList::PARTICIPANT_INITIAL_ANNOUNCEMENTS_PERIOD:
                                     qosprof::domain_participant::builtin::discovery_config::
-                                            clear_initial_announcements_period_nanosec(filename, profile_name);
+                                            clear_initial_announcements_period_nanosec(profile_name);
                                     break;
                                 case DurationTypeList::PARTICIPANT_LEASE_DURATION:
                                     qosprof::domain_participant::builtin::discovery_config::
-                                            clear_lease_duration_nanosec(filename, profile_name);
+                                            clear_lease_duration_nanosec(profile_name);
                                     break;
                             }
                             break;
@@ -742,19 +735,19 @@ void duration_type_parser(
                                     break;
                                 case DurationTypeList::PARTICIPANT_ANNOUNCEMENT_PERIOD:
                                     qosprof::domain_participant::builtin::discovery_config::
-                                            print_lease_announcement_nanosec(filename, profile_name);
+                                            print_lease_announcement_nanosec(profile_name);
                                     break;
                                 case DurationTypeList::PARTICIPANT_CLIENT_ANNOUNCEMENT_PERIOD:
                                     qosprof::domain_participant::builtin::discovery_config::
-                                            print_client_announcement_period_nanosec(filename, profile_name);
+                                            print_client_announcement_period_nanosec(profile_name);
                                     break;
                                 case DurationTypeList::PARTICIPANT_INITIAL_ANNOUNCEMENTS_PERIOD:
                                     qosprof::domain_participant::builtin::discovery_config::
-                                            print_initial_announcements_period_nanosec(filename, profile_name);
+                                            print_initial_announcements_period_nanosec(profile_name);
                                     break;
                                 case DurationTypeList::PARTICIPANT_LEASE_DURATION:
                                     qosprof::domain_participant::builtin::discovery_config::
-                                            print_lease_duration_nanosec(filename, profile_name);
+                                            print_lease_duration_nanosec(profile_name);
                                     break;
                             }
                             break;
@@ -790,8 +783,7 @@ void duration_type_parser(
                                     // TODO
                                     break;
                                 case DurationTypeList::DATAREADER_QOS_RELIABILITY_MAX_BLOCKING_TIME:
-                                    qosprof::data_reader::qos::set_reliability_max_blocking_time_nanosec(filename,
-                                            profile_name, nanoseconds);
+                                    qosprof::data_reader::qos::set_reliability_max_blocking_time_nanosec(                                            profile_name, nanoseconds);
                                     break;
                                 case DurationTypeList::DATAWRITER_HEARTBEAT_PERIOD:
                                     // TODO
@@ -824,25 +816,24 @@ void duration_type_parser(
                                     // TODO
                                     break;
                                 case DurationTypeList::DATAWRITER_QOS_RELIABILITY_MAX_BLOCKING_TIME:
-                                    qosprof::data_writer::qos::set_reliability_max_blocking_time_nanosec(filename,
-                                            profile_name, nanoseconds);
+                                    qosprof::data_writer::qos::set_reliability_max_blocking_time_nanosec(                                            profile_name, nanoseconds);
                                     break;
                                 case DurationTypeList::PARTICIPANT_ANNOUNCEMENT_PERIOD:
                                     qosprof::domain_participant::builtin::discovery_config::
-                                            set_lease_announcement_nanosec(filename, profile_name, nanoseconds);
+                                            set_lease_announcement_nanosec(profile_name, nanoseconds);
                                     break;
                                 case DurationTypeList::PARTICIPANT_CLIENT_ANNOUNCEMENT_PERIOD:
                                     qosprof::domain_participant::builtin::discovery_config::
-                                            set_client_announcement_period_nanosec(filename, profile_name, nanoseconds);
+                                            set_client_announcement_period_nanosec(profile_name, nanoseconds);
                                     break;
                                 case DurationTypeList::PARTICIPANT_INITIAL_ANNOUNCEMENTS_PERIOD:
                                     qosprof::domain_participant::builtin::discovery_config::
-                                            set_initial_announcements_period_nanosec(filename, profile_name,
+                                            set_initial_announcements_period_nanosec(profile_name,
                                             nanoseconds);
                                     break;
                                 case DurationTypeList::PARTICIPANT_LEASE_DURATION:
                                     qosprof::domain_participant::builtin::discovery_config::set_lease_duration_nanosec(
-                                        filename, profile_name, nanoseconds);
+                                        profile_name, nanoseconds);
                                     break;
                             }
                             break;

--- a/cli/src/cpp/utils/duration_type_parser.cpp
+++ b/cli/src/cpp/utils/duration_type_parser.cpp
@@ -191,7 +191,8 @@ void duration_type_parser(
                             // TODO
                             break;
                         case DurationTypeList::PARTICIPANT_ANNOUNCEMENT_PERIOD:
-                            qosprof::domain_participant::builtin::discovery_config::clear_lease_announcement(                                    profile_name);
+                            qosprof::domain_participant::builtin::discovery_config::clear_lease_announcement(
+                                profile_name);
                             break;
                         case DurationTypeList::PARTICIPANT_CLIENT_ANNOUNCEMENT_PERIOD:
                             qosprof::domain_participant::builtin::discovery_config::clear_client_announcement_period(
@@ -202,7 +203,8 @@ void duration_type_parser(
                                 profile_name);
                             break;
                         case DurationTypeList::PARTICIPANT_LEASE_DURATION:
-                            qosprof::domain_participant::builtin::discovery_config::clear_lease_duration(                                    profile_name);
+                            qosprof::domain_participant::builtin::discovery_config::clear_lease_duration(
+                                profile_name);
                             break;
                     }
                     break;
@@ -270,7 +272,8 @@ void duration_type_parser(
                             // TODO
                             break;
                         case DurationTypeList::PARTICIPANT_ANNOUNCEMENT_PERIOD:
-                            qosprof::domain_participant::builtin::discovery_config::print_lease_announcement(                                    profile_name);
+                            qosprof::domain_participant::builtin::discovery_config::print_lease_announcement(
+                                profile_name);
                             break;
                         case DurationTypeList::PARTICIPANT_CLIENT_ANNOUNCEMENT_PERIOD:
                             qosprof::domain_participant::builtin::discovery_config::print_client_announcement_period(
@@ -281,7 +284,8 @@ void duration_type_parser(
                                 profile_name);
                             break;
                         case DurationTypeList::PARTICIPANT_LEASE_DURATION:
-                            qosprof::domain_participant::builtin::discovery_config::print_lease_duration(                                    profile_name);
+                            qosprof::domain_participant::builtin::discovery_config::print_lease_duration(
+                                profile_name);
                             break;
                     }
                     break;
@@ -529,7 +533,8 @@ void duration_type_parser(
                                     // TODO
                                     break;
                                 case DurationTypeList::DATAREADER_QOS_RELIABILITY_MAX_BLOCKING_TIME:
-                                    qosprof::data_reader::qos::set_reliability_max_blocking_time_sec(                                            profile_name, seconds);
+                                    qosprof::data_reader::qos::set_reliability_max_blocking_time_sec(
+                                        profile_name, seconds);
                                     break;
                                 case DurationTypeList::DATAWRITER_HEARTBEAT_PERIOD:
                                     // TODO
@@ -562,7 +567,8 @@ void duration_type_parser(
                                     // TODO
                                     break;
                                 case DurationTypeList::DATAWRITER_QOS_RELIABILITY_MAX_BLOCKING_TIME:
-                                    qosprof::data_writer::qos::set_reliability_max_blocking_time_sec(                                            profile_name, seconds);
+                                    qosprof::data_writer::qos::set_reliability_max_blocking_time_sec(
+                                        profile_name, seconds);
                                     break;
                                 case DurationTypeList::PARTICIPANT_ANNOUNCEMENT_PERIOD:
                                     qosprof::domain_participant::builtin::discovery_config::
@@ -783,7 +789,8 @@ void duration_type_parser(
                                     // TODO
                                     break;
                                 case DurationTypeList::DATAREADER_QOS_RELIABILITY_MAX_BLOCKING_TIME:
-                                    qosprof::data_reader::qos::set_reliability_max_blocking_time_nanosec(                                            profile_name, nanoseconds);
+                                    qosprof::data_reader::qos::set_reliability_max_blocking_time_nanosec(
+                                        profile_name, nanoseconds);
                                     break;
                                 case DurationTypeList::DATAWRITER_HEARTBEAT_PERIOD:
                                     // TODO
@@ -816,7 +823,8 @@ void duration_type_parser(
                                     // TODO
                                     break;
                                 case DurationTypeList::DATAWRITER_QOS_RELIABILITY_MAX_BLOCKING_TIME:
-                                    qosprof::data_writer::qos::set_reliability_max_blocking_time_nanosec(                                            profile_name, nanoseconds);
+                                    qosprof::data_writer::qos::set_reliability_max_blocking_time_nanosec(
+                                        profile_name, nanoseconds);
                                     break;
                                 case DurationTypeList::PARTICIPANT_ANNOUNCEMENT_PERIOD:
                                     qosprof::domain_participant::builtin::discovery_config::

--- a/cli/src/cpp/utils/endpoint_subelement_parser.cpp
+++ b/cli/src/cpp/utils/endpoint_subelement_parser.cpp
@@ -30,7 +30,6 @@ namespace qosprof_cli {
 void endpoint_subelement_parser(
         DDSEntity endpoint,
         CommonCommands command,
-        const std::string& filename,
         const std::string& profile_name,
         std::string& element,
         const std::vector<std::string>& values)
@@ -86,10 +85,10 @@ void endpoint_subelement_parser(
                         switch (endpoint)
                         {
                             case DDSEntity::DATAREADER:
-                                qosprof::data_reader::set_default_profile(filename, profile_name);
+                                qosprof::data_reader::set_default_profile(profile_name);
                                 break;
                             case DDSEntity::DATAWRITER:
-                                qosprof::data_writer::set_default_profile(filename, profile_name);
+                                qosprof::data_writer::set_default_profile(profile_name);
                                 break;
                             default:
                                 print_error = true;
@@ -163,7 +162,7 @@ void endpoint_subelement_parser(
 
         if (!print_usage)
         {
-            qos_parser(endpoint, command, filename, profile_name, subelement, values);
+            qos_parser(endpoint, command, profile_name, subelement, values);
         }
         else
         {

--- a/cli/src/cpp/utils/external_locators_parser.cpp
+++ b/cli/src/cpp/utils/external_locators_parser.cpp
@@ -31,7 +31,6 @@ namespace qosprof_cli {
 void external_locators_parser(
         ExternalLocatorsList list,
         CommonCommands command,
-        const std::string& filename,
         const std::string& profile_name,
         std::string& element,
         const std::vector<std::string>& values)
@@ -81,12 +80,11 @@ void external_locators_parser(
                             // TODO
                             break;
                         case ExternalLocatorsList::PARTICIPANT_DEFAULT_UNICAST:
-                            qosprof::domain_participant::default_external_unicast_locators::clear(filename,
-                                    profile_name, key);
+                            qosprof::domain_participant::default_external_unicast_locators::clear(                                    profile_name, key);
                             break;
                         case ExternalLocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                             qosprof::domain_participant::builtin::metatraffic_external_unicast_locators::clear(
-                                filename, profile_name, key);
+                                profile_name, key);
                             break;
                     }
                     break;
@@ -100,12 +98,11 @@ void external_locators_parser(
                             // TODO
                             break;
                         case ExternalLocatorsList::PARTICIPANT_DEFAULT_UNICAST:
-                            qosprof::domain_participant::default_external_unicast_locators::print(filename,
-                                    profile_name, key);
+                            qosprof::domain_participant::default_external_unicast_locators::print(                                    profile_name, key);
                             break;
                         case ExternalLocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                             qosprof::domain_participant::builtin::metatraffic_external_unicast_locators::print(
-                                filename, profile_name, key);
+                                profile_name, key);
                             break;
                     }
                     break;
@@ -154,11 +151,11 @@ void external_locators_parser(
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_DEFAULT_UNICAST:
                                     qosprof::domain_participant::default_external_unicast_locators::clear_address(
-                                        filename, profile_name, key);
+                                        profile_name, key);
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_external_unicast_locators::
-                                            clear_address(filename, profile_name, key);
+                                            clear_address(profile_name, key);
                                     break;
                             }
                             break;
@@ -173,11 +170,11 @@ void external_locators_parser(
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_DEFAULT_UNICAST:
                                     qosprof::domain_participant::default_external_unicast_locators::print_address(
-                                        filename, profile_name, key);
+                                        profile_name, key);
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_external_unicast_locators::
-                                            print_address(filename, profile_name, key);
+                                            print_address(profile_name, key);
                                     break;
                             }
                             break;
@@ -198,11 +195,11 @@ void external_locators_parser(
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_DEFAULT_UNICAST:
                                     qosprof::domain_participant::default_external_unicast_locators::set_address(
-                                        filename, profile_name, address, key);
+                                        profile_name, address, key);
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_external_unicast_locators::
-                                            set_address(filename, profile_name, address, key);
+                                            set_address(profile_name, address, key);
                                     break;
                             }
                             break;
@@ -224,11 +221,11 @@ void external_locators_parser(
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_DEFAULT_UNICAST:
                                     qosprof::domain_participant::default_external_unicast_locators::clear_cost(
-                                        filename, profile_name, key);
+                                        profile_name, key);
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_external_unicast_locators::
-                                            clear_cost(filename, profile_name, key);
+                                            clear_cost(profile_name, key);
                                     break;
                             }
                             break;
@@ -243,11 +240,11 @@ void external_locators_parser(
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_DEFAULT_UNICAST:
                                     qosprof::domain_participant::default_external_unicast_locators::print_cost(
-                                        filename, profile_name, key);
+                                        profile_name, key);
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_external_unicast_locators::
-                                            print_cost(filename, profile_name, key);
+                                            print_cost(profile_name, key);
                                     break;
                             }
                             break;
@@ -268,11 +265,11 @@ void external_locators_parser(
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_DEFAULT_UNICAST:
                                     qosprof::domain_participant::default_external_unicast_locators::set_cost(
-                                        filename, profile_name, cost, key);
+                                        profile_name, cost, key);
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_external_unicast_locators::
-                                            set_cost(filename, profile_name, cost, key);
+                                            set_cost(profile_name, cost, key);
                                     break;
                             }
                             break;
@@ -294,11 +291,11 @@ void external_locators_parser(
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_DEFAULT_UNICAST:
                                     qosprof::domain_participant::default_external_unicast_locators::clear_externality(
-                                        filename, profile_name, key);
+                                        profile_name, key);
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_external_unicast_locators::
-                                            clear_externality(filename, profile_name, key);
+                                            clear_externality(profile_name, key);
                                     break;
                             }
                             break;
@@ -313,11 +310,11 @@ void external_locators_parser(
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_DEFAULT_UNICAST:
                                     qosprof::domain_participant::default_external_unicast_locators::print_externality(
-                                        filename, profile_name, key);
+                                        profile_name, key);
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_external_unicast_locators::
-                                            print_externality(filename, profile_name, key);
+                                            print_externality(profile_name, key);
                                     break;
                             }
                             break;
@@ -338,11 +335,11 @@ void external_locators_parser(
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_DEFAULT_UNICAST:
                                     qosprof::domain_participant::default_external_unicast_locators::set_externality(
-                                        filename, profile_name, externality, key);
+                                        profile_name, externality, key);
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_external_unicast_locators::
-                                            set_externality(filename, profile_name, externality, key);
+                                            set_externality(profile_name, externality, key);
                                     break;
                             }
                             break;
@@ -369,11 +366,11 @@ void external_locators_parser(
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_DEFAULT_UNICAST:
                                     qosprof::domain_participant::default_external_unicast_locators::print_kind(
-                                        filename, profile_name, key);
+                                        profile_name, key);
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_external_unicast_locators::
-                                            print_kind(filename, profile_name, key);
+                                            print_kind(profile_name, key);
                                     break;
                             }
                             break;
@@ -394,11 +391,11 @@ void external_locators_parser(
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_DEFAULT_UNICAST:
                                     qosprof::domain_participant::default_external_unicast_locators::set_kind(
-                                        filename, profile_name, kind, key);
+                                        profile_name, kind, key);
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_external_unicast_locators::
-                                            set_kind(filename, profile_name, kind, key);
+                                            set_kind(profile_name, kind, key);
                                     break;
                             }
                             break;
@@ -420,11 +417,11 @@ void external_locators_parser(
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_DEFAULT_UNICAST:
                                     qosprof::domain_participant::default_external_unicast_locators::clear_mask(
-                                        filename, profile_name, key);
+                                        profile_name, key);
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_external_unicast_locators::
-                                            clear_mask(filename, profile_name, key);
+                                            clear_mask(profile_name, key);
                                     break;
                             }
                             break;
@@ -439,11 +436,11 @@ void external_locators_parser(
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_DEFAULT_UNICAST:
                                     qosprof::domain_participant::default_external_unicast_locators::print_mask(
-                                        filename, profile_name, key);
+                                        profile_name, key);
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_external_unicast_locators::
-                                            print_mask(filename, profile_name, key);
+                                            print_mask(profile_name, key);
                                     break;
                             }
                             break;
@@ -464,11 +461,11 @@ void external_locators_parser(
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_DEFAULT_UNICAST:
                                     qosprof::domain_participant::default_external_unicast_locators::set_mask(
-                                        filename, profile_name, mask, key);
+                                        profile_name, mask, key);
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_external_unicast_locators::
-                                            set_mask(filename, profile_name, mask, key);
+                                            set_mask(profile_name, mask, key);
                                     break;
                             }
                             break;
@@ -490,11 +487,11 @@ void external_locators_parser(
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_DEFAULT_UNICAST:
                                     qosprof::domain_participant::default_external_unicast_locators::clear_port(
-                                        filename, profile_name, key);
+                                        profile_name, key);
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_external_unicast_locators::
-                                            clear_port(filename, profile_name, key);
+                                            clear_port(profile_name, key);
                                     break;
                             }
                             break;
@@ -509,11 +506,11 @@ void external_locators_parser(
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_DEFAULT_UNICAST:
                                     qosprof::domain_participant::default_external_unicast_locators::print_port(
-                                        filename, profile_name, key);
+                                        profile_name, key);
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_external_unicast_locators::
-                                            print_port(filename, profile_name, key);
+                                            print_port(profile_name, key);
                                     break;
                             }
                             break;
@@ -534,11 +531,11 @@ void external_locators_parser(
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_DEFAULT_UNICAST:
                                     qosprof::domain_participant::default_external_unicast_locators::set_port(
-                                        filename, profile_name, port, key);
+                                        profile_name, port, key);
                                     break;
                                 case ExternalLocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_external_unicast_locators::
-                                            set_port(filename, profile_name, port, key);
+                                            set_port(profile_name, port, key);
                                     break;
                             }
                             break;

--- a/cli/src/cpp/utils/external_locators_parser.cpp
+++ b/cli/src/cpp/utils/external_locators_parser.cpp
@@ -80,7 +80,8 @@ void external_locators_parser(
                             // TODO
                             break;
                         case ExternalLocatorsList::PARTICIPANT_DEFAULT_UNICAST:
-                            qosprof::domain_participant::default_external_unicast_locators::clear(                                    profile_name, key);
+                            qosprof::domain_participant::default_external_unicast_locators::clear(
+                                profile_name, key);
                             break;
                         case ExternalLocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                             qosprof::domain_participant::builtin::metatraffic_external_unicast_locators::clear(
@@ -98,7 +99,8 @@ void external_locators_parser(
                             // TODO
                             break;
                         case ExternalLocatorsList::PARTICIPANT_DEFAULT_UNICAST:
-                            qosprof::domain_participant::default_external_unicast_locators::print(                                    profile_name, key);
+                            qosprof::domain_participant::default_external_unicast_locators::print(
+                                profile_name, key);
                             break;
                         case ExternalLocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                             qosprof::domain_participant::builtin::metatraffic_external_unicast_locators::print(

--- a/cli/src/cpp/utils/locators_parser.cpp
+++ b/cli/src/cpp/utils/locators_parser.cpp
@@ -77,10 +77,12 @@ void locators_parser(
                             qosprof::domain_participant::builtin::initial_peers::clear(profile_name, key);
                             break;
                         case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
-                            qosprof::domain_participant::builtin::metatraffic_multicast_locators::clear(                                    profile_name, key);
+                            qosprof::domain_participant::builtin::metatraffic_multicast_locators::clear(
+                                profile_name, key);
                             break;
                         case LocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
-                            qosprof::domain_participant::builtin::metatraffic_unicast_locators::clear(                                    profile_name, key);
+                            qosprof::domain_participant::builtin::metatraffic_unicast_locators::clear(
+                                profile_name, key);
                             break;
                         case LocatorsList::PARTICIPANT_REMOTE_SERVER_METATRAFFIC_UNICAST:
                             // TODO
@@ -112,10 +114,12 @@ void locators_parser(
                             qosprof::domain_participant::builtin::initial_peers::print(profile_name, key);
                             break;
                         case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
-                            qosprof::domain_participant::builtin::metatraffic_multicast_locators::print(                                    profile_name, key);
+                            qosprof::domain_participant::builtin::metatraffic_multicast_locators::print(
+                                profile_name, key);
                             break;
                         case LocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
-                            qosprof::domain_participant::builtin::metatraffic_unicast_locators::print(                                    profile_name, key);
+                            qosprof::domain_participant::builtin::metatraffic_unicast_locators::print(
+                                profile_name, key);
                             break;
                         case LocatorsList::PARTICIPANT_REMOTE_SERVER_METATRAFFIC_UNICAST:
                             // TODO
@@ -177,7 +181,8 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::clear_address(                                            profile_name, key);
+                                    qosprof::domain_participant::builtin::initial_peers::clear_address(
+                                        profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::clear_address(
@@ -214,7 +219,8 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::print_address(                                            profile_name, key);
+                                    qosprof::domain_participant::builtin::initial_peers::print_address(
+                                        profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::print_address(
@@ -256,7 +262,8 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::set_address(                                            profile_name, address, key);
+                                    qosprof::domain_participant::builtin::initial_peers::set_address(
+                                        profile_name, address, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::set_address(
@@ -305,7 +312,8 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::print_kind(                                            profile_name, key);
+                                    qosprof::domain_participant::builtin::initial_peers::print_kind(
+                                        profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::print_kind(
@@ -347,7 +355,8 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::set_kind(                                            profile_name, kind, key);
+                                    qosprof::domain_participant::builtin::initial_peers::set_kind(
+                                        profile_name, kind, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::set_kind(
@@ -391,7 +400,8 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::clear_physical_port(                                            profile_name, key);
+                                    qosprof::domain_participant::builtin::initial_peers::clear_physical_port(
+                                        profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::
@@ -428,7 +438,8 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::print_physical_port(                                            profile_name, key);
+                                    qosprof::domain_participant::builtin::initial_peers::print_physical_port(
+                                        profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::
@@ -468,7 +479,8 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::set_physical_port(                                            profile_name, values[DEFAULT_POSITION], key);
+                                    qosprof::domain_participant::builtin::initial_peers::set_physical_port(
+                                        profile_name, values[DEFAULT_POSITION], key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::
@@ -512,7 +524,8 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::clear_port(                                            profile_name, key);
+                                    qosprof::domain_participant::builtin::initial_peers::clear_port(
+                                        profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::clear_port(
@@ -549,7 +562,8 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::print_port(                                            profile_name, key);
+                                    qosprof::domain_participant::builtin::initial_peers::print_port(
+                                        profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::print_port(
@@ -591,7 +605,8 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::set_port(                                            profile_name, port, key);
+                                    qosprof::domain_participant::builtin::initial_peers::set_port(
+                                        profile_name, port, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::set_port(
@@ -635,7 +650,8 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::clear_unique_lan_id(                                            profile_name, key);
+                                    qosprof::domain_participant::builtin::initial_peers::clear_unique_lan_id(
+                                        profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::
@@ -672,7 +688,8 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::print_unique_lan_id(                                            profile_name, key);
+                                    qosprof::domain_participant::builtin::initial_peers::print_unique_lan_id(
+                                        profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::
@@ -712,7 +729,8 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::set_unique_lan_id(                                            profile_name, values[DEFAULT_POSITION], key);
+                                    qosprof::domain_participant::builtin::initial_peers::set_unique_lan_id(
+                                        profile_name, values[DEFAULT_POSITION], key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::
@@ -756,7 +774,8 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::clear_wan_address(                                            profile_name, key);
+                                    qosprof::domain_participant::builtin::initial_peers::clear_wan_address(
+                                        profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::
@@ -793,7 +812,8 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::print_wan_address(                                            profile_name, key);
+                                    qosprof::domain_participant::builtin::initial_peers::print_wan_address(
+                                        profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::
@@ -833,7 +853,8 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::set_wan_address(                                            profile_name, values[DEFAULT_POSITION], key);
+                                    qosprof::domain_participant::builtin::initial_peers::set_wan_address(
+                                        profile_name, values[DEFAULT_POSITION], key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::

--- a/cli/src/cpp/utils/locators_parser.cpp
+++ b/cli/src/cpp/utils/locators_parser.cpp
@@ -32,7 +32,6 @@ namespace qosprof_cli {
 void locators_parser(
         LocatorsList list,
         CommonCommands command,
-        const std::string& filename,
         const std::string& profile_name,
         std::string& element,
         const std::string& key,
@@ -75,15 +74,13 @@ void locators_parser(
                             // TODO
                             break;
                         case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                            qosprof::domain_participant::builtin::initial_peers::clear(filename, profile_name, key);
+                            qosprof::domain_participant::builtin::initial_peers::clear(profile_name, key);
                             break;
                         case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
-                            qosprof::domain_participant::builtin::metatraffic_multicast_locators::clear(filename,
-                                    profile_name, key);
+                            qosprof::domain_participant::builtin::metatraffic_multicast_locators::clear(                                    profile_name, key);
                             break;
                         case LocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
-                            qosprof::domain_participant::builtin::metatraffic_unicast_locators::clear(filename,
-                                    profile_name, key);
+                            qosprof::domain_participant::builtin::metatraffic_unicast_locators::clear(                                    profile_name, key);
                             break;
                         case LocatorsList::PARTICIPANT_REMOTE_SERVER_METATRAFFIC_UNICAST:
                             // TODO
@@ -112,15 +109,13 @@ void locators_parser(
                             // TODO
                             break;
                         case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                            qosprof::domain_participant::builtin::initial_peers::print(filename, profile_name, key);
+                            qosprof::domain_participant::builtin::initial_peers::print(profile_name, key);
                             break;
                         case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
-                            qosprof::domain_participant::builtin::metatraffic_multicast_locators::print(filename,
-                                    profile_name, key);
+                            qosprof::domain_participant::builtin::metatraffic_multicast_locators::print(                                    profile_name, key);
                             break;
                         case LocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
-                            qosprof::domain_participant::builtin::metatraffic_unicast_locators::print(filename,
-                                    profile_name, key);
+                            qosprof::domain_participant::builtin::metatraffic_unicast_locators::print(                                    profile_name, key);
                             break;
                         case LocatorsList::PARTICIPANT_REMOTE_SERVER_METATRAFFIC_UNICAST:
                             // TODO
@@ -182,16 +177,15 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::clear_address(filename,
-                                            profile_name, key);
+                                    qosprof::domain_participant::builtin::initial_peers::clear_address(                                            profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::clear_address(
-                                        filename, profile_name, key);
+                                        profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_unicast_locators::clear_address(
-                                        filename, profile_name, key);
+                                        profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_REMOTE_SERVER_METATRAFFIC_UNICAST:
                                     // TODO
@@ -220,16 +214,15 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::print_address(filename,
-                                            profile_name, key);
+                                    qosprof::domain_participant::builtin::initial_peers::print_address(                                            profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::print_address(
-                                        filename, profile_name, key);
+                                        profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_unicast_locators::print_address(
-                                        filename, profile_name, key);
+                                        profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_REMOTE_SERVER_METATRAFFIC_UNICAST:
                                     // TODO
@@ -263,16 +256,15 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::set_address(filename,
-                                            profile_name, address, key);
+                                    qosprof::domain_participant::builtin::initial_peers::set_address(                                            profile_name, address, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::set_address(
-                                        filename, profile_name, address, key);
+                                        profile_name, address, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_unicast_locators::set_address(
-                                        filename, profile_name, address, key);
+                                        profile_name, address, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_REMOTE_SERVER_METATRAFFIC_UNICAST:
                                     // TODO
@@ -313,16 +305,15 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::print_kind(filename,
-                                            profile_name, key);
+                                    qosprof::domain_participant::builtin::initial_peers::print_kind(                                            profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::print_kind(
-                                        filename, profile_name, key);
+                                        profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_unicast_locators::print_kind(
-                                        filename, profile_name, key);
+                                        profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_REMOTE_SERVER_METATRAFFIC_UNICAST:
                                     // TODO
@@ -356,16 +347,15 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::set_kind(filename,
-                                            profile_name, kind, key);
+                                    qosprof::domain_participant::builtin::initial_peers::set_kind(                                            profile_name, kind, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::set_kind(
-                                        filename, profile_name, kind, key);
+                                        profile_name, kind, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_unicast_locators::set_kind(
-                                        filename, profile_name, kind, key);
+                                        profile_name, kind, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_REMOTE_SERVER_METATRAFFIC_UNICAST:
                                     // TODO
@@ -401,16 +391,15 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::clear_physical_port(filename,
-                                            profile_name, key);
+                                    qosprof::domain_participant::builtin::initial_peers::clear_physical_port(                                            profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::
-                                            clear_physical_port(filename, profile_name, key);
+                                            clear_physical_port(profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_unicast_locators::
-                                            clear_physical_port(filename, profile_name, key);
+                                            clear_physical_port(profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_REMOTE_SERVER_METATRAFFIC_UNICAST:
                                     // TODO
@@ -439,16 +428,15 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::print_physical_port(filename,
-                                            profile_name, key);
+                                    qosprof::domain_participant::builtin::initial_peers::print_physical_port(                                            profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::
-                                            print_physical_port(filename, profile_name, key);
+                                            print_physical_port(profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_unicast_locators::
-                                            print_physical_port(filename, profile_name, key);
+                                            print_physical_port(profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_REMOTE_SERVER_METATRAFFIC_UNICAST:
                                     // TODO
@@ -480,16 +468,15 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::set_physical_port(filename,
-                                            profile_name, values[DEFAULT_POSITION], key);
+                                    qosprof::domain_participant::builtin::initial_peers::set_physical_port(                                            profile_name, values[DEFAULT_POSITION], key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::
-                                            set_physical_port(filename, profile_name, values[DEFAULT_POSITION], key);
+                                            set_physical_port(profile_name, values[DEFAULT_POSITION], key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_unicast_locators::
-                                            set_physical_port(filename, profile_name, values[DEFAULT_POSITION], key);
+                                            set_physical_port(profile_name, values[DEFAULT_POSITION], key);
                                     break;
                                 case LocatorsList::PARTICIPANT_REMOTE_SERVER_METATRAFFIC_UNICAST:
                                     // TODO
@@ -525,16 +512,15 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::clear_port(filename,
-                                            profile_name, key);
+                                    qosprof::domain_participant::builtin::initial_peers::clear_port(                                            profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::clear_port(
-                                        filename, profile_name, key);
+                                        profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_unicast_locators::clear_port(
-                                        filename, profile_name, key);
+                                        profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_REMOTE_SERVER_METATRAFFIC_UNICAST:
                                     // TODO
@@ -563,16 +549,15 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::print_port(filename,
-                                            profile_name, key);
+                                    qosprof::domain_participant::builtin::initial_peers::print_port(                                            profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::print_port(
-                                        filename, profile_name, key);
+                                        profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_unicast_locators::print_port(
-                                        filename, profile_name, key);
+                                        profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_REMOTE_SERVER_METATRAFFIC_UNICAST:
                                     // TODO
@@ -606,16 +591,15 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::set_port(filename,
-                                            profile_name, port, key);
+                                    qosprof::domain_participant::builtin::initial_peers::set_port(                                            profile_name, port, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::set_port(
-                                        filename, profile_name, port, key);
+                                        profile_name, port, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_unicast_locators::set_port(
-                                        filename, profile_name, port, key);
+                                        profile_name, port, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_REMOTE_SERVER_METATRAFFIC_UNICAST:
                                     // TODO
@@ -651,16 +635,15 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::clear_unique_lan_id(filename,
-                                            profile_name, key);
+                                    qosprof::domain_participant::builtin::initial_peers::clear_unique_lan_id(                                            profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::
-                                            clear_unique_lan_id(filename, profile_name, key);
+                                            clear_unique_lan_id(profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_unicast_locators::
-                                            clear_unique_lan_id(filename, profile_name, key);
+                                            clear_unique_lan_id(profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_REMOTE_SERVER_METATRAFFIC_UNICAST:
                                     // TODO
@@ -689,16 +672,15 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::print_unique_lan_id(filename,
-                                            profile_name, key);
+                                    qosprof::domain_participant::builtin::initial_peers::print_unique_lan_id(                                            profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::
-                                            print_unique_lan_id(filename, profile_name, key);
+                                            print_unique_lan_id(profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_unicast_locators::
-                                            print_unique_lan_id(filename, profile_name, key);
+                                            print_unique_lan_id(profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_REMOTE_SERVER_METATRAFFIC_UNICAST:
                                     // TODO
@@ -730,16 +712,15 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::set_unique_lan_id(filename,
-                                            profile_name, values[DEFAULT_POSITION], key);
+                                    qosprof::domain_participant::builtin::initial_peers::set_unique_lan_id(                                            profile_name, values[DEFAULT_POSITION], key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::
-                                            set_unique_lan_id(filename, profile_name, values[DEFAULT_POSITION], key);
+                                            set_unique_lan_id(profile_name, values[DEFAULT_POSITION], key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_unicast_locators::
-                                            set_unique_lan_id(filename, profile_name, values[DEFAULT_POSITION], key);
+                                            set_unique_lan_id(profile_name, values[DEFAULT_POSITION], key);
                                     break;
                                 case LocatorsList::PARTICIPANT_REMOTE_SERVER_METATRAFFIC_UNICAST:
                                     // TODO
@@ -775,16 +756,15 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::clear_wan_address(filename,
-                                            profile_name, key);
+                                    qosprof::domain_participant::builtin::initial_peers::clear_wan_address(                                            profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::
-                                            clear_wan_address(filename, profile_name, key);
+                                            clear_wan_address(profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_unicast_locators::
-                                            clear_wan_address(filename, profile_name, key);
+                                            clear_wan_address(profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_REMOTE_SERVER_METATRAFFIC_UNICAST:
                                     // TODO
@@ -813,16 +793,15 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::print_wan_address(filename,
-                                            profile_name, key);
+                                    qosprof::domain_participant::builtin::initial_peers::print_wan_address(                                            profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::
-                                            print_wan_address(filename, profile_name, key);
+                                            print_wan_address(profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_unicast_locators::
-                                            print_wan_address(filename, profile_name, key);
+                                            print_wan_address(profile_name, key);
                                     break;
                                 case LocatorsList::PARTICIPANT_REMOTE_SERVER_METATRAFFIC_UNICAST:
                                     // TODO
@@ -854,16 +833,15 @@ void locators_parser(
                                     // TODO
                                     break;
                                 case LocatorsList::PARTICIPANT_INITIAL_PEERS:
-                                    qosprof::domain_participant::builtin::initial_peers::set_wan_address(filename,
-                                            profile_name, values[DEFAULT_POSITION], key);
+                                    qosprof::domain_participant::builtin::initial_peers::set_wan_address(                                            profile_name, values[DEFAULT_POSITION], key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_MULTICAST:
                                     qosprof::domain_participant::builtin::metatraffic_multicast_locators::
-                                            set_wan_address(filename, profile_name, values[DEFAULT_POSITION], key);
+                                            set_wan_address(profile_name, values[DEFAULT_POSITION], key);
                                     break;
                                 case LocatorsList::PARTICIPANT_METATRAFFIC_UNICAST:
                                     qosprof::domain_participant::builtin::metatraffic_unicast_locators::
-                                            set_wan_address(filename, profile_name, values[DEFAULT_POSITION], key);
+                                            set_wan_address(profile_name, values[DEFAULT_POSITION], key);
                                     break;
                                 case LocatorsList::PARTICIPANT_REMOTE_SERVER_METATRAFFIC_UNICAST:
                                     // TODO

--- a/cli/src/cpp/utils/main_element_parser.cpp
+++ b/cli/src/cpp/utils/main_element_parser.cpp
@@ -28,7 +28,6 @@ namespace qosprof_cli {
 
 void main_element_parser(
         CommonCommands command,
-        const std::string& filename,
         int argc,
         char** argv)
 {
@@ -79,7 +78,7 @@ void main_element_parser(
         if (!print_usage)
         {
             endpoint_subelement_parser(((element == DATAREADER_ELEMENT) ?
-                    DDSEntity::DATAREADER : DDSEntity::DATAWRITER), command, filename, profile_name, subelement,
+                    DDSEntity::DATAREADER : DDSEntity::DATAWRITER), command, profile_name, subelement,
                     values);
         }
         else
@@ -121,7 +120,7 @@ void main_element_parser(
 
         if (!print_usage)
         {
-            participant_subelement_parser(command, filename, profile_name, subelement, values);
+            participant_subelement_parser(command, profile_name, subelement, values);
         }
         else
         {
@@ -151,7 +150,7 @@ void main_element_parser(
 
         if (!print_usage)
         {
-            transport_subelement_parser(command, filename, profile_name, subelement, values);
+            transport_subelement_parser(command, profile_name, subelement, values);
         }
         else
         {

--- a/cli/src/cpp/utils/participant_subelement_parser.cpp
+++ b/cli/src/cpp/utils/participant_subelement_parser.cpp
@@ -29,7 +29,6 @@ namespace qosprof_cli {
 
 void participant_subelement_parser(
         CommonCommands command,
-        const std::string& filename,
         const std::string& profile_name,
         std::string& element,
         const std::vector<std::string>& values)
@@ -62,7 +61,7 @@ void participant_subelement_parser(
 
         if (!print_usage)
         {
-            builtin_parser(command, filename, profile_name, subelement, values);
+            builtin_parser(command, profile_name, subelement, values);
         }
         else
         {
@@ -96,14 +95,14 @@ void participant_subelement_parser(
                 {
                     case CommonCommands::CLEAR:
                         // TODO: think if the CLI command should change with the new behavior -> participant.default_profile
-                        qosprof::domain_participant::clear_default_profile(filename);
+                        qosprof::domain_participant::clear_default_profile();
                         break;
                     case CommonCommands::PRINT:
                         // TODO: think if the CLI command should change with the new behavior.
-                        qosprof::domain_participant::print_default_profile(filename);
+                        qosprof::domain_participant::print_default_profile();
                         break;
                     case CommonCommands::SET:
-                        qosprof::domain_participant::set_default_profile(filename, profile_name);
+                        qosprof::domain_participant::set_default_profile(profile_name);
                         break;
                 }
             }
@@ -135,7 +134,7 @@ void participant_subelement_parser(
 
         if (!print_usage)
         {
-            external_locators_parser(ExternalLocatorsList::PARTICIPANT_DEFAULT_UNICAST, command, filename, profile_name,
+            external_locators_parser(ExternalLocatorsList::PARTICIPANT_DEFAULT_UNICAST, command, profile_name,
                     subelement, values);
         }
         else
@@ -190,14 +189,14 @@ void participant_subelement_parser(
                         print_usage = !check_command_arguments(command, 0, values.size(), message.str(), true);
                         if (!print_usage)
                         {
-                            qosprof::domain_participant::clear_name(filename, profile_name);
+                            qosprof::domain_participant::clear_name(profile_name);
                         }
                         break;
                     case CommonCommands::PRINT:
                         print_usage = !check_command_arguments(command, 0, values.size(), message.str(), true);
                         if (!print_usage)
                         {
-                            qosprof::domain_participant::print_name(filename, profile_name);
+                            qosprof::domain_participant::print_name(profile_name);
                         }
                         break;
                     case CommonCommands::QUERY:
@@ -207,7 +206,7 @@ void participant_subelement_parser(
                         print_usage = !check_command_arguments(command, 1, values.size(), message.str(), true);
                         if (!print_usage)
                         {
-                            qosprof::domain_participant::set_name(filename, profile_name, values[DEFAULT_POSITION]);
+                            qosprof::domain_participant::set_name(profile_name, values[DEFAULT_POSITION]);
                         }
                         break;
                 }
@@ -254,14 +253,14 @@ void participant_subelement_parser(
                         print_usage = !check_command_arguments(command, 0, values.size(), message.str(), true);
                         if (!print_usage)
                         {
-                            qosprof::domain_participant::clear_use_builtin_transports(filename, profile_name);
+                            qosprof::domain_participant::clear_use_builtin_transports(profile_name);
                         }
                         break;
                     case CommonCommands::PRINT:
                         print_usage = !check_command_arguments(command, 0, values.size(), message.str(), true);
                         if (!print_usage)
                         {
-                            qosprof::domain_participant::print_use_builtin_transports(filename, profile_name);
+                            qosprof::domain_participant::print_use_builtin_transports(profile_name);
                         }
                         break;
                     case CommonCommands::QUERY:
@@ -271,7 +270,7 @@ void participant_subelement_parser(
                         print_usage = !check_command_arguments(command, 1, values.size(), message.str(), true);
                         if (!print_usage)
                         {
-                            qosprof::domain_participant::set_use_builtin_transports(filename, profile_name,
+                            qosprof::domain_participant::set_use_builtin_transports(profile_name,
                                     values[DEFAULT_POSITION]);
                         }
                         break;
@@ -308,14 +307,14 @@ void participant_subelement_parser(
                         print_usage = !check_command_arguments(command, 0, values.size(), message.str(), true);
                         if (!print_usage)
                         {
-                            qosprof::domain_participant::clear_user_transports(filename, profile_name, key);
+                            qosprof::domain_participant::clear_user_transports(profile_name, key);
                         }
                         break;
                     case CommonCommands::PRINT:
                         print_usage = !check_command_arguments(command, 0, values.size(), message.str(), true);
                         if (!print_usage)
                         {
-                            qosprof::domain_participant::print_user_transports(filename, profile_name, key);
+                            qosprof::domain_participant::print_user_transports(profile_name, key);
                         }
                         break;
                     case CommonCommands::QUERY:
@@ -325,14 +324,14 @@ void participant_subelement_parser(
                         print_usage = print_usage || !check_index(key, true);
                         if (!print_usage)
                         {
-                            qosprof::domain_participant::user_transports_size(filename, profile_name);
+                            qosprof::domain_participant::user_transports_size(profile_name);
                         }
                         break;
                     case CommonCommands::SET:
                         print_usage = !check_command_arguments(command, 1, values.size(), message.str(), true);
                         if (!print_usage)
                         {
-                            qosprof::domain_participant::set_user_transports(filename, profile_name,
+                            qosprof::domain_participant::set_user_transports(profile_name,
                                     values[DEFAULT_POSITION], key);
                         }
                         break;

--- a/cli/src/cpp/utils/qos_parser.cpp
+++ b/cli/src/cpp/utils/qos_parser.cpp
@@ -30,7 +30,6 @@ namespace qosprof_cli {
 void qos_parser(
         DDSEntity entity,
         CommonCommands command,
-        const std::string& filename,
         const std::string& profile_name,
         std::string& element,
         const std::vector<std::string>& values)
@@ -151,11 +150,11 @@ void qos_parser(
                             switch (entity)
                             {
                                 case DDSEntity::DATAREADER:
-                                    qosprof::data_reader::qos::set_durability_kind(filename, profile_name,
+                                    qosprof::data_reader::qos::set_durability_kind(profile_name,
                                             durability_kind);
                                     break;
                                 case DDSEntity::DATAWRITER:
-                                    qosprof::data_writer::qos::set_durability_kind(filename, profile_name,
+                                    qosprof::data_writer::qos::set_durability_kind(profile_name,
                                             durability_kind);
                                     break;
                                 default:
@@ -222,7 +221,7 @@ void qos_parser(
 
         if (!print_usage)
         {
-            reliability_qos_parser(entity, command, filename, profile_name, subelement, values, message);
+            reliability_qos_parser(entity, command, profile_name, subelement, values, message);
         }
         else
         {
@@ -264,7 +263,6 @@ void qos_parser(
 void reliability_qos_parser(
         DDSEntity entity,
         CommonCommands command,
-        const std::string& filename,
         const std::string& profile_name,
         std::string& element,
         const std::vector<std::string>& values,
@@ -350,11 +348,11 @@ void reliability_qos_parser(
                             switch (entity)
                             {
                                 case DDSEntity::DATAREADER:
-                                    qosprof::data_reader::qos::set_reliability_kind(filename, profile_name,
+                                    qosprof::data_reader::qos::set_reliability_kind(profile_name,
                                             reliability_kind);
                                     break;
                                 case DDSEntity::DATAWRITER:
-                                    qosprof::data_writer::qos::set_reliability_kind(filename, profile_name,
+                                    qosprof::data_writer::qos::set_reliability_kind(profile_name,
                                             reliability_kind);
                                     break;
                                 default:
@@ -392,7 +390,7 @@ void reliability_qos_parser(
                         subsubelement, values, message);
         if (!print_usage)
         {
-            duration_type_parser(duration_type, command, filename, profile_name, subsubelement, values, message);
+            duration_type_parser(duration_type, command, profile_name, subsubelement, values, message);
         }
         else
         {

--- a/cli/src/cpp/utils/transport_subelement_parser.cpp
+++ b/cli/src/cpp/utils/transport_subelement_parser.cpp
@@ -29,7 +29,6 @@ namespace qosprof_cli {
 
 void transport_subelement_parser(
         CommonCommands command,
-        const std::string& filename,
         const std::string& transport_identifier,
         std::string& element,
         const std::vector<std::string>& values)
@@ -80,7 +79,7 @@ void transport_subelement_parser(
                         print_usage = !check_command_arguments(command, 0, values.size(), message.str(), true);
                         if (!print_usage)
                         {
-                            qosprof::transport_descriptor::clear_interface_whitelist(filename, transport_identifier,
+                            qosprof::transport_descriptor::clear_interface_whitelist(transport_identifier,
                                     key);
                         }
                         break;
@@ -88,19 +87,19 @@ void transport_subelement_parser(
                         print_usage = !check_command_arguments(command, 0, values.size(), message.str(), true);
                         if (!print_usage)
                         {
-                            qosprof::transport_descriptor::print_interface_whitelist(filename, transport_identifier,
+                            qosprof::transport_descriptor::print_interface_whitelist(transport_identifier,
                                     key);
                         }
                         break;
                     case CommonCommands::QUERY:
                         // TODO: query kind should be passed in order to check the arguments and the amount of them
-                        //qosprof::transport_descriptor::interface_whitelist_size(filename, transport_identifier);
+                        //qosprof::transport_descriptor::interface_whitelist_size(transport_identifier);
                         break;
                     case CommonCommands::SET:
                         print_usage = !check_command_arguments(command, 1, values.size(), message.str(), true);
                         if (!print_usage)
                         {
-                            qosprof::transport_descriptor::set_interface_whitelist(filename, transport_identifier,
+                            qosprof::transport_descriptor::set_interface_whitelist(transport_identifier,
                                     values[DEFAULT_POSITION], key);
                         }
                         break;
@@ -152,14 +151,14 @@ void transport_subelement_parser(
                         print_usage = !check_command_arguments(command, 0, values.size(), message.str(), true);
                         if (!print_usage)
                         {
-                            qosprof::transport_descriptor::clear_kind(filename, transport_identifier);
+                            qosprof::transport_descriptor::clear_kind(transport_identifier);
                         }
                         break;
                     case CommonCommands::PRINT:
                         print_usage = !check_command_arguments(command, 0, values.size(), message.str(), true);
                         if (!print_usage)
                         {
-                            qosprof::transport_descriptor::print_kind(filename, transport_identifier);
+                            qosprof::transport_descriptor::print_kind(transport_identifier);
                         }
                         break;
                     case CommonCommands::QUERY:
@@ -194,7 +193,7 @@ void transport_subelement_parser(
                             {
                                 kind = values[DEFAULT_POSITION];
                             }
-                            qosprof::transport_descriptor::set_kind(filename, transport_identifier, kind);
+                            qosprof::transport_descriptor::set_kind(transport_identifier, kind);
                         }
                         break;
                 }

--- a/cli/src/cpp/utils/utils.hpp
+++ b/cli/src/cpp/utils/utils.hpp
@@ -145,14 +145,12 @@ const std::regex bracket_pattern("\\[([^\\]]*)\\]");
  * @brief Participant builtin discovery config parser.
  *
  * @param[in] command Command kind.
- * @param[in] filename File to be modified.
  * @param[in] profile_name Domain Participant profile name.
  * @param[in] element String with the dot-separated subelements.
  * @param[in] values Vector of strings with the values passed to CLI.
  */
 void builtin_discovery_config_parser(
         CommonCommands command,
-        const std::string& filename,
         const std::string& profile_name,
         std::string& element,
         const std::vector<std::string>& values);
@@ -181,14 +179,12 @@ bool builtin_locator_parser(
  * @brief Participant builtin parser.
  *
  * @param[in] command Command kind.
- * @param[in] filename File to be modified.
  * @param[in] profile_name Domain Participant profile name.
  * @param[in] element String with the dot-separated subelements.
  * @param[in] values Vector of strings with the values passed to CLI.
  */
 void builtin_parser(
         CommonCommands command,
-        const std::string& filename,
         const std::string& profile_name,
         std::string& element,
         const std::vector<std::string>& values);
@@ -198,7 +194,6 @@ void builtin_parser(
  *
  * @param[in] endpoint Endpoint kind: DataReader | DataWriter.
  * @param[in] command Command kind.
- * @param[in] filename File to be modified.
  * @param[in] profile_name DataReader profile name.
  * @param[in] element String with the dot-separated subelements.
  * @param[in] values Vector of strings with the values passed to CLI.
@@ -206,7 +201,6 @@ void builtin_parser(
 void endpoint_subelement_parser(
         DDSEntity endpoint,
         CommonCommands command,
-        const std::string& filename,
         const std::string& profile_name,
         std::string& element,
         const std::vector<std::string>& values);
@@ -225,7 +219,6 @@ void endpoint_subelement_parser(
 void duration_type_parser(
         DurationTypeList duration_type,
         CommonCommands command,
-        const std::string& filename,
         const std::string& profile_name,
         std::string& element,
         const std::vector<std::string>& values,
@@ -244,7 +237,6 @@ void duration_type_parser(
 void external_locators_parser(
         ExternalLocatorsList list,
         CommonCommands command,
-        const std::string& filename,
         const std::string& profile_name,
         std::string& element,
         const std::vector<std::string>& values);
@@ -264,7 +256,6 @@ void external_locators_parser(
 void locators_parser(
         LocatorsList list,
         CommonCommands command,
-        const std::string& filename,
         const std::string& profile_name,
         std::string& element,
         const std::string& key,
@@ -275,13 +266,11 @@ void locators_parser(
  * @brief Parser for the main element to be configured.
  *
  * @param[in] command Command kind.
- * @param[in] filename File to be modified.
  * @param[in] argc Number of arguments passed to the parser.
  * @param[in] argv Arguments to be parsed.
  */
 void main_element_parser(
         CommonCommands command,
-        const std::string& filename,
         int argc,
         char** argv);
 
@@ -289,14 +278,12 @@ void main_element_parser(
  * @brief Parser for the participant main subelements.
  *
  * @param[in] command Command kind.
- * @param[in] filename File to be modified.
  * @param[in] profile_name Participant profile name.
  * @param[in] element String with the dot-separated subelements.
  * @param[in] values Vector of strings with the values passed to CLI.
  */
 void participant_subelement_parser(
         CommonCommands command,
-        const std::string& filename,
         const std::string& profile_name,
         std::string& element,
         const std::vector<std::string>& values);
@@ -313,7 +300,6 @@ void participant_subelement_parser(
 void qos_parser(
         DDSEntity entity,
         CommonCommands command,
-        const std::string& filename,
         const std::string& profile_name,
         std::string& element,
         const std::vector<std::string>& values);
@@ -331,7 +317,6 @@ void qos_parser(
 void reliability_qos_parser(
         DDSEntity entity,
         CommonCommands command,
-        const std::string& filename,
         const std::string& profile_name,
         std::string& element,
         const std::vector<std::string>& values,
@@ -347,7 +332,6 @@ void reliability_qos_parser(
  */
 void transport_subelement_parser(
         CommonCommands command,
-        const std::string& filename,
         const std::string& transport_identifier,
         std::string& element,
         const std::vector<std::string>& values);

--- a/cli/src/cpp/utils/utils.hpp
+++ b/cli/src/cpp/utils/utils.hpp
@@ -228,7 +228,6 @@ void duration_type_parser(
  *
  * @param[in] list Identify the specific list which is being accessed.
  * @param[in] command Command kind.
- * @param[in] filename File to be accessed.
  * @param[in] profile_name DDS entity profile name.
  * @param[in] element String with the dot-separated subelements.
  * @param[in] values Vector of strings with the values passed to CLI.
@@ -245,7 +244,6 @@ void external_locators_parser(
  *
  * @param[in] list Identify the specific list which is being accessed.
  * @param[in] command Command kind.
- * @param[in] filename File to be accessed.
  * @param[in] profile_name DDS entity profile name.
  * @param[in] element String with the dot-separated subelements.
  * @param[in] key Index of the locator to be accessed in the list.

--- a/cli/src/cpp/utils/utils.hpp
+++ b/cli/src/cpp/utils/utils.hpp
@@ -210,7 +210,6 @@ void endpoint_subelement_parser(
  *
  * @param duration_type Duration type being parsed.
  * @param command Command kind.
- * @param filename File to be accessed.
  * @param profile_name DDS entity profile name.
  * @param element String with the dot-separated subelements.
  * @param values Vector of strings with the values passed to CLI.
@@ -292,7 +291,6 @@ void participant_subelement_parser(
  *
  * @param entity Endpoint kind.
  * @param command Command kind.
- * @param filename File to be modified.
  * @param profile_name Endpoint profile name.
  * @param element String with the dot-separated subelements.
  * @param values Vector of strings with the values passed to CLI.
@@ -308,7 +306,6 @@ void qos_parser(
  *
  * @param entity Endpoint kind.
  * @param command Command kind.
- * @param filename File to be modified.
  * @param profile_name Endpoint profile name.
  * @param element String with the dot-separated subelements.
  * @param values Vector of strings with the values passed to CLI.
@@ -325,7 +322,6 @@ void reliability_qos_parser(
  * @brief Transport descriptor parser
  *
  * @param command Command kind.
- * @param filename File to be modified.
  * @param transport_identifier transport identifier.
  * @param element String with the dot-separated subelements.
  * @param values Vector of strings with the values passed to CLI.

--- a/cli/test/README.md
+++ b/cli/test/README.md
@@ -112,9 +112,9 @@ This document includes CLI commands and the expected CLI output in order to help
 |`fastddsqosprof file.xml set datareader[profile].qos.reliability.duration.max_blocking_time 1`|N/A|N/A|
 |`fastddsqosprof file.xml set datareader[profile].qos.reliability.duration.max_blocking_time other`|`Fast DDS QoS Profiles Manager exception caught: value 'other' does not match any member types of the union`|N/A|
 |`fastddsqosprof file.xml set datareader[profile].qos.reliability.duration.max_blocking_time arg1 arg2 -h`|N/A|`RELIABILITY_DURATION_QOS_USAGE`|
-|`fastddsqosprof file.xml set datareader[profile].qos.reliability.duration.max_blocking_time 2 500`|**BUG** (currently `Fast DDS QoS Profiles Manager exception caught: invalid document structure`) [^3]|N/A|
+|`fastddsqosprof file.xml set datareader[profile].qos.reliability.duration.max_blocking_time 2 500`|N/A|N/A|
 |`fastddsqosprof file.xml set datareader[profile].qos.reliability.duration.max_blocking_time infinite 500`|`Fast DDS QoS Profiles Manager exception caught: value 'infinite' does not match any member types of the union`|N/A|
-|`fastddsqosprof file.xml set datareader[profile].qos.reliability.duration.max_blocking_time 1 other`|**BUG** (currently `Fast DDS QoS Profiles Manager exception caught: invalid document structure`) [^3]|N/A|
+|`fastddsqosprof file.xml set datareader[profile].qos.reliability.duration.max_blocking_time 1 other`|`Fast DDS QoS Profiles Manager exception caught: value 'other' does not match any member types of the union`|N/A|
 |`fastddsqosprof file.xml set datareader[profile].qos.reliability.duration.max_blocking_time.sec`|`ERROR: set command for DataReader <reliability> QoS: 'duration' attribute: 'max_blocking_time' duration type <sec> attribute expects 1 arguments and received 0`|`RELIABILITY_DURATION_QOS_USAGE`|
 |`fastddsqosprof file.xml set datareader[profile].qos.reliability.duration.max_blocking_time.sec[]`|`ERROR: DataReader <reliability> QoS: 'duration' attribute: 'max_blocking_time' duration type <sec> attribute must not be keyed []`|`RELIABILITY_DURATION_QOS_USAGE`|
 |`fastddsqosprof file.xml set datareader[profile].qos.reliability.duration.max_blocking_time.sec.other`|`ERROR: DataReader <reliability> QoS: 'duration' attribute: 'max_blocking_time' duration type <sec> attribute must be FINAL element`|`RELIABILITY_DURATION_QOS_USAGE`|
@@ -218,9 +218,9 @@ This document includes CLI commands and the expected CLI output in order to help
 |`fastddsqosprof file.xml set datawriter[profile].qos.reliability.duration.max_blocking_time 1`|N/A|N/A|
 |`fastddsqosprof file.xml set datawriter[profile].qos.reliability.duration.max_blocking_time other`|`Fast DDS QoS Profiles Manager exception caught: value 'other' does not match any member types of the union`|N/A|
 |`fastddsqosprof file.xml set datawriter[profile].qos.reliability.duration.max_blocking_time arg1 arg2 -h`|N/A|`RELIABILITY_DURATION_QOS_USAGE`|
-|`fastddsqosprof file.xml set datawriter[profile].qos.reliability.duration.max_blocking_time 2 500`|**BUG** (currently `Fast DDS QoS Profiles Manager exception caught: invalid document structure`) [^3]|N/A|
+|`fastddsqosprof file.xml set datawriter[profile].qos.reliability.duration.max_blocking_time 2 500`|N/A|N/A|
 |`fastddsqosprof file.xml set datawriter[profile].qos.reliability.duration.max_blocking_time infinite 500`|`Fast DDS QoS Profiles Manager exception caught: value 'infinite' does not match any member types of the union`|N/A|
-|`fastddsqosprof file.xml set datawriter[profile].qos.reliability.duration.max_blocking_time 1 other`|**BUG** (currently `Fast DDS QoS Profiles Manager exception caught: invalid document structure`) [^3]|N/A|
+|`fastddsqosprof file.xml set datawriter[profile].qos.reliability.duration.max_blocking_time 1 other`|`Fast DDS QoS Profiles Manager exception caught: value 'other' does not match any member types of the union`|N/A|
 |`fastddsqosprof file.xml set datawriter[profile].qos.reliability.duration.max_blocking_time.sec`|`ERROR: set command for DataWriter <reliability> QoS: 'duration' attribute: 'max_blocking_time' duration type <sec> attribute expects 1 arguments and received 0`|`RELIABILITY_DURATION_QOS_USAGE`|
 |`fastddsqosprof file.xml set datawriter[profile].qos.reliability.duration.max_blocking_time.sec[]`|`ERROR: DataWriter <reliability> QoS: 'duration' attribute: 'max_blocking_time' duration type <sec> attribute must not be keyed []`|`RELIABILITY_DURATION_QOS_USAGE`|
 |`fastddsqosprof file.xml set datawriter[profile].qos.reliability.duration.max_blocking_time.sec.other`|`ERROR: DataWriter <reliability> QoS: 'duration' attribute: 'max_blocking_time' duration type <sec> attribute must be FINAL element`|`RELIABILITY_DURATION_QOS_USAGE`|
@@ -303,9 +303,9 @@ This document includes CLI commands and the expected CLI output in order to help
 |`fastddsqosprof file.xml set participant[profile].builtin.discovery_config.duration.lease 1`|N/A|N/A|
 |`fastddsqosprof file.xml set participant[profile].builtin.discovery_config.duration.lease other`|`Fast DDS QoS Profiles Manager exception caught: value 'other' does not match any member types of the union`|N/A|
 |`fastddsqosprof file.xml set participant[profile].builtin.discovery_config.duration.lease arg1 arg2 help`|N/A|`PARTICIPANT_BUILTIN_DISCOVERY_CONFIG_DURATION_USAGE`|
-|`fastddsqosprof file.xml set participant[profile].builtin.discovery_config.duration.lease 1 500`|**BUG** (currently `Fast DDS QoS Profiles Manager exception caught: invalid document structure`) [^3]|N/A|
+|`fastddsqosprof file.xml set participant[profile].builtin.discovery_config.duration.lease 1 500`|N/A|N/A|
 |`fastddsqosprof file.xml set participant[profile].builtin.discovery_config.duration.lease infinite 500`|`Fast DDS QoS Profiles Manager exception caught: value 'infinite' does not match any member types of the union`|N/A|
-|`fastddsqosprof file.xml set participant[profile].builtin.discovery_config.duration.lease 1 other`|**BUG** (currently `Fast DDS QoS Profiles Manager exception caught: invalid document structure`) [^3]|N/A|
+|`fastddsqosprof file.xml set participant[profile].builtin.discovery_config.duration.lease 1 other`|`Fast DDS QoS Profiles Manager exception caught: value 'other' does not match any member types of the union`|N/A|
 |`fastddsqosprof file.xml set participant[profile].builtin.discovery_config.duration.lease.sec`|`ERROR: set command for Participant builtin discovery config <duration>: 'lease' duration type <sec> attribute expects 1 arguments and received 0`|`PARTICIPANT_BUILTIN_DISCOVERY_CONFIG_DURATION_USAGE`|
 |`fastddsqosprof file.xml set participant[profile].builtin.discovery_config.duration.lease.sec[]`|`ERROR: Participant builtin discovery config <duration>: 'lease' duration type <sec> attribute must not be keyed []`|`PARTICIPANT_BUILTIN_DISCOVERY_CONFIG_DURATION_USAGE`|
 |`fastddsqosprof file.xml set participant[profile].builtin.discovery_config.duration.lease.sec.other`|`ERROR: Participant builtin discovery config <duration>: 'lease' duration type <sec> attribute must be FINAL element`|`PARTICIPANT_BUILTIN_DISCOVERY_CONFIG_DURATION_USAGE`|
@@ -327,9 +327,9 @@ This document includes CLI commands and the expected CLI output in order to help
 |`fastddsqosprof file.xml set participant[profile].builtin.discovery_config.duration.announcements 1`|N/A|N/A|
 |`fastddsqosprof file.xml set participant[profile].builtin.discovery_config.duration.announcements other`|`Fast DDS QoS Profiles Manager exception caught: value 'other' does not match any member types of the union`|N/A|
 |`fastddsqosprof file.xml set participant[profile].builtin.discovery_config.duration.announcements arg1 arg2 help`|N/A|`PARTICIPANT_BUILTIN_DISCOVERY_CONFIG_DURATION_USAGE`|
-|`fastddsqosprof file.xml set participant[profile].builtin.discovery_config.duration.announcements 1 500`|**BUG** (currently `Fast DDS QoS Profiles Manager exception caught: invalid document structure`) [^3]|N/A|
+|`fastddsqosprof file.xml set participant[profile].builtin.discovery_config.duration.announcements 1 500`|N/A|N/A|
 |`fastddsqosprof file.xml set participant[profile].builtin.discovery_config.duration.announcements infinite 500`|`Fast DDS QoS Profiles Manager exception caught: value 'infinite' does not match any member types of the union`|N/A|
-|`fastddsqosprof file.xml set participant[profile].builtin.discovery_config.duration.announcements 1 other`|**BUG** (currently `Fast DDS QoS Profiles Manager exception caught: invalid document structure`) [^3]|N/A|
+|`fastddsqosprof file.xml set participant[profile].builtin.discovery_config.duration.announcements 1 other`|`Fast DDS QoS Profiles Manager exception caught: value 'other' does not match any member types of the union`|N/A|
 |`fastddsqosprof file.xml set participant[profile].builtin.discovery_config.duration.announcements.sec`|`ERROR: set command for Participant builtin discovery config <duration>: 'announcements' duration type <sec> attribute expects 1 arguments and received 0`|`PARTICIPANT_BUILTIN_DISCOVERY_CONFIG_DURATION_USAGE`|
 |`fastddsqosprof file.xml set participant[profile].builtin.discovery_config.duration.announcements.sec[]`|`ERROR: Participant builtin discovery config <duration>: 'announcements' duration type <sec> attribute must not be keyed []`|`PARTICIPANT_BUILTIN_DISCOVERY_CONFIG_DURATION_USAGE`|
 |`fastddsqosprof file.xml set participant[profile].builtin.discovery_config.duration.announcements.sec.other`|`ERROR: Participant builtin discovery config <duration>: 'announcements' duration type <sec> attribute must be FINAL element`|`PARTICIPANT_BUILTIN_DISCOVERY_CONFIG_DURATION_USAGE`|
@@ -728,16 +728,8 @@ This document includes CLI commands and the expected CLI output in order to help
 
 [^1]: **PENDING**: Print and clear default profile command will not require a profile name.
 [^2]: **PENDING**: Print, clear and query commands should not allow an empty index with a subelement.
-[^3]: **BUG**: Access to file before previous changes have been written although Xerces has correctly returned from `write` operation.
 
 ## Caveats
 
 This current test plan is focused only on the CLI usage and errors.
 Currently, this test plan is not concerned about the validity of the arguments passed to Fast DDS QoS Profiles Manager Library, nor about the handling of the returned information.
-
-
-## Known issues
-
-* Simultaneous `set` operations would lead to an unexpected exception reporting the following message: `Fast DDS QoS Profiles Manager exception caught: invalid document structure`.
-  This happens due to accessing the file before previous changes have been written although Xerces has correctly returned from `write` operation.
-  These are some of the `set` calls that trigger this issue: `fastddsqosprof file.xml set participant[profile].builtin.discovery_config.duration.lease 1 500`, `fastddsqosprof file.xml set participant[profile].builtin.discovery_config.duration.announcements 1 500`, and some other non-supported yet calls that have already been designed, as `fastddsqosprof file.xml set participant[profile].locators.default_unicast[] udpv4 127.0.0.1 1234`.

--- a/cli/test/README.md
+++ b/cli/test/README.md
@@ -733,3 +733,7 @@ This document includes CLI commands and the expected CLI output in order to help
 
 This current test plan is focused only on the CLI usage and errors.
 Currently, this test plan is not concerned about the validity of the arguments passed to Fast DDS QoS Profiles Manager Library, nor about the handling of the returned information.
+
+## Known issues
+
+Currently, no known issues have been detected.

--- a/docs/code/cli_verb_set_example.xml
+++ b/docs/code/cli_verb_set_example.xml
@@ -13,6 +13,7 @@
                 <reliability>
                     <max_blocking_time>
                         <sec>1</sec>
+                        <nanosec>100</nanosec>
                     </max_blocking_time>
                 </reliability>
             </qos>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,7 @@
     :hidden:
 
     /rst/fastdds_qos_profiles_manager_lib/api_reference
+    /rst/fastdds_qos_profiles_manager_lib/qos_profiles_manager
     /rst/fastdds_qos_profiles_manager_lib/participant
     /rst/fastdds_qos_profiles_manager_lib/datareader
     /rst/fastdds_qos_profiles_manager_lib/datawriter

--- a/docs/rst/01-exports/api-lib-aliases.include
+++ b/docs/rst/01-exports/api-lib-aliases.include
@@ -1,1 +1,0 @@
-.. |FileNotFound-api| replace:: :cpp:class:`FileNotFound <eprosima::qosprof::FileNotFound>`

--- a/docs/rst/fastdds_qos_profiles_manager_cli/cli_elements/cli_common_elements/cli_common_duration_type_element.rst
+++ b/docs/rst/fastdds_qos_profiles_manager_cli/cli_elements/cli_common_elements/cli_common_duration_type_element.rst
@@ -1,3 +1,5 @@
+.. include:: ../../../01-exports/roles.include
+
 .. _fastdds_qos_profiles_manager_cli_common_duration_type_element:
 
 Duration type configuration
@@ -30,6 +32,10 @@ The duration type configurable ``<subelements>`` are explained in the table belo
       - ``duration.<duration_type>``
       - Complex parameter
       - ``infinite``
+    * - All ``subelements``
+      - ``duration.<duration_type> <sec_value> <nanosec_value>``
+      - Complex parameter
+      - ``<sec_value>`` as ``int32_t`` |br| ``<nanosec_value>`` as ``uint32_t``
 
 .. note::
 

--- a/docs/rst/fastdds_qos_profiles_manager_cli/cli_elements/cli_common_elements/cli_common_duration_type_element.rst
+++ b/docs/rst/fastdds_qos_profiles_manager_cli/cli_elements/cli_common_elements/cli_common_duration_type_element.rst
@@ -37,9 +37,16 @@ The duration type configurable ``<subelements>`` are explained in the table belo
       - Complex parameter
       - ``<sec_value>`` as ``int32_t`` |br| ``<nanosec_value>`` as ``uint32_t``
 
+Duration type can also be set in the following supported usages:
+
+* Setting an infinite duration: ``duration.<duration_type> infinite``
+
+* Setting the duration directly: ``duration.<duration_type> <sec_value> <nanosec_value>``
+
 .. note::
 
-    Duration type seconds can also be set with ``duration.<duration_type>``, similar to the infinite duration.
+    The duration can be directly set also by passing only the ``<sec_value>`` argument: ``duration.<duration_type> <sec_value>``
+
 
 The ``<duration_type>`` element is defined for each specific element.
 The list below includes the currently supported ``<duration_type>`` elements:

--- a/docs/rst/fastdds_qos_profiles_manager_cli/cli_elements/cli_common_elements/cli_common_duration_type_element.rst
+++ b/docs/rst/fastdds_qos_profiles_manager_cli/cli_elements/cli_common_elements/cli_common_duration_type_element.rst
@@ -28,14 +28,6 @@ The duration type configurable ``<subelements>`` are explained in the table belo
       - ``duration.<duration_type>.nanosec``
       - Simple parameter
       - ``uint32_t``
-    * - Infinite duration type
-      - ``duration.<duration_type>``
-      - Complex parameter
-      - ``infinite``
-    * - All ``subelements``
-      - ``duration.<duration_type> <sec_value> <nanosec_value>``
-      - Complex parameter
-      - ``<sec_value>`` as ``int32_t`` |br| ``<nanosec_value>`` as ``uint32_t``
 
 Duration type can also be set in the following supported usages:
 

--- a/docs/rst/fastdds_qos_profiles_manager_cli/cli_usage.rst
+++ b/docs/rst/fastdds_qos_profiles_manager_cli/cli_usage.rst
@@ -14,8 +14,6 @@ Usage
 
 After the executable, the first parameter expected is the name of the XML configuration file that is going to be read/modified.
 The ``<file>`` path can be provided both in an absolute or relative manner.
-If the file is non-existent, the |FileNotFound-api| exception thrown by the library is caught and the corresponding error is displayed, except if the commanded verb has been ``set``.
-In that specific case, the file is created with the corresponding configuration parameter.
 
 The CLI supported verbs are explained in the table below:
 
@@ -52,9 +50,9 @@ If the parameter is being ``set``, the corresponding configuration ``value`` has
   For instance, the following command
 
   .. code-block:: bash
-    
+
     fastddsqosprof file.xml set participant -h
-    
+
   will show the usage corresponding to the DomainParticipant profiles configuration.
   More information can be found in :ref:`fastdds_qos_profiles_manager_cli_help_verb`.
 

--- a/docs/rst/fastdds_qos_profiles_manager_cli/cli_verbs/cli_set_verb.rst
+++ b/docs/rst/fastdds_qos_profiles_manager_cli/cli_verbs/cli_set_verb.rst
@@ -20,7 +20,7 @@ The snippet below shows different examples:
 
     $ fastddsqosprof file set datareader[dr_profile].default_profile
 
-    $ fastddsqosprof file set datawriter[dw_profile].qos.reliability.duration.max_blocking_time 1
+    $ fastddsqosprof file set datawriter[dw_profile].qos.reliability.duration.max_blocking_time 1 100
 
     $ fastddsqosprof file set participant[p_profile].name "My participant"
 

--- a/docs/rst/fastdds_qos_profiles_manager_lib/api_reference.rst
+++ b/docs/rst/fastdds_qos_profiles_manager_lib/api_reference.rst
@@ -4,9 +4,3 @@ Introduction
 ============
 
 This section presents the public API provided by *eProsima Fast DDS QoS Profiles Manager Library*.
-
-The *Library* needs to be initialized and closed in each use.
-The ``initialize`` method would create a XML workspace in which any *Library* call can be executed.
-When no more *Library* API calls needed, the ``terminate`` method would apply the possible changes in the filesystem, and would close the XML workspace.
-
-See :ref:`initialize and terminate methods reference <api_qos_profiles_manager>` for further information.

--- a/docs/rst/fastdds_qos_profiles_manager_lib/api_reference.rst
+++ b/docs/rst/fastdds_qos_profiles_manager_lib/api_reference.rst
@@ -4,3 +4,9 @@ Introduction
 ============
 
 This section presents the public API provided by *eProsima Fast DDS QoS Profiles Manager Library*.
+
+The *Library* needs to be initialized and closed in each use.
+The ``initialize`` method would create a XML workspace in which any *Library* call can be executed.
+When no more *Library* API calls needed, the ``terminate`` method would apply the possible changes in the filesystem, and would close the XML workspace.
+
+See :ref:`initialize and terminate methods reference <api_qos_profiles_manager>` for further information.

--- a/docs/rst/fastdds_qos_profiles_manager_lib/exception.rst
+++ b/docs/rst/fastdds_qos_profiles_manager_lib/exception.rst
@@ -20,8 +20,5 @@ Exceptions
 .. doxygenclass:: eprosima::qosprof::Error
     :project: fastdds_qos_profiles_manager_lib
 
-.. doxygenclass:: eprosima::qosprof::FileNotFound
-    :project: fastdds_qos_profiles_manager_lib
-
 .. doxygenclass:: eprosima::qosprof::Unsupported
     :project: fastdds_qos_profiles_manager_lib

--- a/docs/rst/fastdds_qos_profiles_manager_lib/qos_profiles_manager.rst
+++ b/docs/rst/fastdds_qos_profiles_manager_lib/qos_profiles_manager.rst
@@ -1,0 +1,9 @@
+.. _api_qos_profiles_manager:
+
+.. rst-class:: api-ref
+
+QoS Profiles Manager
+--------------------
+
+.. doxygenfile:: QoSProfilesManager.hpp
+    :project: fastdds_qos_profiles_manager_lib

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -103,7 +103,7 @@ set(${PROJECT_NAME}_source_files
     src/cpp/domain_participant/Port.cpp
     src/cpp/domain_participant/PropertiesPolicy.cpp
     src/cpp/exception/Exception.cpp
-    src/cpp/QosProfileManager.cpp
+    src/cpp/QosProfilesManager.cpp
     src/cpp/transport_descriptor/TransportDescriptor.cpp
     src/cpp/utils/ErrorHandlerXMLManager.cpp
     src/cpp/utils/StringXMLManager.cpp

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -103,6 +103,7 @@ set(${PROJECT_NAME}_source_files
     src/cpp/domain_participant/Port.cpp
     src/cpp/domain_participant/PropertiesPolicy.cpp
     src/cpp/exception/Exception.cpp
+    src/cpp/QosProfileManager.cpp
     src/cpp/transport_descriptor/TransportDescriptor.cpp
     src/cpp/utils/ErrorHandlerXMLManager.cpp
     src/cpp/utils/StringXMLManager.cpp

--- a/lib/include/fastdds_qos_profiles_manager_lib/QoSProfileManager.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/QoSProfileManager.hpp
@@ -16,32 +16,34 @@
  * @file
  */
 
-#include <common/qos/Durability.hpp>
+#ifndef _FAST_DDS_QOS_PROFILES_MANAGER_HPP_
+#define _FAST_DDS_QOS_PROFILES_MANAGER_HPP_
+
+#include <fastdds_qos_profiles_manager_lib/fastdds_qos_profiles_manager_dll.h>
 
 #include <string>
 
-#include <utils/TagsXMLManager.hpp>
-#include <utils/XMLManager.hpp>
-
 namespace eprosima {
 namespace qosprof {
-namespace common {
-namespace qos {
-namespace durability {
 
-void set_kind(
-        utils::XMLManager& manager,
-        const std::string& kind)
-{
-    // Obtain kind node
-    manager.move_to_node(utils::tag::KIND, true);
+/**
+ * @brief Initialize XML workspace
+ *
+ * @param xml_file Absolute/relative path to the XML file.
+ * @param create_file bool create file if the flag is set
+ *
+ * @throw Error Exception if the workspace could not be initialized
+ */
+FASTDDS_QOS_PROFILES_MANAGER_DllAPI void initialize(
+        const std::string& xml_file,
+        const bool create_file);
 
-    // Set value to node
-    manager.set_value_to_node(kind);
-}
+/**
+ * @brief Terminate XML workspace
+ */
+FASTDDS_QOS_PROFILES_MANAGER_DllAPI void terminate();
 
-} // durability
-} // qos
-} // common
 } // qosprof
 } // eprosima
+
+#endif // _FAST_DDS_QOS_PROFILES_MANAGER_HPP_

--- a/lib/include/fastdds_qos_profiles_manager_lib/QoSProfilesManager.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/QoSProfilesManager.hpp
@@ -43,6 +43,8 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void initialize(
  * @brief Terminate the eProsima QoS Profiles Manager Library XML workspace related to the specified XML file.
  *  If changes required to be applied in the XML configuration file, this method would also apply them in filesystem.
  *  If error occurred or resultant XML configuration is not valid, the XML configuration will not be modified.
+ *
+ * @throw Error Exception if the XML file could not be written in filesystem
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void terminate();
 

--- a/lib/include/fastdds_qos_profiles_manager_lib/QoSProfilesManager.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/QoSProfilesManager.hpp
@@ -34,6 +34,7 @@ namespace qosprof {
  * @param create_file bool create file if the flag is set and the file is not found.
  *
  * @throw Error Exception if the workspace could not be initialized, or it was already initialized.
+ * @throw FileNotFound Exception if the provided XML file is not found/readable.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void initialize(
         const std::string& xml_file,

--- a/lib/include/fastdds_qos_profiles_manager_lib/QoSProfilesManager.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/QoSProfilesManager.hpp
@@ -27,21 +27,22 @@ namespace eprosima {
 namespace qosprof {
 
 /**
- * @brief Initialize XML workspace
+ * @brief Initialize eProsima QoS Profiles Manager Library XML workspace. This workspace gets related to the given
+ *  XML file, and all the Library API calls would be related to that XML file.
  *
  * @param xml_file Absolute/relative path to the XML file.
- * @param create_file bool create file if the flag is set and the file is not found
+ * @param create_file bool create file if the flag is set and the file is not found.
  *
- * @throw Error Exception if the workspace could not be initialized, or it was already initialized
+ * @throw Error Exception if the workspace could not be initialized, or it was already initialized.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void initialize(
         const std::string& xml_file,
         const bool create_file);
 
 /**
- * @brief Terminate XML workspace. If required to save or update the XML configuration in the filesystem,this method
- *        must be called to save them.
- *        If error occurred or resultant XML configuration is not valid, it will not save the XML configuration.
+ * @brief Terminate the eProsima QoS Profiles Manager Library XML workspace related to the specified XML file.
+ *  If changes required to be applied in the XML configuration file, this method would also apply them in filesystem.
+ *  If error occurred or resultant XML configuration is not valid, the XML configuration will not be modified.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void terminate();
 

--- a/lib/include/fastdds_qos_profiles_manager_lib/QoSProfilesManager.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/QoSProfilesManager.hpp
@@ -30,7 +30,7 @@ namespace qosprof {
  * @brief Initialize XML workspace
  *
  * @param xml_file Absolute/relative path to the XML file.
- * @param create_file bool create file if the flag is set
+ * @param create_file bool create file if the flag is set and the file is not found
  *
  * @throw Error Exception if the workspace could not be initialized
  */
@@ -39,7 +39,9 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void initialize(
         const bool create_file);
 
 /**
- * @brief Terminate XML workspace
+ * @brief Terminate XML workspace. If required to save or update the XML configuration in the filesystem,this method
+ *        must be called to save them.
+ *        If error occurred or resultant XML configuration is not valid, it will not save the XML configuration.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void terminate();
 

--- a/lib/include/fastdds_qos_profiles_manager_lib/QoSProfilesManager.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/QoSProfilesManager.hpp
@@ -32,7 +32,7 @@ namespace qosprof {
  * @param xml_file Absolute/relative path to the XML file.
  * @param create_file bool create file if the flag is set and the file is not found
  *
- * @throw Error Exception if the workspace could not be initialized
+ * @throw Error Exception if the workspace could not be initialized, or it was already initialized
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void initialize(
         const std::string& xml_file,

--- a/lib/include/fastdds_qos_profiles_manager_lib/QoSProfilesManager.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/QoSProfilesManager.hpp
@@ -31,14 +31,11 @@ namespace qosprof {
  *  XML file, and all the Library API calls would be related to that XML file.
  *
  * @param xml_file Absolute/relative path to the XML file.
- * @param create_file bool create file if the flag is set and the file is not found.
  *
  * @throw Error Exception if the workspace could not be initialized, or it was already initialized.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void initialize(
-        const std::string& xml_file,
-        const bool create_file);
+        const std::string& xml_file);
 
 /**
  * @brief Terminate the eProsima QoS Profiles Manager Library XML workspace related to the specified XML file.

--- a/lib/include/fastdds_qos_profiles_manager_lib/QoSProfilesManager.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/QoSProfilesManager.hpp
@@ -38,9 +38,10 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void initialize(
         const std::string& xml_file);
 
 /**
- * @brief Terminate the eProsima QoS Profiles Manager Library XML workspace related to the specified XML file.
- *  If changes required to be applied in the XML configuration file, this method would also apply them in filesystem.
- *  If error occurred or resultant XML configuration is not valid, the XML configuration will not be modified.
+ * @brief Terminate the initialized eProsima QoS Profiles Manager Library XML workspace. This function must be called
+ *  before initializing a new workspace. If changes required to be applied in the XML configuration file, this method
+ *  would also apply them in filesystem. If error occurred or resultant XML configuration is not valid, the XML
+ *  configuration will not be modified.
  *
  * @throw Error Exception if the XML file could not be written in filesystem
  */

--- a/lib/include/fastdds_qos_profiles_manager_lib/data_reader/DataReader.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/data_reader/DataReader.hpp
@@ -42,14 +42,12 @@ namespace data_reader {
 /**
  * @brief Set the selected DataReader profile as default profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id DataReader profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_default_profile(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 } // data_reader

--- a/lib/include/fastdds_qos_profiles_manager_lib/data_reader/DataReader.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/data_reader/DataReader.hpp
@@ -44,7 +44,7 @@ namespace data_reader {
  *
  * @param[in] profile_id DataReader profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_default_profile(

--- a/lib/include/fastdds_qos_profiles_manager_lib/data_reader/Qos.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/data_reader/Qos.hpp
@@ -46,6 +46,7 @@ namespace qos {
  * @param[in] profile_id DataReader profile identifier.
  * @param[in] kind Durability QoS kind value.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided durability QoS kind value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_durability_kind(
@@ -58,6 +59,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_durability_kind(
  * @param[in] profile_id DataReader profile identifier.
  * @param[in] kind Reliability QoS kind value.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided reliability QoS kind value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_reliability_kind(
@@ -70,6 +72,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_reliability_kind(
  * @param[in] profile_id DataReader profile identifier.
  * @param[in] sec Reliability QoS max blocking time seconds to be set
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided reliability QoS max blocking time seconds are not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_reliability_max_blocking_time_sec(
@@ -82,6 +85,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_reliability_max_blocking_time_sec(
  * @param[in] profile_id DataReader profile identifier.
  * @param[in] nanosec Reliability QoS max blocking time nanoseconds to be set
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided reliability QoS max blocking time nanoseconds are not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_reliability_max_blocking_time_nanosec(

--- a/lib/include/fastdds_qos_profiles_manager_lib/data_reader/Qos.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/data_reader/Qos.hpp
@@ -43,56 +43,48 @@ namespace qos {
 /**
  * @brief Set the DataReader durability QoS kind.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id DataReader profile identifier.
  * @param[in] kind Durability QoS kind value.
  *
  * @throw ElementInvalid Exception if the provided durability QoS kind value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_durability_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& kind);
 
 /**
  * @brief Set the DataReader reliability QoS kind.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id DataReader profile identifier.
  * @param[in] kind Reliability QoS kind value.
  *
  * @throw ElementInvalid Exception if the provided reliability QoS kind value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_reliability_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& kind);
 
 /**
  * @brief Set the DataReader reliability QoS max blocking time seconds.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id DataReader profile identifier.
  * @param[in] sec Reliability QoS max blocking time seconds to be set
  *
  * @throw ElementInvalid Exception if the provided reliability QoS max blocking time seconds are not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_reliability_max_blocking_time_sec(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& sec);
 
 /**
  * @brief Set the DataReader reliability QoS max blocking time nanoseconds.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id DataReader profile identifier.
  * @param[in] nanosec Reliability QoS max blocking time nanoseconds to be set
  *
  * @throw ElementInvalid Exception if the provided reliability QoS max blocking time nanoseconds are not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_reliability_max_blocking_time_nanosec(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& nanosec);
 

--- a/lib/include/fastdds_qos_profiles_manager_lib/data_writer/DataWriter.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/data_writer/DataWriter.hpp
@@ -44,7 +44,7 @@ namespace data_writer {
  *
  * @param[in] profile_id DataWriter profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_default_profile(

--- a/lib/include/fastdds_qos_profiles_manager_lib/data_writer/DataWriter.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/data_writer/DataWriter.hpp
@@ -42,14 +42,12 @@ namespace data_writer {
 /**
  * @brief Set the selected DataWriter profile as default profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id DataWriter profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_default_profile(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 } // data_writer

--- a/lib/include/fastdds_qos_profiles_manager_lib/data_writer/Qos.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/data_writer/Qos.hpp
@@ -46,6 +46,7 @@ namespace qos {
  * @param[in] profile_id DataWriter profile identifier.
  * @param[in] kind Durability QoS kind value.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided durability QoS kind value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_durability_kind(
@@ -58,6 +59,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_durability_kind(
  * @param[in] profile_id DataWriter profile identifier.
  * @param[in] kind Reliability QoS kind value.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided reliability QoS kind value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_reliability_kind(
@@ -70,6 +72,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_reliability_kind(
  * @param[in] profile_id DataWriter profile identifier.
  * @param[in] sec Reliability QoS max blocking time seconds to be set
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided reliability QoS max blocking time seconds are not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_reliability_max_blocking_time_sec(
@@ -82,6 +85,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_reliability_max_blocking_time_sec(
  * @param[in] profile_id DataWriter profile identifier.
  * @param[in] nanosec Reliability QoS max blocking time nanoseconds to be set
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided reliability QoS max blocking time nanoseconds are not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_reliability_max_blocking_time_nanosec(

--- a/lib/include/fastdds_qos_profiles_manager_lib/data_writer/Qos.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/data_writer/Qos.hpp
@@ -43,56 +43,48 @@ namespace qos {
 /**
  * @brief Set the DataWriter durability QoS kind.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id DataWriter profile identifier.
  * @param[in] kind Durability QoS kind value.
  *
  * @throw ElementInvalid Exception if the provided durability QoS kind value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_durability_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& kind);
 
 /**
  * @brief Set the DataWriter reliability QoS kind.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id DataWriter profile identifier.
  * @param[in] kind Reliability QoS kind value.
  *
  * @throw ElementInvalid Exception if the provided reliability QoS kind value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_reliability_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& kind);
 
 /**
  * @brief Set the DataWriter reliability QoS max blocking time seconds.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id DataWriter profile identifier.
  * @param[in] sec Reliability QoS max blocking time seconds to be set
  *
  * @throw ElementInvalid Exception if the provided reliability QoS max blocking time seconds are not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_reliability_max_blocking_time_sec(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& sec);
 
 /**
  * @brief Set the DataWriter reliability QoS max blocking time nanoseconds.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id DataWriter profile identifier.
  * @param[in] nanosec Reliability QoS max blocking time nanoseconds to be set
  *
  * @throw ElementInvalid Exception if the provided reliability QoS max blocking time nanoseconds are not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_reliability_max_blocking_time_nanosec(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& nanosec);
 

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/Allocation.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/Allocation.hpp
@@ -610,6 +610,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_send_buffers_preallocated_dynamic
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] max_unicast Maximum number of allowed remote unicast locators.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_remote_locators_max_unicast(
@@ -622,6 +623,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_remote_locators_max_unicast(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] max_multicast Maximum number of allowed remote multicast locators.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_remote_locators_max_multicast(
@@ -634,6 +636,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_remote_locators_max_multicast(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] initial Initial number of preallocated participants.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_participants_initial(
@@ -646,6 +649,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_participants_initial(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] maximum Maximum number of participants.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_participants_maximum(
@@ -659,6 +663,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_participants_maximum(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] increment Increment of participants.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_participants_increment(
@@ -671,6 +676,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_participants_increment(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] initial Initial number of preallocated readers.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_readers_initial(
@@ -683,6 +689,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_readers_initial(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] maximum Maximum number of readers.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_readers_maximum(
@@ -696,6 +703,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_readers_maximum(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] increment Increment of readers.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_readers_increment(
@@ -708,6 +716,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_readers_increment(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] initial Initial number of preallocated writers.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_writers_initial(
@@ -720,6 +729,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_writers_initial(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] maximum Maximum number of writers.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_writers_maximum(
@@ -733,6 +743,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_writers_maximum(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] increment Increment of writers.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_writers_increment(
@@ -745,6 +756,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_writers_increment(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] max_partitions Maximum number of partitions allowed in the Domain Participant.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_max_partitions(
@@ -757,6 +769,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_max_partitions(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] max_user_data Maximum allowed size for user data message in the Domain Participant.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_max_user_data(
@@ -769,6 +782,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_max_user_data(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] max_properties Maximum allowed number of properties in the Domain Participant.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_max_properties(
@@ -781,6 +795,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_max_properties(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] send_buffers_preallocated_number Number of send buffers preallocated.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_send_buffers_preallocated_number(
@@ -793,6 +808,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_send_buffers_preallocated_number(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] send_buffers_dynamic Send buffers dynamic flag.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_send_buffers_dynamic(

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/Allocation.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/Allocation.hpp
@@ -35,7 +35,6 @@ namespace allocations {
 /**
  * @brief Parse XML file and print specific Domain Participant allocations configuration.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string XML section containing the allocations configuration.
@@ -45,13 +44,11 @@ namespace allocations {
  *        allocations configuration does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant remote locators limit.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string XML section with the remote locators limit configuration.
@@ -61,13 +58,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  *        remote locators configuration does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_remote_locators(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant remote unicast locators limit.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Remote unicast locators limit.
@@ -77,13 +72,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_remote_locators(
  *        remote unicast locators limit does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_remote_locators_max_unicast(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant remote multicast locators limit.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Remote multicast locators limit.
@@ -93,13 +86,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_remote_locators_max_unicas
  *        remote multicast locators limit does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_remote_locators_max_multicast(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant total participants limit.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string XML section with the total participants allocation configuration.
@@ -109,13 +100,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_remote_locators_max_multic
  *        total participants configuration does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_participants(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant initial participants (preallocated).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Initial number of preallocated participants.
@@ -125,13 +114,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_participants(
  *        initial participants configuration does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_participants_initial(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant maximum number of participants allowed.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Maximum number of participants.
@@ -141,14 +128,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_participants_initial
  *        maximum participants configuration does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_participants_maximum(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant number of allocated participants when the allocated
  *        memory is consumed.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Increment of participants.
@@ -158,13 +143,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_participants_maximum
  *        increment participants configuration does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_participants_increment(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant total readers limit.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string XML section with the total readers allocation configuration.
@@ -174,13 +157,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_participants_increme
  *        total readers configuration does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_readers(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant initial readers (preallocated).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Initial number of preallocated readers.
@@ -190,13 +171,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_readers(
  *        initial readers configuration does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_readers_initial(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant maximum number of readers allowed.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Maximum number of readers.
@@ -206,14 +185,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_readers_initial(
  *        maximum readers configuration does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_readers_maximum(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant number of allocated readers when the allocated memory is
  *        consumed.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Increment of readers.
@@ -223,13 +200,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_readers_maximum(
  *        increment readers configuration does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_readers_increment(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant total writers limit.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string XML section with the total writers allocation configuration.
@@ -239,13 +214,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_readers_increment(
  *        total writers configuration does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_writers(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant initial writers (preallocated).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Initial number of preallocated writers.
@@ -255,13 +228,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_writers(
  *        initial writers configuration does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_writers_initial(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant maximum number of writers allowed.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Maximum number of writers.
@@ -271,14 +242,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_writers_initial(
  *        maximum writers configuration does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_writers_maximum(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant number of allocated writers when the allocated memory is
  *        consumed.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Increment of writers.
@@ -288,13 +257,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_writers_maximum(
  *        increment writers configuration does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_writers_increment(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant maximum number of partitions.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Maximum number of partitions allowed in the Domain Participant.
@@ -304,13 +271,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_writers_increment(
  *        maximum number of partitions is not set.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_max_partitions(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant maximum size of user data message.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Maximum allowed size for user data message in the Domain Participant.
@@ -320,13 +285,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_max_partitions(
  *        maximum size is not set.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_max_user_data(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant maximum number of properties.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Maximum allowed number of properties in the Domain Participant.
@@ -336,13 +299,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_max_user_data(
  *        maximum property number is not set.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_max_properties(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant send buffers allocations configuration.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string XML section with the send buffers allocation configuration.
@@ -352,13 +313,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_max_properties(
  *        send buffers configuration does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_send_buffers(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant initially preallocated send buffers.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Number of send buffers preallocated.
@@ -368,13 +327,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_send_buffers(
  *        send buffers preallocations are not set.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_send_buffers_preallocated_number(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant send buffers dynamic flag.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Send buffers dynamic flag.
@@ -384,7 +341,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_send_buffers_preallocated_
  *        send buffers configuration flag is not set.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_send_buffers_dynamic(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /************************************************************************/
@@ -394,300 +350,254 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_send_buffers_dynamic(
 /**
  * @brief Remove allocations configuration in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove remote locators limit in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_remote_locators(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove remote unicast locators limit in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_remote_locators_max_unicast(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove remote multicast locators limit in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_remote_locators_max_multicast(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove remote multicast locators limit in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_remote_locators_max_multicast(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove total participants limit in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_participants(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove initial participants (preallocated) in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_participants_initial(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove maximum number of participants allowed in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_participants_maximum(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove participant increment configuration in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_participants_increment(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove total readers limit in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_readers(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove initial readers (preallocated) in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_readers_initial(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove maximum number of readers allowed in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_readers_maximum(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove readers increment configuration in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_readers_increment(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove total writers limit in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_writers(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove initial writers (preallocated) in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_writers_initial(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove maximum number of writers allowed in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_writers_maximum(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove writers increment configuration in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_writers_increment(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove maximum number of partitions in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_max_partitions(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove maximum size of user data message in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_max_user_data(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove maximum number of properties in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_max_properties(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove send buffers allocations configuration in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_send_buffers(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove initially preallocated send buffers configuration in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_send_buffers_preallocated_number(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove send buffers dynamic flag in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_send_buffers_preallocated_dynamic(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /************************************************************************/
@@ -697,56 +607,48 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_send_buffers_preallocated_dynamic
 /**
  * @brief Set the remote unicast locators limit in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] max_unicast Maximum number of allowed remote unicast locators.
  *
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_remote_locators_max_unicast(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& max_unicast);
 
 /**
  * @brief Set the remote multicast locators limit in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] max_multicast Maximum number of allowed remote multicast locators.
  *
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_remote_locators_max_multicast(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& max_multicast);
 
 /**
  * @brief Set the initial participants (preallocated) in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] initial Initial number of preallocated participants.
  *
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_participants_initial(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& initial);
 
 /**
  * @brief Set the maximum number of participants allowed in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] maximum Maximum number of participants.
  *
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_participants_maximum(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& maximum);
 
@@ -754,42 +656,36 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_participants_maximum(
  * @brief Set the number of allocated participants when the allocated memory is consumed in the Domain Participant
  *        profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] increment Increment of participants.
  *
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_participants_increment(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& increment);
 
 /**
  * @brief Set the initial readers (preallocated) in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] initial Initial number of preallocated readers.
  *
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_readers_initial(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& initial);
 
 /**
  * @brief Set the maximum number of readers allowed in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] maximum Maximum number of readers.
  *
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_readers_maximum(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& maximum);
 
@@ -797,42 +693,36 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_readers_maximum(
  * @brief Set the number of allocated readers when the allocated memory is consumed in the Domain Participant
  *        profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] increment Increment of readers.
  *
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_readers_increment(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& increment);
 
 /**
  * @brief Set the initial writers (preallocated) in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] initial Initial number of preallocated writers.
  *
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_writers_initial(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& initial);
 
 /**
  * @brief Set the maximum number of writers allowed in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] maximum Maximum number of writers.
  *
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_writers_maximum(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& maximum);
 
@@ -840,84 +730,72 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_writers_maximum(
  * @brief Set the number of allocated writers when the allocated memory is consumed in the Domain Participant
  *        profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] increment Increment of writers.
  *
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_total_writers_increment(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& increment);
 
 /**
  * @brief Set the maximum number of partitions in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] max_partitions Maximum number of partitions allowed in the Domain Participant.
  *
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_max_partitions(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& max_partitions);
 
 /**
  * @brief Set the maximum size of user data message in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] max_user_data Maximum allowed size for user data message in the Domain Participant.
  *
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_max_user_data(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& max_user_data);
 
 /**
  * @brief Set the maximum number of properties in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] max_properties Maximum allowed number of properties in the Domain Participant.
  *
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_max_properties(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& max_properties);
 
 /**
  * @brief Set the initially preallocated send buffers in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] send_buffers_preallocated_number Number of send buffers preallocated.
  *
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_send_buffers_preallocated_number(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& send_buffers_preallocated_number);
 
 /**
  * @brief Set the send buffers dynamic flag in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] send_buffers_dynamic Send buffers dynamic flag.
  *
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_send_buffers_dynamic(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& send_buffers_dynamic);
 

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/Allocation.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/Allocation.hpp
@@ -39,7 +39,7 @@ namespace allocations {
  *
  * @return std::string XML section containing the allocations configuration.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        allocations configuration does not exist.
  */
@@ -53,7 +53,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  *
  * @return std::string XML section with the remote locators limit configuration.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        remote locators configuration does not exist.
  */
@@ -67,7 +67,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_remote_locators(
  *
  * @return std::string Remote unicast locators limit.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        remote unicast locators limit does not exist.
  */
@@ -81,7 +81,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_remote_locators_max_unicas
  *
  * @return std::string Remote multicast locators limit.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        remote multicast locators limit does not exist.
  */
@@ -95,7 +95,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_remote_locators_max_multic
  *
  * @return std::string XML section with the total participants allocation configuration.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        total participants configuration does not exist.
  */
@@ -109,7 +109,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_participants(
  *
  * @return std::string Initial number of preallocated participants.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        initial participants configuration does not exist.
  */
@@ -123,7 +123,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_participants_initial
  *
  * @return std::string Maximum number of participants.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        maximum participants configuration does not exist.
  */
@@ -138,7 +138,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_participants_maximum
  *
  * @return std::string Increment of participants.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        increment participants configuration does not exist.
  */
@@ -152,7 +152,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_participants_increme
  *
  * @return std::string XML section with the total readers allocation configuration.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        total readers configuration does not exist.
  */
@@ -166,7 +166,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_readers(
  *
  * @return std::string Initial number of preallocated readers.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        initial readers configuration does not exist.
  */
@@ -180,7 +180,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_readers_initial(
  *
  * @return std::string Maximum number of readers.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        maximum readers configuration does not exist.
  */
@@ -195,7 +195,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_readers_maximum(
  *
  * @return std::string Increment of readers.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        increment readers configuration does not exist.
  */
@@ -209,7 +209,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_readers_increment(
  *
  * @return std::string XML section with the total writers allocation configuration.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        total writers configuration does not exist.
  */
@@ -223,7 +223,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_writers(
  *
  * @return std::string Initial number of preallocated writers.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        initial writers configuration does not exist.
  */
@@ -237,7 +237,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_writers_initial(
  *
  * @return std::string Maximum number of writers.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        maximum writers configuration does not exist.
  */
@@ -252,7 +252,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_writers_maximum(
  *
  * @return std::string Increment of writers.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        increment writers configuration does not exist.
  */
@@ -266,7 +266,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_total_writers_increment(
  *
  * @return std::string Maximum number of partitions allowed in the Domain Participant.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        maximum number of partitions is not set.
  */
@@ -280,7 +280,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_max_partitions(
  *
  * @return std::string Maximum allowed size for user data message in the Domain Participant.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        maximum size is not set.
  */
@@ -294,7 +294,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_max_user_data(
  *
  * @return std::string Maximum allowed number of properties in the Domain Participant.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        maximum property number is not set.
  */
@@ -308,7 +308,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_max_properties(
  *
  * @return std::string XML section with the send buffers allocation configuration.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        send buffers configuration does not exist.
  */
@@ -322,7 +322,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_send_buffers(
  *
  * @return std::string Number of send buffers preallocated.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        send buffers preallocations are not set.
  */
@@ -336,7 +336,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_send_buffers_preallocated_
  *
  * @return std::string Send buffers dynamic flag.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        send buffers configuration flag is not set.
  */
@@ -352,7 +352,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_send_buffers_dynamic(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
@@ -363,7 +363,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_remote_locators(
@@ -374,7 +374,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_remote_locators(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_remote_locators_max_unicast(
@@ -385,7 +385,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_remote_locators_max_unicast(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_remote_locators_max_multicast(
@@ -396,7 +396,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_remote_locators_max_multicast(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_remote_locators_max_multicast(
@@ -407,7 +407,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_remote_locators_max_multicast(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_participants(
@@ -418,7 +418,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_participants(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_participants_initial(
@@ -429,7 +429,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_participants_initial(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_participants_maximum(
@@ -440,7 +440,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_participants_maximum(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_participants_increment(
@@ -451,7 +451,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_participants_increment(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_readers(
@@ -462,7 +462,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_readers(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_readers_initial(
@@ -473,7 +473,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_readers_initial(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_readers_maximum(
@@ -484,7 +484,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_readers_maximum(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_readers_increment(
@@ -495,7 +495,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_readers_increment(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_writers(
@@ -506,7 +506,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_writers(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_writers_initial(
@@ -517,7 +517,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_writers_initial(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_writers_maximum(
@@ -528,7 +528,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_writers_maximum(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_writers_increment(
@@ -539,7 +539,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_total_writers_increment(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_max_partitions(
@@ -550,7 +550,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_max_partitions(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_max_user_data(
@@ -561,7 +561,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_max_user_data(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_max_properties(
@@ -572,7 +572,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_max_properties(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_send_buffers(
@@ -583,7 +583,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_send_buffers(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_send_buffers_preallocated_number(
@@ -594,7 +594,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_send_buffers_preallocated_number(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_send_buffers_preallocated_dynamic(

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DefaultExternalUnicastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DefaultExternalUnicastLocators.hpp
@@ -275,6 +275,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_mask(
  * @param[in] kind Default unicast locator kind.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -293,6 +294,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @param[in] port Default unicast locator port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -311,6 +313,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @param[in] address Default unicast locator IP address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -330,6 +333,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @param[in] externality Default unicast locator externality.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator externality is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -348,6 +352,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_externality(
  * @param[in] cost Default unicast locator cost.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator cost is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -366,6 +371,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_cost(
  * @param[in] mask Default unicast locator mask.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator mask is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DefaultExternalUnicastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DefaultExternalUnicastLocators.hpp
@@ -275,7 +275,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_mask(
  * @param[in] kind Default unicast locator kind.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -294,7 +293,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @param[in] port Default unicast locator port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -313,7 +311,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @param[in] address Default unicast locator IP address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -333,7 +330,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @param[in] externality Default unicast locator externality.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator externality is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -352,7 +348,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_externality(
  * @param[in] cost Default unicast locator cost.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator cost is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -371,7 +366,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_cost(
  * @param[in] mask Default unicast locator mask.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator mask is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DefaultExternalUnicastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DefaultExternalUnicastLocators.hpp
@@ -40,7 +40,7 @@ namespace default_external_unicast_locators {
  *
  * @return std::string XML section containing the Domain Participant specific default external unicast locator.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -57,7 +57,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  *
  * @return std::string Domain Participant specific default external unicast locator kind.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -74,7 +74,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
  *
  * @return std::string Domain Participant specific default external unicast locator port.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -91,7 +91,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
  *
  * @return std::string Domain Participant specific default external unicast locator IP address.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -109,7 +109,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
  *
  * @return std::string Domain Participant specific default external unicast locator externality.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -126,7 +126,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_externality(
  *
  * @return std::string Domain Participant specific default external unicast locator cost.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -143,7 +143,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_cost(
  *
  * @return std::string Domain Participant specific default external unicast locator mask.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -163,7 +163,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_mask(
  *
  * @return uint32_t Number of default external unicast locators in the list.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the list
  *        has not been set.
  */
@@ -180,7 +180,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete list is removed.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -195,7 +195,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -210,7 +210,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -225,7 +225,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -240,7 +240,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_externality(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -255,7 +255,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_cost(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -278,7 +278,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_mask(
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
@@ -296,7 +296,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
@@ -314,7 +314,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
@@ -333,7 +333,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @throw ElementInvalid Exception if the provided locator externality is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_externality(
@@ -351,7 +351,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_externality(
  * @throw ElementInvalid Exception if the provided locator cost is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_cost(
@@ -369,7 +369,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_cost(
  * @throw ElementInvalid Exception if the provided locator mask is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_mask(

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DefaultExternalUnicastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DefaultExternalUnicastLocators.hpp
@@ -35,7 +35,6 @@ namespace default_external_unicast_locators {
 /**
  * @brief Parse XML file and print the specific Domain Participant specific default external unicast locator.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed. If empty, the complete list is printed.
  *
@@ -47,14 +46,12 @@ namespace default_external_unicast_locators {
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the specific Domain Participant specific default external unicast locator kind.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -66,14 +63,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the specific Domain Participant specific default external unicast locator port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -85,14 +80,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the specific Domain Participant specific default external unicast locator IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -104,7 +97,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -112,7 +104,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
  * @brief Parse XML file and print the specific Domain Participant specific default external unicast locator
  *        externality.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -124,14 +115,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_externality(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the specific Domain Participant specific default external unicast locator cost.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -143,14 +132,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_externality(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_cost(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the specific Domain Participant specific default external unicast locator mask.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -162,7 +149,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_cost(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_mask(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -173,7 +159,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_mask(
 /**
  * @brief Number of default external unicast locators in the Domain Participant.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return uint32_t Number of default external unicast locators in the list.
@@ -183,7 +168,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_mask(
  *        has not been set.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /************************************************************************/
@@ -193,7 +177,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
 /**
  * @brief Remove specific Domain Participant default external unicast locator.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete list is removed.
  *
@@ -203,14 +186,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant default external unicast locator port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -220,14 +201,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant default external unicast locator IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -237,14 +216,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant default external unicast locator externality.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -254,14 +231,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_externality(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant default external unicast locator cost.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -271,14 +246,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_externality(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_cost(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant default external unicast locator mask.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -288,7 +261,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_cost(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_mask(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -299,7 +271,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_mask(
 /**
  * @brief Append a new default external unicast locator with specified kind or update the existing locator kind.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] kind Default unicast locator kind.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -311,7 +282,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_mask(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& kind,
         const std::string& index);
@@ -319,7 +289,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
 /**
  * @brief Append a default external unicast locator with specified port or update the existing locator port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] port Default unicast locator port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -331,7 +300,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& port,
         const std::string& index);
@@ -339,7 +307,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
 /**
  * @brief Append a default external unicast locator with specified IP address or update the existing locator IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] address Default unicast locator IP address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -351,7 +318,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& address,
         const std::string& index);
@@ -360,7 +326,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @brief Append a default external unicast locator with specified externality or update the existing locator
  *        externality.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] externality Default unicast locator externality.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -372,7 +337,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_externality(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& externality,
         const std::string& index);
@@ -380,7 +344,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_externality(
 /**
  * @brief Append a default external unicast locator with specified cost or update the existing locator cost.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] cost Default unicast locator cost.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -392,7 +355,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_externality(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_cost(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& cost,
         const std::string& index);
@@ -400,7 +362,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_cost(
 /**
  * @brief Append a default external unicast locator with specified mask or update the existing locator mask.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] mask Default unicast locator mask.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -412,7 +373,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_cost(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_mask(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& mask,
         const std::string& index);

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DefaultMulticastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DefaultMulticastLocators.hpp
@@ -40,7 +40,7 @@ namespace default_multicast_locators {
  *
  * @return std::string XML section containing the Domain Participant specific default multicast locator.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -57,7 +57,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  *
  * @return std::string Domain Participant specific default multicast locator kind.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -74,7 +74,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
  *
  * @return std::string Domain Participant specific default multicast locator port.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -92,7 +92,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
  *
  * @return std::string Domain Participant specific default multicast locator TCP physical port.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -109,7 +109,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_physical_port(
  *
  * @return std::string Domain Participant specific default multicast locator IP address.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -127,7 +127,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
  *
  * @return std::string Domain Participant specific default multicast locator TCPv4 unique LAN ID.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -145,7 +145,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_unique_lan_id(
  *
  * @return std::string Domain Participant specific default multicast locator TCPv4 WAN IP address.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -165,7 +165,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_address(
  *
  * @return uint32_t Number of default multicast locators in the list.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the list
  *        has not been set.
  */
@@ -182,7 +182,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete list is removed.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -197,7 +197,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -212,7 +212,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -227,7 +227,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_physical_port(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -242,7 +242,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -257,7 +257,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_unique_lan_id(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -280,7 +280,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
@@ -298,7 +298,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
@@ -317,7 +317,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @throw ElementInvalid Exception if the provided locator physical port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
@@ -335,7 +335,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
@@ -354,7 +354,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @throw ElementInvalid Exception if the provided locator identifier is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
@@ -372,7 +372,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_wan_address(

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DefaultMulticastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DefaultMulticastLocators.hpp
@@ -277,6 +277,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @param[in] kind Default multicast locator kind.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -295,6 +296,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @param[in] port Default multicast locator port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -314,6 +316,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @param[in] physical_port Default multicast locator TCP physical port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator physical port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -332,6 +335,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @param[in] address Default multicast locator IP address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -351,6 +355,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @param[in] unique_lan_id Default multicast TCPv4 locator unique LAN ID.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator identifier is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -369,6 +374,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @param[in] wan_address Default multicast TCPv4 locator WAN address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DefaultMulticastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DefaultMulticastLocators.hpp
@@ -277,7 +277,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @param[in] kind Default multicast locator kind.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -296,7 +295,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @param[in] port Default multicast locator port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -316,7 +314,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @param[in] physical_port Default multicast locator TCP physical port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator physical port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -335,7 +332,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @param[in] address Default multicast locator IP address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -355,7 +351,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @param[in] unique_lan_id Default multicast TCPv4 locator unique LAN ID.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator identifier is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -374,7 +369,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @param[in] wan_address Default multicast TCPv4 locator WAN address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DefaultMulticastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DefaultMulticastLocators.hpp
@@ -35,7 +35,6 @@ namespace default_multicast_locators {
 /**
  * @brief Parse XML file and print the specific Domain Participant specific default multicast locator.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed. If empty, the complete list is printed.
  *
@@ -47,14 +46,12 @@ namespace default_multicast_locators {
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the specific Domain Participant specific default multicast locator kind.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -66,14 +63,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the specific Domain Participant specific default multicast locator port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -85,7 +80,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -93,7 +87,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
  * @brief Parse XML file and print the specific Domain Participant specific default multicast locator physical port.
  *        TCP only.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -105,14 +98,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the specific Domain Participant specific default multicast locator IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -124,7 +115,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_physical_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -132,7 +122,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
  * @brief Parse XML file and print the specific Domain Participant specific default multicast locator unique LAN ID.
  *        TCPv4 only.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -144,7 +133,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -152,7 +140,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_unique_lan_id(
  * @brief Parse XML file and print the specific Domain Participant specific default multicast locator WAN IPv4 address.
  *        TCPv4 only.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -164,7 +151,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_unique_lan_id(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -175,7 +161,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_address(
 /**
  * @brief Number of default multicast locators in the Domain Participant.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return uint32_t Number of default multicast locators in the list.
@@ -185,7 +170,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_address(
  *        has not been set.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /************************************************************************/
@@ -195,7 +179,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
 /**
  * @brief Remove specific Domain Participant default multicast locator.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete list is removed.
  *
@@ -205,14 +188,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant default multicast locator port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -222,14 +203,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant default multicast locator physical port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -239,14 +218,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant default multicast locator IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -256,14 +233,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_physical_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant default multicast locator unique LAN ID.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -273,14 +248,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant default multicast locator WAN IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -290,7 +263,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_unique_lan_id(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -301,7 +273,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
 /**
  * @brief Append a default multicast locator with specified kind or update the existing locator kind.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] kind Default multicast locator kind.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -313,7 +284,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& kind,
         const std::string& index);
@@ -321,7 +291,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
 /**
  * @brief Append a default multicast locator with specified port or update the existing locator port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] port Default multicast locator port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -333,7 +302,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& port,
         const std::string& index);
@@ -342,7 +310,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @brief Append a default multicast locator with specified physical port or update the existing locator physical port
  *        (TCP only).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] physical_port Default multicast locator TCP physical port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -354,7 +321,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& physical_port,
         const std::string& index);
@@ -362,7 +328,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
 /**
  * @brief Append a default multicast locator with specified IP address or update the existing locator IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] address Default multicast locator IP address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -374,7 +339,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& address,
         const std::string& index);
@@ -383,7 +347,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @brief Append a default multicast TCPv4 locator with specified unique LAN ID or update the existing locator unique
  *        LAN ID.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] unique_lan_id Default multicast TCPv4 locator unique LAN ID.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -395,7 +358,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& unique_lan_id,
         const std::string& index);
@@ -403,7 +365,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
 /**
  * @brief Append a default multicast TCPv4 locator with specified WAN address or update the existing locator WAN address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] wan_address Default multicast TCPv4 locator WAN address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -415,7 +376,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& wan_address,
         const std::string& index);

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DefaultUnicastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DefaultUnicastLocators.hpp
@@ -277,6 +277,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @param[in] kind Default unicast locator kind.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -295,6 +296,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @param[in] port Default unicast locator port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -314,6 +316,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @param[in] physical_port Default unicast locator TCP physical port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator physical port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -332,6 +335,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @param[in] address Default unicast locator IP address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -351,6 +355,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @param[in] unique_lan_id Default unicast TCPv4 locator unique LAN ID.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator identifier is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -369,6 +374,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @param[in] wan_address Default unicast TCPv4 locator WAN address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DefaultUnicastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DefaultUnicastLocators.hpp
@@ -40,7 +40,7 @@ namespace default_unicast_locators {
  *
  * @return std::string XML section containing the Domain Participant specific default unicast locator.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -57,7 +57,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  *
  * @return std::string Domain Participant specific default unicast locator kind.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -74,7 +74,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
  *
  * @return std::string Domain Participant specific default unicast locator port.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -92,7 +92,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
  *
  * @return std::string Domain Participant specific default unicast locator TCP physical port.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -109,7 +109,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_physical_port(
  *
  * @return std::string Domain Participant specific default unicast locator IP address.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -127,7 +127,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
  *
  * @return std::string Domain Participant specific default unicast locator TCPv4 unique LAN ID.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -145,7 +145,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_unique_lan_id(
  *
  * @return std::string Domain Participant specific default unicast locator TCPv4 WAN IP address.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -165,7 +165,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_address(
  *
  * @return uint32_t Number of default unicast locators in the list.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the list
  *        has not been set.
  */
@@ -182,7 +182,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete list is removed.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -197,7 +197,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -212,7 +212,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -227,7 +227,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_physical_port(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -242,7 +242,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -257,7 +257,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_unique_lan_id(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -280,7 +280,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
@@ -298,7 +298,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
@@ -317,7 +317,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @throw ElementInvalid Exception if the provided locator physical port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
@@ -335,7 +335,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
@@ -354,7 +354,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @throw ElementInvalid Exception if the provided locator identifier is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
@@ -372,7 +372,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_wan_address(

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DefaultUnicastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DefaultUnicastLocators.hpp
@@ -35,7 +35,6 @@ namespace default_unicast_locators {
 /**
  * @brief Parse XML file and print the specific Domain Participant specific default unicast locator.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed. If empty, the complete list is printed.
  *
@@ -47,14 +46,12 @@ namespace default_unicast_locators {
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the specific Domain Participant specific default unicast locator kind.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -66,14 +63,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the specific Domain Participant specific default unicast locator port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -85,7 +80,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -93,7 +87,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
  * @brief Parse XML file and print the specific Domain Participant specific default unicast locator physical port.
  *        TCP only.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -105,14 +98,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the specific Domain Participant specific default unicast locator IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -124,7 +115,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_physical_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -132,7 +122,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
  * @brief Parse XML file and print the specific Domain Participant specific default unicast locator unique LAN ID.
  *        TCPv4 only.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -144,7 +133,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -152,7 +140,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_unique_lan_id(
  * @brief Parse XML file and print the specific Domain Participant specific default unicast locator WAN IPv4 address.
  *        TCPv4 only.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -164,7 +151,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_unique_lan_id(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -175,7 +161,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_address(
 /**
  * @brief Number of default unicast locators in the Domain Participant.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return uint32_t Number of default unicast locators in the list.
@@ -185,7 +170,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_address(
  *        has not been set.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /************************************************************************/
@@ -195,7 +179,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
 /**
  * @brief Remove specific Domain Participant default unicast locator.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete list is removed.
  *
@@ -205,14 +188,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant default unicast locator port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -222,14 +203,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant default unicast locator physical port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -239,14 +218,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant default unicast locator IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -256,14 +233,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_physical_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant default unicast locator unique LAN ID.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -273,14 +248,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant default unicast locator WAN IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -290,7 +263,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_unique_lan_id(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -301,7 +273,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
 /**
  * @brief Append a default unicast locator with specified kind or update the existing locator kind.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] kind Default unicast locator kind.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -313,7 +284,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& kind,
         const std::string& index);
@@ -321,7 +291,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
 /**
  * @brief Append a default unicast locator with specified port or update the existing locator port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] port Default unicast locator port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -333,7 +302,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& port,
         const std::string& index);
@@ -342,7 +310,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @brief Append a default unicast locator with specified physical port or update the existing locator physical port
  *        (TCP only).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] physical_port Default unicast locator TCP physical port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -354,7 +321,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& physical_port,
         const std::string& index);
@@ -362,7 +328,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
 /**
  * @brief Append a default unicast locator with specified IP address or update the existing locator IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] address Default unicast locator IP address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -374,7 +339,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& address,
         const std::string& index);
@@ -383,7 +347,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @brief Append a default unicast TCPv4 locator with specified unique LAN ID or update the existing locator unique
  *        LAN ID.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] unique_lan_id Default unicast TCPv4 locator unique LAN ID.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -395,7 +358,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& unique_lan_id,
         const std::string& index);
@@ -403,7 +365,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
 /**
  * @brief Append a default unicast TCPv4 locator with specified WAN address or update the existing locator WAN address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] wan_address Default unicast TCPv4 locator WAN address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -415,7 +376,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& wan_address,
         const std::string& index);

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DefaultUnicastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DefaultUnicastLocators.hpp
@@ -277,7 +277,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @param[in] kind Default unicast locator kind.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -296,7 +295,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @param[in] port Default unicast locator port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -316,7 +314,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @param[in] physical_port Default unicast locator TCP physical port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator physical port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -335,7 +332,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @param[in] address Default unicast locator IP address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -355,7 +351,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @param[in] unique_lan_id Default unicast TCPv4 locator unique LAN ID.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator identifier is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -374,7 +369,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @param[in] wan_address Default unicast TCPv4 locator WAN address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DomainParticipant.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DomainParticipant.hpp
@@ -39,7 +39,7 @@ namespace domain_participant {
  *
  * @return std::string XML section containing the specific Domain Participant profile.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
@@ -50,7 +50,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  *
  * @return std::string Domain Participant default profile.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if there is no default Domain Participant profile in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_default_profile();
@@ -62,7 +62,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_default_profile();
  *
  * @return std::string Domain Participant Domain ID.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        Domain ID has not been set in the profile.
  */
@@ -76,7 +76,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_domain_id(
  *
  * @return std::string Domain Participant name.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        name has not been set in the profile.
  */
@@ -90,7 +90,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_name(
  *
  * @return std::string Domain Participant ignore non matching locators flag.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        ignore non matching locators flag has not been set in the profile.
  */
@@ -104,7 +104,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_ignore_non_matching_locato
  *
  * @return std::string Domain Participant send socket buffer size.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        send socket buffer size has not been set in the profile.
  */
@@ -118,7 +118,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_send_socket_buffer_size(
  *
  * @return std::string Domain Participant listen socket buffer size.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        listen socket buffer size has not been set in the profile.
  */
@@ -132,7 +132,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_listen_socket_buffer_size(
  *
  * @return std::string Domain Participant ID.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        Domain Participant ID has not been set in the profile.
  */
@@ -147,7 +147,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_participant_id(
  *
  * @return std::string Domain Participant specific user transport.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -163,7 +163,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_user_transports(
  *
  * @return std::string Domain Participant use builtin trasports flag.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        use builtin trasports flag has not been set in the profile.
  */
@@ -178,7 +178,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_use_builtin_transports(
  *
  * @return std::string Domain Participant specific user data.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -194,7 +194,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_user_data(
  *
  * @return std::string Domain Participant GUID prefix.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        GUID prefix has not been set in the profile.
  */
@@ -210,7 +210,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_prefix(
  *
  * @return uint32_t Number of Domain Participant profiles in the XML file.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size();
 
@@ -220,7 +220,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size();
  * @return std::vector<std::string> Identifier list.
  *         Empty list if there are no Domain Participant profiles.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::vector<std::string> keys();
 
@@ -231,7 +231,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::vector<std::string> keys();
  *
  * @return uint32_t Number of user transports in the list.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t user_transports_size(
@@ -244,7 +244,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t user_transports_size(
  *
  * @return uint32_t Number of user data elements in the list.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t user_data_size(
@@ -259,7 +259,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t user_data_size(
  *
  * @param[in] profile_id Domain participant profile identifier. If empty, every Domain Participant profile is deleted.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
@@ -268,7 +268,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
 /**
  * @brief Remove the is_default_profile attribute from the default Domain Participant profile.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_default_profile();
 
@@ -277,7 +277,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_default_profile();
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_domain_id(
@@ -288,7 +288,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_domain_id(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_name(
@@ -299,7 +299,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_name(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_ignore_non_matching_locators(
@@ -310,7 +310,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_ignore_non_matching_locators(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_send_socket_buffer_size(
@@ -321,7 +321,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_send_socket_buffer_size(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_listen_socket_buffer_size(
@@ -332,7 +332,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_listen_socket_buffer_size(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_participant_id(
@@ -344,7 +344,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_participant_id(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete collection is erased.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection if an index is provided.
  * @throw BadParameter Exception if the index is not an integer.
@@ -358,7 +358,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_user_transports(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_use_builtin_transports(
@@ -370,7 +370,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_use_builtin_transports(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete collection is erased.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection if an index is provided.
  * @throw BadParameter Exception if the index is not an integer.
@@ -384,7 +384,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_user_data(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_prefix(
@@ -401,7 +401,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_prefix(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_default_profile(
@@ -517,7 +517,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_prefix(
  * @throw ElementInvalid Exception if the provided Transport descriptor profile identifier is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_user_transports(
@@ -535,7 +535,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_user_transports(
  * @throw ElementInvalid Exception if the provided user data is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_user_data(

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DomainParticipant.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DomainParticipant.hpp
@@ -35,7 +35,6 @@ namespace domain_participant {
 /**
  * @brief Parse XML file and print specific Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier. If empty every Domain Participant profile is printed.
  *
  * @return std::string XML section containing the specific Domain Participant profile.
@@ -44,26 +43,21 @@ namespace domain_participant {
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print the name of the Domain Participant default profile.
- *
- * @param[in] xml_file Absolute/relative path to the XML file.
  *
  * @return std::string Domain Participant default profile.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if there is no default Domain Participant profile in the XML file.
  */
-FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_default_profile(
-        const std::string& xml_file);
+FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_default_profile();
 
 /**
  * @brief Parse XML file and print the Domain Participant Domain ID.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant Domain ID.
@@ -73,13 +67,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_default_profile(
  *        Domain ID has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_domain_id(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print the Domain Participant name.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant name.
@@ -89,13 +81,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_domain_id(
  *        name has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_name(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print the Domain Participant ignore non matching locators flag.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant ignore non matching locators flag.
@@ -105,13 +95,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_name(
  *        ignore non matching locators flag has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_ignore_non_matching_locators(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print the Domain Participant send socket buffer size.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant send socket buffer size.
@@ -121,13 +109,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_ignore_non_matching_locato
  *        send socket buffer size has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_send_socket_buffer_size(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print the Domain Participant listen socket buffer size.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant listen socket buffer size.
@@ -137,13 +123,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_send_socket_buffer_size(
  *        listen socket buffer size has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_listen_socket_buffer_size(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print the Domain Participant ID.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant ID.
@@ -153,13 +137,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_listen_socket_buffer_size(
  *        Domain Participant ID has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_participant_id(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print the Domain Participant specific user transport element.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed. If empty, the complete collection is printed.
  *
@@ -171,14 +153,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_participant_id(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_user_transports(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the Domain Participant use builtin trasports flag.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant use builtin trasports flag.
@@ -188,13 +168,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_user_transports(
  *        use builtin trasports flag has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_use_builtin_transports(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print the Domain Participant specific user data element.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed. If empty, the complete collection is printed.
  *
@@ -206,14 +184,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_use_builtin_transports(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_user_data(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the Domain Participant GUID prefix.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant GUID prefix.
@@ -223,7 +199,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_user_data(
  *        GUID prefix has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_prefix(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /************************************************************************/
@@ -233,32 +208,25 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_prefix(
 /**
  * @brief Number of Domain Participant profiles contained in the XML file.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
- *
  * @return uint32_t Number of Domain Participant profiles in the XML file.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  */
-FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
-        const std::string& xml_file);
+FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size();
 
 /**
  * @brief List of the identifiers for every Domain Participant profile in the XML file.
- *
- * @param[in] xml_file Absolute/relative path to the XML file.
  *
  * @return std::vector<std::string> Identifier list.
  *         Empty list if there are no Domain Participant profiles.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  */
-FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::vector<std::string> keys(
-        const std::string& xml_file);
+FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::vector<std::string> keys();
 
 /**
  * @brief Number of user transports in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return uint32_t Number of user transports in the list.
@@ -267,13 +235,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::vector<std::string> keys(
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t user_transports_size(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Number of user data elements in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return uint32_t Number of user data elements in the list.
@@ -282,7 +248,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t user_transports_size(
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t user_data_size(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /************************************************************************/
@@ -292,108 +257,90 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t user_data_size(
 /**
  * @brief Remove specific Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier. If empty, every Domain Participant profile is deleted.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove the is_default_profile attribute from the default Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
- *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  */
-FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_default_profile(
-        const std::string& xml_file);
+FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_default_profile();
 
 /**
  * @brief Remove Domain ID from specific Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_domain_id(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove Domain Participant name from specific Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_name(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove ignore non matching locators flag from specific Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_ignore_non_matching_locators(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove send socket buffer size from specific Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_send_socket_buffer_size(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove listen socket buffer size from specific Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_listen_socket_buffer_size(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove Domain Participant ID from specific Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_participant_id(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific user transport from specific Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete collection is erased.
  *
@@ -403,27 +350,23 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_participant_id(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_user_transports(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove use builtin transports flag from specific Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_use_builtin_transports(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific user data from specific Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete collection is erased.
  *
@@ -433,21 +376,18 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_use_builtin_transports(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_user_data(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove GUID prefix from specific Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_prefix(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /************************************************************************/
@@ -459,125 +399,107 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_prefix(
  *        As only one default profile is allowed, if another default profile exists, it is overriden and the
  *        is_default_profile attribute is removed.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_default_profile(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Set the Domain Participant domain ID.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] domain_id Domain Participant domain ID.
  *
  * @throw ElementInvalid Exception if the provided domain ID is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_domain_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& domain_id);
 
 /**
  * @brief Set the Domain Participant name.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] name Domain Participant name.
  *
  * @throw ElementInvalid Exception if the provided name is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_name(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& name);
 
 /**
  * @brief Set the Domain Participant ignore non matching locators flag.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] ignore_non_matching_locators Ignore non matching locators flag.
  *
  * @throw ElementInvalid Exception if the provided flag value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_ignore_non_matching_locators(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& ignore_non_matching_locators);
 
 /**
  * @brief Set the Domain Participant send socket buffer size.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] send_socket_buffer_size Size of the buffer in the socket used for sending data.
  *
  * @throw ElementInvalid Exception if the provided size is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_send_socket_buffer_size(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& send_socket_buffer_size);
 
 /**
  * @brief Set the Domain Participant listen socket buffer size.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] listen_socket_buffer_size Size of the buffer in the socket used for listening data.
  *
  * @throw ElementInvalid Exception if the provided size is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_listen_socket_buffer_size(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& listen_socket_buffer_size);
 
 /**
  * @brief Set the Domain Participant ID.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] participant_id Domain Participant ID.
  *
  * @throw ElementInvalid Exception if the provided ID is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_participant_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& participant_id);
 
 /**
  * @brief Set the Domain Participant use builtin transports flag.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] use_builtin_transports Use builtin transports flag.
  *
  * @throw ElementInvalid Exception if the provided flag value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_use_builtin_transports(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& use_builtin_transports);
 
 /**
  * @brief Set the Domain Participant GUID prefix.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Domain Participant GUID prefix.
  *
  * @throw ElementInvalid Exception if the provided GUID prefix is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_prefix(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix);
 
@@ -588,7 +510,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_prefix(
 /**
  * @brief Append a user transport to the collection or update user transport element in the collection.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] transport_id Transport descriptor profile identifier.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -600,7 +521,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_prefix(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_user_transports(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& transport_id,
         const std::string& index);
@@ -608,7 +528,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_user_transports(
 /**
  * @brief Append user data or update specific user data.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] user_data User data to be updated.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -620,7 +539,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_user_transports(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_user_data(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& user_data,
         const std::string& index);

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DomainParticipant.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DomainParticipant.hpp
@@ -413,6 +413,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_default_profile(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] domain_id Domain Participant domain ID.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided domain ID is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_domain_id(
@@ -425,6 +426,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_domain_id(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] name Domain Participant name.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided name is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_name(
@@ -437,6 +439,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_name(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] ignore_non_matching_locators Ignore non matching locators flag.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided flag value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_ignore_non_matching_locators(
@@ -449,6 +452,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_ignore_non_matching_locators(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] send_socket_buffer_size Size of the buffer in the socket used for sending data.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided size is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_send_socket_buffer_size(
@@ -461,6 +465,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_send_socket_buffer_size(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] listen_socket_buffer_size Size of the buffer in the socket used for listening data.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided size is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_listen_socket_buffer_size(
@@ -473,6 +478,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_listen_socket_buffer_size(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] participant_id Domain Participant ID.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided ID is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_participant_id(
@@ -485,6 +491,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_participant_id(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] use_builtin_transports Use builtin transports flag.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided flag value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_use_builtin_transports(
@@ -497,6 +504,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_use_builtin_transports(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Domain Participant GUID prefix.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided GUID prefix is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_prefix(
@@ -514,6 +522,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_prefix(
  * @param[in] transport_id Transport descriptor profile identifier.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided Transport descriptor profile identifier is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -532,6 +541,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_user_transports(
  * @param[in] user_data User data to be updated.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided user data is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DomainParticipant.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/DomainParticipant.hpp
@@ -522,7 +522,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_prefix(
  * @param[in] transport_id Transport descriptor profile identifier.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided Transport descriptor profile identifier is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -541,7 +540,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_user_transports(
  * @param[in] user_data User data to be updated.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided user data is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/Port.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/Port.hpp
@@ -39,7 +39,7 @@ namespace port {
  *
  * @return std::string XML section containing the port parameters configuration.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        port parameters configuration element does not exist.
  */
@@ -53,7 +53,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  *
  * @return std::string Base port parameter.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        base port parameter has not been set.
  */
@@ -67,7 +67,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_base(
  *
  * @return std::string Domain ID gain port parameter.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        domain ID gain port parameter has not been set.
  */
@@ -81,7 +81,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_domain_id_gain(
  *
  * @return std::string Participant ID gain port parameter.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        participant ID gain port parameter has not been set.
  */
@@ -95,7 +95,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_participant_id_gain(
  *
  * @return std::string Multicast metadata offset port parameter.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        multicast metadata offset port parameter has not been set.
  */
@@ -109,7 +109,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_offset_d0(
  *
  * @return std::string Unicast metadata offset port parameter.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        unicast metadata offset port parameter has not been set.
  */
@@ -123,7 +123,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_offset_d1(
  *
  * @return std::string Multicast user data offset port parameter.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        multicast user data offset port parameter has not been set.
  */
@@ -137,7 +137,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_offset_d2(
  *
  * @return std::string Unicast user data offset port parameter.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        user data metadata offset port parameter has not been set.
  */
@@ -153,7 +153,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_offset_d3(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
@@ -164,7 +164,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_base(
@@ -175,7 +175,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_base(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_domain_id_gain(
@@ -186,7 +186,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_domain_id_gain(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_participant_id_gain(
@@ -197,7 +197,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_participant_id_gain(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_offset_d0(
@@ -208,7 +208,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_offset_d0(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_offset_d1(
@@ -219,7 +219,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_offset_d1(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_offset_d2(
@@ -230,7 +230,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_offset_d2(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_offset_d3(

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/Port.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/Port.hpp
@@ -35,7 +35,6 @@ namespace port {
 /**
  * @brief Parse XML file and print specific Domain Participant port parameters configuration.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string XML section containing the port parameters configuration.
@@ -45,13 +44,11 @@ namespace port {
  *        port parameters configuration element does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant base port parameter.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Base port parameter.
@@ -61,13 +58,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  *        base port parameter has not been set.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_base(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant domain ID gain port parameter.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain ID gain port parameter.
@@ -77,13 +72,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_base(
  *        domain ID gain port parameter has not been set.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_domain_id_gain(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant participant ID gain port parameter.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Participant ID gain port parameter.
@@ -93,13 +86,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_domain_id_gain(
  *        participant ID gain port parameter has not been set.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_participant_id_gain(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant multicast metadata offset port parameter.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Multicast metadata offset port parameter.
@@ -109,13 +100,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_participant_id_gain(
  *        multicast metadata offset port parameter has not been set.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_offset_d0(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant unicast metadata offset port parameter.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Unicast metadata offset port parameter.
@@ -125,13 +114,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_offset_d0(
  *        unicast metadata offset port parameter has not been set.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_offset_d1(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant multicast user data offset port parameter.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Multicast user data offset port parameter.
@@ -141,13 +128,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_offset_d1(
  *        multicast user data offset port parameter has not been set.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_offset_d2(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant unicast user data offset port parameter.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Unicast user data offset port parameter.
@@ -157,7 +142,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_offset_d2(
  *        user data metadata offset port parameter has not been set.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_offset_d3(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /************************************************************************/
@@ -167,105 +151,89 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_offset_d3(
 /**
  * @brief Remove specific Domain Participant port parameters configuration.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant base port parameter.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_base(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant domain ID gain port parameter.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_domain_id_gain(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant participant ID gain port parameter.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_participant_id_gain(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant multicast metadata offset port parameter.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_offset_d0(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant unicast metadata offset port parameter.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_offset_d1(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant multicast user data offset port parameter.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_offset_d2(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant unicast user data offset port parameter.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_offset_d3(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /************************************************************************/
@@ -275,98 +243,84 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_offset_d3(
 /**
  * @brief Set the Domain Participant base port parameter.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] port_base Base port parameter.
  *
  * @throw ElementInvalid Exception if the provided parameter value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_base(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& port_base);
 
 /**
  * @brief Set the Domain Participant domain ID gain port parameter.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] domain_id_gain Domain ID gain port parameter.
  *
  * @throw ElementInvalid Exception if the provided parameter value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_domain_id_gain(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& domain_id_gain);
 
 /**
  * @brief Set the Domain Participant participant ID gain port parameter.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] participant_id_gain Participant ID gain port parameter.
  *
  * @throw ElementInvalid Exception if the provided parameter value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_participant_id_gain(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& participant_id_gain);
 
 /**
  * @brief Set the Domain Participant multicast metadata offset port parameter.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] offset_d0 Multicast metadata offset port parameter.
  *
  * @throw ElementInvalid Exception if the provided parameter value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_offset_d0(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& offset_d0);
 
 /**
  * @brief Set the Domain Participant unicast metadata offset port parameter.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] offset_d1 Unicast metadata offset port parameter.
  *
  * @throw ElementInvalid Exception if the provided parameter value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_offset_d1(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& offset_d1);
 
 /**
  * @brief Set the Domain Participant multicast user data offset port parameter.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] offset_d2 Multicast user data offset port parameter.
  *
  * @throw ElementInvalid Exception if the provided parameter value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_offset_d2(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& offset_d2);
 
 /**
  * @brief Set the Domain Participant unicast user data offset port parameter.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] offset_d3 Unicast user data offset port parameter.
  *
  * @throw ElementInvalid Exception if the provided parameter value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_offset_d3(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& offset_d3);
 

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/Port.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/Port.hpp
@@ -246,6 +246,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_offset_d3(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] port_base Base port parameter.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided parameter value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_base(
@@ -258,6 +259,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_base(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] domain_id_gain Domain ID gain port parameter.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided parameter value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_domain_id_gain(
@@ -270,6 +272,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_domain_id_gain(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] participant_id_gain Participant ID gain port parameter.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided parameter value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_participant_id_gain(
@@ -282,6 +285,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_participant_id_gain(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] offset_d0 Multicast metadata offset port parameter.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided parameter value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_offset_d0(
@@ -294,6 +298,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_offset_d0(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] offset_d1 Unicast metadata offset port parameter.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided parameter value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_offset_d1(
@@ -306,6 +311,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_offset_d1(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] offset_d2 Multicast user data offset port parameter.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided parameter value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_offset_d2(
@@ -318,6 +324,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_offset_d2(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] offset_d3 Unicast user data offset port parameter.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided parameter value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_offset_d3(

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/PropertiesPolicy.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/PropertiesPolicy.hpp
@@ -36,7 +36,6 @@ namespace properties_policy {
 /**
  * @brief Parse XML file and print specific Domain Participant property in the policy list.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] property_id Property name to be printed. If empty, print the complete property policy list.
  *
@@ -47,14 +46,12 @@ namespace properties_policy {
  *        file or the properties policy element does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& property_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant property value in the policy list.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] property_id Property name which value is printed.
  *
@@ -65,14 +62,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  *        file or the properties policy element does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_value(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& property_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant property propagate attribute in the policy list.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] property_id Property name which propagate attribute is printed.
  *
@@ -83,7 +78,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_value(
  *        file or the properties policy element does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_propagate(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& property_id);
 
@@ -94,7 +88,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_propagate(
 /**
  * @brief Number of properties defined in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return uint32_t Number of properties.
@@ -103,13 +96,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_propagate(
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief List of the property names defined in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::vector<std::string> Identifier list.
@@ -119,7 +110,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::vector<std::string> keys(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /************************************************************************/
@@ -129,7 +119,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::vector<std::string> keys(
 /**
  * @brief Remove specific property in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] property_id Property name to be removed. If empty, every property is removed from the profile.
  *
@@ -137,14 +126,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::vector<std::string> keys(
  * @throw ElementNotFound Exception if the specified Domain Participant profile/Property is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& property_id);
 
 /**
  * @brief Remove specific property value in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] property_id Property name which value is to be removed.
  *
@@ -152,14 +139,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
  * @throw ElementNotFound Exception if the specified Domain Participant profile/Property is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_value(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& property_id);
 
 /**
  * @brief Remove specific property propagate attribute in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] property_id Property name which propagate attribute is to be removed.
  *
@@ -167,7 +152,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_value(
  * @throw ElementNotFound Exception if the specified Domain Participant profile/Property is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_propagate(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& property_id);
 
@@ -178,7 +162,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_propagate(
 /**
  * @brief Set the property value in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] property_id Property name which value is being set/updated.
  * @param[in] value New property value.
@@ -186,7 +169,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_propagate(
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_value(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& property_id,
         const std::string& value);
@@ -194,7 +176,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_value(
 /**
  * @brief Set the property propagate attribute in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] property_id Property name which value is being set/updated.
  * @param[in] propagate New propagate value.
@@ -202,7 +183,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_value(
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_propagate(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& property_id,
         const std::string& propagate);
@@ -214,14 +194,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_propagate(
 /**
  * @brief Append a new property with empty value to the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] property_id Property name.
  *
  * @throw ElementInvalid Exception if the provided property name is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void push(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& property_id);
 

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/PropertiesPolicy.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/PropertiesPolicy.hpp
@@ -41,7 +41,7 @@ namespace properties_policy {
  *
  * @return std::string XML section containing the specific property.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/Property name is not found in the XML
  *        file or the properties policy element does not exist.
  */
@@ -57,7 +57,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  *
  * @return std::string Property value.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/Property name is not found in the XML
  *        file or the properties policy element does not exist.
  */
@@ -73,7 +73,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_value(
  *
  * @return std::string Property propagate attribute.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/Property name is not found in the XML
  *        file or the properties policy element does not exist.
  */
@@ -92,7 +92,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_propagate(
  *
  * @return uint32_t Number of properties.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
@@ -106,7 +106,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
  * @return std::vector<std::string> Identifier list.
  *         Empty list if there are no properties.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::vector<std::string> keys(
@@ -122,7 +122,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::vector<std::string> keys(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] property_id Property name to be removed. If empty, every property is removed from the profile.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/Property is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
@@ -135,7 +135,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] property_id Property name which value is to be removed.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/Property is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_value(
@@ -148,7 +148,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_value(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] property_id Property name which propagate attribute is to be removed.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/Property is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_propagate(

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/PropertiesPolicy.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/PropertiesPolicy.hpp
@@ -166,6 +166,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_propagate(
  * @param[in] property_id Property name which value is being set/updated.
  * @param[in] value New property value.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_value(
@@ -180,6 +181,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_value(
  * @param[in] property_id Property name which value is being set/updated.
  * @param[in] propagate New propagate value.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_propagate(
@@ -197,6 +199,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_propagate(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] property_id Property name.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided property name is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void push(

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/Builtin.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/Builtin.hpp
@@ -35,7 +35,6 @@ namespace builtin {
 /**
  * @brief Parse XML file and print specific Domain Participant builtin configuration.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string XML section containing the specific Domain Participant builtin configuration.
@@ -45,13 +44,11 @@ namespace builtin {
  *        builtin element does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant builtin avoid_builtin_multicast flag.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant specific avoid_builtin_multicast flag.
@@ -61,13 +58,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  *        corresponding builtin flag does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_avoid_builtin_multicast(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant builtin use writer liveliness protocol flag.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant specific use writer liveliness protocol flag.
@@ -77,13 +72,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_avoid_builtin_multicast(
  *        corresponding builtin flag does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_use_writer_liveliness_protocol(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant builtin DataReaders History Memory Policy.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant builtin DataReaders History Memory Policy.
@@ -93,13 +86,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_use_writer_liveliness_prot
  *        corresponding builtin History Memory Policy does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_reader_history_memory_policy(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant builtin DataWriters History Memory Policy.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant builtin DataWriters History Memory Policy.
@@ -109,13 +100,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_reader_history_memory_poli
  *        corresponding builtin History Memory Policy does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_writer_history_memory_policy(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant builtin DataReaders payload size.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant builtin DataReaders payload size.
@@ -125,13 +114,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_writer_history_memory_poli
  *        corresponding builtin payload size element does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_reader_payload_size(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant builtin DataWriters payload size.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant builtin DataWriters payload size.
@@ -141,14 +128,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_reader_payload_size(
  *        corresponding builtin payload size element does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_writer_payload_size(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant builtin number of physical ports to try if configured
  *        port is already in use (mutation tries).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant builtin mutation tries.
@@ -158,7 +143,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_writer_payload_size(
  *        builtin mutation tries element does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_mutation_tries(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /************************************************************************/
@@ -168,105 +152,89 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_mutation_tries(
 /**
  * @brief Remove specific Domain Participant builtin configuration.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant builtin avoid_builtin_multicast flag.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_avoid_builtin_multicast(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant builtin use writer liveliness protocol flag.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_use_writer_liveliness_protocol(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant builtin DataReaders History Memory Policy.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_reader_history_memory_policy(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant builtin DataWriters History Memory Policy.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_writer_history_memory_policy(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant builtin DataReaders payload size.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_reader_payload_size(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant builtin DataWriters payload size.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_witer_payload_size(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant builtin DataWriters mutation tries.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_mutation_tries(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /************************************************************************/
@@ -276,98 +244,84 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_mutation_tries(
 /**
  * @brief Set the Domain Participant builtin avoid_builtin_multicast flag.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] avoid_builtin_multicast Builtin avoid_builtin_multicast flag.
  *
  * @throw ElementInvalid Exception if the provided flag value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_avoid_builtin_multicast(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& avoid_builtin_multicast);
 
 /**
  * @brief Set the Domain Participant builtin use writer liveliness protocol flag.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] use_writer_liveliness_protocol Builtin use writer liveliness protocol flag.
  *
  * @throw ElementInvalid Exception if the provided flag value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_use_writer_liveliness_protocol(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& use_writer_liveliness_protocol);
 
 /**
  * @brief Set the Domain Participant builtin DataReaders History Memory Policy.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] reader_history_memory_policy Builtin DataReaders History Memory Policy.
  *
  * @throw ElementInvalid Exception if the provided Memory Policy value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_reader_history_memory_policy(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& reader_history_memory_policy);
 
 /**
  * @brief Set the Domain Participant builtin DataWriters History Memory Policy.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] writer_history_memory_policy Builtin DataWriters History Memory Policy.
  *
  * @throw ElementInvalid Exception if the provided Memory Policy value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_writer_history_memory_policy(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& writer_history_memory_policy);
 
 /**
  * @brief Set the Domain Participant builtin DataReaders payload size.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] reader_payload_size Builtin DataReaders payload size.
  *
  * @throw ElementInvalid Exception if the provided payload size value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_reader_payload_size(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& reader_payload_size);
 
 /**
  * @brief Set the Domain Participant builtin DataWriters payload size.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] writer_payload_size Builtin DataWriters payload size.
  *
  * @throw ElementInvalid Exception if the provided payload size value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_writer_payload_size(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& writer_payload_size);
 
 /**
  * @brief Set the Domain Participant builtin mutation tries.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] mutation_tries Builtin mutation tries.
  *
  * @throw ElementInvalid Exception if the provided mutation tries value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_mutation_tries(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& mutation_tries);
 

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/Builtin.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/Builtin.hpp
@@ -247,6 +247,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_mutation_tries(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] avoid_builtin_multicast Builtin avoid_builtin_multicast flag.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided flag value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_avoid_builtin_multicast(
@@ -259,6 +260,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_avoid_builtin_multicast(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] use_writer_liveliness_protocol Builtin use writer liveliness protocol flag.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided flag value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_use_writer_liveliness_protocol(
@@ -271,6 +273,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_use_writer_liveliness_protocol(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] reader_history_memory_policy Builtin DataReaders History Memory Policy.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided Memory Policy value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_reader_history_memory_policy(
@@ -283,6 +286,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_reader_history_memory_policy(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] writer_history_memory_policy Builtin DataWriters History Memory Policy.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided Memory Policy value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_writer_history_memory_policy(
@@ -295,6 +299,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_writer_history_memory_policy(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] reader_payload_size Builtin DataReaders payload size.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided payload size value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_reader_payload_size(
@@ -307,6 +312,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_reader_payload_size(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] writer_payload_size Builtin DataWriters payload size.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided payload size value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_writer_payload_size(
@@ -319,6 +325,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_writer_payload_size(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] mutation_tries Builtin mutation tries.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided mutation tries value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_mutation_tries(

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/Builtin.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/Builtin.hpp
@@ -39,7 +39,7 @@ namespace builtin {
  *
  * @return std::string XML section containing the specific Domain Participant builtin configuration.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        builtin element does not exist.
  */
@@ -53,7 +53,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  *
  * @return std::string Domain Participant specific avoid_builtin_multicast flag.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        corresponding builtin flag does not exist.
  */
@@ -67,7 +67,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_avoid_builtin_multicast(
  *
  * @return std::string Domain Participant specific use writer liveliness protocol flag.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        corresponding builtin flag does not exist.
  */
@@ -81,7 +81,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_use_writer_liveliness_prot
  *
  * @return std::string Domain Participant builtin DataReaders History Memory Policy.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        corresponding builtin History Memory Policy does not exist.
  */
@@ -95,7 +95,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_reader_history_memory_poli
  *
  * @return std::string Domain Participant builtin DataWriters History Memory Policy.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        corresponding builtin History Memory Policy does not exist.
  */
@@ -109,7 +109,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_writer_history_memory_poli
  *
  * @return std::string Domain Participant builtin DataReaders payload size.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        corresponding builtin payload size element does not exist.
  */
@@ -123,7 +123,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_reader_payload_size(
  *
  * @return std::string Domain Participant builtin DataWriters payload size.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        corresponding builtin payload size element does not exist.
  */
@@ -138,7 +138,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_writer_payload_size(
  *
  * @return std::string Domain Participant builtin mutation tries.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        builtin mutation tries element does not exist.
  */
@@ -154,7 +154,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_mutation_tries(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
@@ -165,7 +165,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_avoid_builtin_multicast(
@@ -176,7 +176,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_avoid_builtin_multicast(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_use_writer_liveliness_protocol(
@@ -187,7 +187,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_use_writer_liveliness_protocol(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_reader_history_memory_policy(
@@ -198,7 +198,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_reader_history_memory_policy(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_writer_history_memory_policy(
@@ -209,7 +209,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_writer_history_memory_policy(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_reader_payload_size(
@@ -220,7 +220,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_reader_payload_size(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_witer_payload_size(
@@ -231,7 +231,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_witer_payload_size(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_mutation_tries(

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/InitialPeers.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/InitialPeers.hpp
@@ -41,7 +41,7 @@ namespace initial_peers {
  *
  * @return std::string XML section containing the Domain Participant specific builtin initial peers.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -58,7 +58,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  *
  * @return std::string Domain Participant specific builtin initial peers kind.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -75,7 +75,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
  *
  * @return std::string Domain Participant specific builtin initial peers port.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -94,7 +94,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
  *
  * @return std::string Domain Participant specific builtin initial peers TCP physical port.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -112,7 +112,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_physical_port(
  *
  * @return std::string Domain Participant specific builtin initial peers IP address.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -131,7 +131,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
  *
  * @return std::string Domain Participant specific builtin initial peers TCPv4 unique LAN ID.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -150,7 +150,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_unique_lan_id(
  *
  * @return std::string Domain Participant specific builtin initial peers TCPv4 WAN IP address.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -170,7 +170,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_address(
  *
  * @return uint32_t Number of builtin initial peerss in the list.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the list
  *        has not been set.
  */
@@ -187,7 +187,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete list is removed.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -202,7 +202,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -217,7 +217,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -232,7 +232,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_physical_port(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -247,7 +247,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -262,7 +262,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_unique_lan_id(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -285,7 +285,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
@@ -303,7 +303,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
@@ -322,7 +322,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @throw ElementInvalid Exception if the provided locator physical port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
@@ -340,7 +340,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
@@ -359,7 +359,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @throw ElementInvalid Exception if the provided locator identifier is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
@@ -378,7 +378,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_wan_address(

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/InitialPeers.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/InitialPeers.hpp
@@ -282,7 +282,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @param[in] kind Initial peers kind.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -301,7 +300,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @param[in] port Initial peers port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -321,7 +319,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @param[in] physical_port Initial peers TCP physical port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator physical port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -340,7 +337,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @param[in] address Initial peers IP address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -360,7 +356,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @param[in] unique_lan_id Initial peers TCPv4 locator unique LAN ID.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator identifier is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -380,7 +375,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @param[in] wan_address Initial peers TCPv4 locator WAN address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/InitialPeers.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/InitialPeers.hpp
@@ -282,6 +282,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @param[in] kind Initial peers kind.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -300,6 +301,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @param[in] port Initial peers port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -319,6 +321,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @param[in] physical_port Initial peers TCP physical port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator physical port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -337,6 +340,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @param[in] address Initial peers IP address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -356,6 +360,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @param[in] unique_lan_id Initial peers TCPv4 locator unique LAN ID.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator identifier is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -375,6 +380,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @param[in] wan_address Initial peers TCPv4 locator WAN address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/InitialPeers.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/InitialPeers.hpp
@@ -36,7 +36,6 @@ namespace initial_peers {
 /**
  * @brief Parse XML file and print the specific Domain Participant specific builtin initial peers.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed. If empty, the complete list is printed.
  *
@@ -48,14 +47,12 @@ namespace initial_peers {
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the specific Domain Participant specific builtin initial peers kind.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -67,14 +64,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the specific Domain Participant specific builtin initial peers port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -86,7 +81,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -95,7 +89,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
  *        port.
  *        TCP only.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -107,7 +100,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -115,7 +107,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_physical_port(
  * @brief Parse XML file and print the specific Domain Participant specific builtin initial peers IP
  *        address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -127,7 +118,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_physical_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -136,7 +126,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
  *        LAN ID.
  *        TCPv4 only.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -148,7 +137,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -157,7 +145,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_unique_lan_id(
  *        address.
  *        TCPv4 only.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -169,7 +156,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_unique_lan_id(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -180,7 +166,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_address(
 /**
  * @brief Number of builtin initial peerss in the Domain Participant.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return uint32_t Number of builtin initial peerss in the list.
@@ -190,7 +175,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_address(
  *        has not been set.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /************************************************************************/
@@ -200,7 +184,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
 /**
  * @brief Remove specific Domain Participant builtin initial peers.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete list is removed.
  *
@@ -210,14 +193,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant builtin initial peers port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -227,14 +208,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant builtin initial peers physical port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -244,14 +223,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant builtin initial peers IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -261,14 +238,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_physical_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant builtin initial peers unique LAN ID.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -278,14 +253,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant builtin initial peers WAN IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -295,7 +268,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_unique_lan_id(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -306,7 +278,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
 /**
  * @brief Append a builtin initial peers with specified kind or update the builtin initial peers kind.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] kind Initial peers kind.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -318,7 +289,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& kind,
         const std::string& index);
@@ -326,7 +296,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
 /**
  * @brief Append a builtin initial peers with specified port or update the builtin initial peers port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] port Initial peers port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -338,7 +307,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& port,
         const std::string& index);
@@ -347,7 +315,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @brief Append a builtin initial peers with specified physical port or update the builtin initial peers physical port
  *        (TCP only).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] physical_port Initial peers TCP physical port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -359,7 +326,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& physical_port,
         const std::string& index);
@@ -367,7 +333,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
 /**
  * @brief Append a builtin initial peers with specified IP address or update the builtin initial peers IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] address Initial peers IP address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -379,7 +344,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& address,
         const std::string& index);
@@ -388,7 +352,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @brief Append a builtin initial peers TCPv4 locator with specified unique LAN ID or update the builtin initial peers
  *        TCPv4 locator unique LAN ID.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] unique_lan_id Initial peers TCPv4 locator unique LAN ID.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -400,7 +363,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& unique_lan_id,
         const std::string& index);
@@ -409,7 +371,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @brief Append a builtin initial peers TCPv4 locator with specified WAN address or update the builtin initial peers
  *        TCPv4 locator WAN address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] wan_address Initial peers TCPv4 locator WAN address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -421,7 +382,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& wan_address,
         const std::string& index);

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/MetatrafficExternalUnicastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/MetatrafficExternalUnicastLocators.hpp
@@ -277,7 +277,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_mask(
  * @param[in] kind Metatraffic unicast locator kind.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -297,7 +296,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @param[in] port Metatraffic unicast locator port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -317,7 +315,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @param[in] address Metatraffic unicast locator IP address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -337,7 +334,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @param[in] externality Metatraffic unicast locator externality.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator externality is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -357,7 +353,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_externality(
  * @param[in] cost Metatraffic unicast locator cost.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator cost is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -377,7 +372,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_cost(
  * @param[in] mask Metatraffic unicast locator mask.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator mask is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/MetatrafficExternalUnicastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/MetatrafficExternalUnicastLocators.hpp
@@ -41,7 +41,7 @@ namespace metatraffic_external_unicast_locators {
  *
  * @return std::string XML section containing the Domain Participant specific metatraffic external unicast locator.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -58,7 +58,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  *
  * @return std::string Domain Participant specific metatraffic external unicast locator kind.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -75,7 +75,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
  *
  * @return std::string Domain Participant specific metatraffic external unicast locator port.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -92,7 +92,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
  *
  * @return std::string Domain Participant specific metatraffic external unicast locator IP address.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -110,7 +110,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
  *
  * @return std::string Domain Participant specific metatraffic external unicast locator externality.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -127,7 +127,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_externality(
  *
  * @return std::string Domain Participant specific metatraffic external unicast locator cost.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -144,7 +144,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_cost(
  *
  * @return std::string Domain Participant specific metatraffic external unicast locator mask.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -164,7 +164,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_mask(
  *
  * @return uint32_t Number of metatraffic external unicast locators in the list.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the list
  *        has not been set.
  */
@@ -181,7 +181,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete list is removed.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -196,7 +196,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -211,7 +211,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -226,7 +226,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -241,7 +241,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_externality(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -256,7 +256,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_cost(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -280,7 +280,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_mask(
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
@@ -299,7 +299,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
@@ -318,7 +318,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
@@ -337,7 +337,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @throw ElementInvalid Exception if the provided locator externality is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_externality(
@@ -356,7 +356,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_externality(
  * @throw ElementInvalid Exception if the provided locator cost is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_cost(
@@ -375,7 +375,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_cost(
  * @throw ElementInvalid Exception if the provided locator mask is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_mask(

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/MetatrafficExternalUnicastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/MetatrafficExternalUnicastLocators.hpp
@@ -277,6 +277,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_mask(
  * @param[in] kind Metatraffic unicast locator kind.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -296,6 +297,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @param[in] port Metatraffic unicast locator port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -315,6 +317,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @param[in] address Metatraffic unicast locator IP address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -334,6 +337,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @param[in] externality Metatraffic unicast locator externality.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator externality is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -353,6 +357,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_externality(
  * @param[in] cost Metatraffic unicast locator cost.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator cost is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -372,6 +377,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_cost(
  * @param[in] mask Metatraffic unicast locator mask.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator mask is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/MetatrafficExternalUnicastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/MetatrafficExternalUnicastLocators.hpp
@@ -36,7 +36,6 @@ namespace metatraffic_external_unicast_locators {
 /**
  * @brief Parse XML file and print the specific Domain Participant specific metatraffic external unicast locator.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed. If empty, the complete list is printed.
  *
@@ -48,14 +47,12 @@ namespace metatraffic_external_unicast_locators {
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the specific Domain Participant specific metatraffic external unicast locator kind.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -67,14 +64,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the specific Domain Participant specific metatraffic external unicast locator port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -86,14 +81,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the specific Domain Participant specific metatraffic external unicast locator IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -105,7 +98,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -113,7 +105,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
  * @brief Parse XML file and print the specific Domain Participant specific metatraffic external unicast locator
  *        externality.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -125,14 +116,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_externality(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the specific Domain Participant specific metatraffic external unicast locator cost.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -144,14 +133,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_externality(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_cost(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the specific Domain Participant specific metatraffic external unicast locator mask.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -163,7 +150,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_cost(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_mask(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -174,7 +160,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_mask(
 /**
  * @brief Number of metatraffic external unicast locators in the Domain Participant.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return uint32_t Number of metatraffic external unicast locators in the list.
@@ -184,7 +169,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_mask(
  *        has not been set.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /************************************************************************/
@@ -194,7 +178,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
 /**
  * @brief Remove specific Domain Participant metatraffic external unicast locator.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete list is removed.
  *
@@ -204,14 +187,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant metatraffic external unicast locator port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -221,14 +202,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant metatraffic external unicast locator IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -238,14 +217,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant metatraffic external unicast locator externality.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -255,14 +232,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_externality(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant metatraffic external unicast locator cost.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -272,14 +247,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_externality(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_cost(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant metatraffic external unicast locator mask.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -289,7 +262,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_cost(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_mask(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -301,7 +273,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_mask(
  * @brief Append a metatraffic external unicast locator with specified kind or update the metatraffic external unicast
  *        locator kind.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] kind Metatraffic unicast locator kind.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -313,7 +284,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_mask(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& kind,
         const std::string& index);
@@ -322,7 +292,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @brief Append a metatraffic external unicast locator with specified port or update the metatraffic external unicast
  *        locator port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] port Metatraffic unicast locator port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -334,7 +303,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& port,
         const std::string& index);
@@ -343,7 +311,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @brief Append a metatraffic external unicast locator with specified IP address or update the metatraffic external
  *        unicast locator IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] address Metatraffic unicast locator IP address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -355,7 +322,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& address,
         const std::string& index);
@@ -364,7 +330,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @brief Append a metatraffic external unicast locator with specified externality or update the metatraffic external
  *        unicast locator externality.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] externality Metatraffic unicast locator externality.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -376,7 +341,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_externality(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& externality,
         const std::string& index);
@@ -385,7 +349,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_externality(
  * @brief Append a metatraffic external unicast locator with specified cost or update the metatraffic external unicast
  *        locator cost.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] cost Metatraffic unicast locator cost.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -397,7 +360,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_externality(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_cost(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& cost,
         const std::string& index);
@@ -406,7 +368,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_cost(
  * @brief Append a metatraffic external unicast locator with specified mask or update the metatraffic external unicast
  *        locator mask.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] mask Metatraffic unicast locator mask.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -418,7 +379,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_cost(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_mask(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& mask,
         const std::string& index);

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/MetatrafficMulticastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/MetatrafficMulticastLocators.hpp
@@ -283,6 +283,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @param[in] kind Metatraffic multicast locator kind.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -302,6 +303,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @param[in] port Metatraffic multicast locator port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -321,6 +323,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @param[in] physical_port Metatraffic multicast locator TCP physical port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator physical port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -340,6 +343,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @param[in] address Metatraffic multicast locator IP address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -359,6 +363,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @param[in] unique_lan_id Metatraffic multicast TCPv4 locator unique LAN ID.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator identifier is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -378,6 +383,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @param[in] wan_address Metatraffic multicast TCPv4 locator WAN address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/MetatrafficMulticastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/MetatrafficMulticastLocators.hpp
@@ -41,7 +41,7 @@ namespace metatraffic_multicast_locators {
  *
  * @return std::string XML section containing the Domain Participant specific builtin metatraffic multicast locator.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -58,7 +58,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  *
  * @return std::string Domain Participant specific builtin metatraffic multicast locator kind.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -75,7 +75,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
  *
  * @return std::string Domain Participant specific builtin metatraffic multicast locator port.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -94,7 +94,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
  *
  * @return std::string Domain Participant specific builtin metatraffic multicast locator TCP physical port.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -112,7 +112,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_physical_port(
  *
  * @return std::string Domain Participant specific builtin metatraffic multicast locator IP address.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -131,7 +131,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
  *
  * @return std::string Domain Participant specific builtin metatraffic multicast locator TCPv4 unique LAN ID.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -150,7 +150,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_unique_lan_id(
  *
  * @return std::string Domain Participant specific builtin metatraffic multicast locator TCPv4 WAN IP address.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -170,7 +170,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_address(
  *
  * @return uint32_t Number of builtin metatraffic multicast locators in the list.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the list
  *        has not been set.
  */
@@ -187,7 +187,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete list is removed.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -202,7 +202,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -217,7 +217,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -232,7 +232,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_physical_port(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -247,7 +247,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -262,7 +262,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_unique_lan_id(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -286,7 +286,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
@@ -305,7 +305,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
@@ -324,7 +324,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @throw ElementInvalid Exception if the provided locator physical port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
@@ -343,7 +343,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
@@ -362,7 +362,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @throw ElementInvalid Exception if the provided locator identifier is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
@@ -381,7 +381,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_wan_address(

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/MetatrafficMulticastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/MetatrafficMulticastLocators.hpp
@@ -283,7 +283,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @param[in] kind Metatraffic multicast locator kind.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -303,7 +302,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @param[in] port Metatraffic multicast locator port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -323,7 +321,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @param[in] physical_port Metatraffic multicast locator TCP physical port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator physical port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -343,7 +340,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @param[in] address Metatraffic multicast locator IP address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -363,7 +359,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @param[in] unique_lan_id Metatraffic multicast TCPv4 locator unique LAN ID.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator identifier is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -383,7 +378,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @param[in] wan_address Metatraffic multicast TCPv4 locator WAN address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/MetatrafficMulticastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/MetatrafficMulticastLocators.hpp
@@ -36,7 +36,6 @@ namespace metatraffic_multicast_locators {
 /**
  * @brief Parse XML file and print the specific Domain Participant specific builtin metatraffic multicast locator.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed. If empty, the complete list is printed.
  *
@@ -48,14 +47,12 @@ namespace metatraffic_multicast_locators {
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the specific Domain Participant specific builtin metatraffic multicast locator kind.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -67,14 +64,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the specific Domain Participant specific builtin metatraffic multicast locator port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -86,7 +81,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -95,7 +89,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
  *        port.
  *        TCP only.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -107,7 +100,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -115,7 +107,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_physical_port(
  * @brief Parse XML file and print the specific Domain Participant specific builtin metatraffic multicast locator IP
  *        address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -127,7 +118,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_physical_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -136,7 +126,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
  *        LAN ID.
  *        TCPv4 only.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -148,7 +137,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -157,7 +145,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_unique_lan_id(
  *        address.
  *        TCPv4 only.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -169,7 +156,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_unique_lan_id(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -180,7 +166,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_address(
 /**
  * @brief Number of builtin metatraffic multicast locators in the Domain Participant.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return uint32_t Number of builtin metatraffic multicast locators in the list.
@@ -190,7 +175,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_address(
  *        has not been set.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /************************************************************************/
@@ -200,7 +184,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
 /**
  * @brief Remove specific Domain Participant builtin metatraffic multicast locator.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete list is removed.
  *
@@ -210,14 +193,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant builtin metatraffic multicast locator port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -227,14 +208,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant builtin metatraffic multicast locator physical port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -244,14 +223,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant builtin metatraffic multicast locator IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -261,14 +238,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_physical_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant builtin metatraffic multicast locator unique LAN ID.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -278,14 +253,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant builtin metatraffic multicast locator WAN IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -295,7 +268,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_unique_lan_id(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -307,7 +279,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @brief Append a builtin metatraffic multicast locator with specified kind or update the builtin metatraffic multicast
  *        locator kind.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] kind Metatraffic multicast locator kind.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -319,7 +290,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& kind,
         const std::string& index);
@@ -328,7 +298,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @brief Append a builtin metatraffic multicast locator with specified port or update the builtin metatraffic multicast
  *        locator port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] port Metatraffic multicast locator port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -340,7 +309,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& port,
         const std::string& index);
@@ -349,7 +317,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @brief Append a builtin metatraffic multicast locator with specified physical port or update the builtin metatraffic
  *        multicast locator physical port (TCP only).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] physical_port Metatraffic multicast locator TCP physical port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -361,7 +328,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& physical_port,
         const std::string& index);
@@ -370,7 +336,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @brief Append a builtin metatraffic multicast locator with specified IP address or update the builtin metatraffic
  *        multicast locator IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] address Metatraffic multicast locator IP address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -382,7 +347,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& address,
         const std::string& index);
@@ -391,7 +355,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @brief Append a builtin metatraffic multicast TCPv4 locator with specified unique LAN ID or update the builtin
  *        metatraffic multicast TCPv4 locator unique LAN ID.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] unique_lan_id Metatraffic multicast TCPv4 locator unique LAN ID.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -403,7 +366,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& unique_lan_id,
         const std::string& index);
@@ -412,7 +374,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @brief Append a builtin metatraffic multicast TCPv4 locator with specified WAN address or update the builtin
  *        metatraffic multicast TCPv4 locator WAN address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] wan_address Metatraffic multicast TCPv4 locator WAN address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -424,7 +385,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& wan_address,
         const std::string& index);

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/MetatrafficUnicastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/MetatrafficUnicastLocators.hpp
@@ -41,7 +41,7 @@ namespace metatraffic_unicast_locators {
  *
  * @return std::string XML section containing the Domain Participant specific builtin metatraffic unicast locator.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -58,7 +58,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  *
  * @return std::string Domain Participant specific builtin metatraffic unicast locator kind.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -75,7 +75,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
  *
  * @return std::string Domain Participant specific builtin metatraffic unicast locator port.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -94,7 +94,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
  *
  * @return std::string Domain Participant specific builtin metatraffic unicast locator TCP physical port.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -112,7 +112,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_physical_port(
  *
  * @return std::string Domain Participant specific builtin metatraffic unicast locator IP address.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -131,7 +131,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
  *
  * @return std::string Domain Participant specific builtin metatraffic unicast locator TCPv4 unique LAN ID.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -150,7 +150,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_unique_lan_id(
  *
  * @return std::string Domain Participant specific builtin metatraffic unicast locator TCPv4 WAN IP address.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -170,7 +170,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_address(
  *
  * @return uint32_t Number of builtin metatraffic unicast locators in the list.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the list
  *        has not been set.
  */
@@ -187,7 +187,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete list is removed.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -202,7 +202,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -217,7 +217,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -232,7 +232,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_physical_port(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -247,7 +247,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -262,7 +262,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_unique_lan_id(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -286,7 +286,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
@@ -305,7 +305,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
@@ -324,7 +324,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @throw ElementInvalid Exception if the provided locator physical port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
@@ -343,7 +343,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
@@ -362,7 +362,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @throw ElementInvalid Exception if the provided locator identifier is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
@@ -381,7 +381,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_wan_address(

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/MetatrafficUnicastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/MetatrafficUnicastLocators.hpp
@@ -36,7 +36,6 @@ namespace metatraffic_unicast_locators {
 /**
  * @brief Parse XML file and print the specific Domain Participant specific builtin metatraffic unicast locator.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed. If empty, the complete list is printed.
  *
@@ -48,14 +47,12 @@ namespace metatraffic_unicast_locators {
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the specific Domain Participant specific builtin metatraffic unicast locator kind.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -67,14 +64,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the specific Domain Participant specific builtin metatraffic unicast locator port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -86,7 +81,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -95,7 +89,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
  *        port.
  *        TCP only.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -107,7 +100,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -115,7 +107,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_physical_port(
  * @brief Parse XML file and print the specific Domain Participant specific builtin metatraffic unicast locator IP
  *        address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -127,7 +118,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_physical_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -136,7 +126,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
  *        LAN ID.
  *        TCPv4 only.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -148,7 +137,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -157,7 +145,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_unique_lan_id(
  *        address.
  *        TCPv4 only.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed.
  *
@@ -169,7 +156,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_unique_lan_id(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -180,7 +166,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_address(
 /**
  * @brief Number of builtin metatraffic unicast locators in the Domain Participant.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return uint32_t Number of builtin metatraffic unicast locators in the list.
@@ -190,7 +175,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_address(
  *        has not been set.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /************************************************************************/
@@ -200,7 +184,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
 /**
  * @brief Remove specific Domain Participant builtin metatraffic unicast locator.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete list is removed.
  *
@@ -210,14 +193,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant builtin metatraffic unicast locator port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -227,14 +208,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant builtin metatraffic unicast locator physical port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -244,14 +223,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant builtin metatraffic unicast locator IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -261,14 +238,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_physical_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant builtin metatraffic unicast locator unique LAN ID.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -278,14 +253,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
 /**
  * @brief Remove specific Domain Participant builtin metatraffic unicast locator WAN IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be modified.
  *
@@ -295,7 +268,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_unique_lan_id(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -307,7 +279,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @brief Append a builtin metatraffic unicast locator with specified kind or update the builtin metatraffic unicast
  *        locator kind.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] kind Metatraffic unicast locator kind.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -319,7 +290,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& kind,
         const std::string& index);
@@ -328,7 +298,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @brief Append a builtin metatraffic unicast locator with specified port or update the builtin metatraffic unicast
  *        locator port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] port Metatraffic unicast locator port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -340,7 +309,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& port,
         const std::string& index);
@@ -349,7 +317,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @brief Append a builtin metatraffic unicast locator with specified physical port or update the builtin metatraffic
  *        unicast locator physical port (TCP only).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] physical_port Metatraffic unicast locator TCP physical port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -361,7 +328,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& physical_port,
         const std::string& index);
@@ -370,7 +336,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @brief Append a builtin metatraffic unicast locator with specified IP address or update the builtin metatraffic
  *        unicast locator IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] address Metatraffic unicast locator IP address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -382,7 +347,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& address,
         const std::string& index);
@@ -391,7 +355,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @brief Append a builtin metatraffic unicast TCPv4 locator with specified unique LAN ID or update the builtin
  *        metatraffic unicast TCPv4 locator unique LAN ID.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] unique_lan_id Metatraffic unicast TCPv4 locator unique LAN ID.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -403,7 +366,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& unique_lan_id,
         const std::string& index);
@@ -412,7 +374,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @brief Append a builtin metatraffic unicast TCPv4 locator with specified WAN address or update the builtin
  *        metatraffic unicast TCPv4 locator WAN address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] wan_address Metatraffic unicast TCPv4 locator WAN address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -424,7 +385,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& wan_address,
         const std::string& index);

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/MetatrafficUnicastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/MetatrafficUnicastLocators.hpp
@@ -283,6 +283,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @param[in] kind Metatraffic unicast locator kind.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -302,6 +303,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @param[in] port Metatraffic unicast locator port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -321,6 +323,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @param[in] physical_port Metatraffic unicast locator TCP physical port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator physical port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -340,6 +343,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @param[in] address Metatraffic unicast locator IP address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -359,6 +363,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @param[in] unique_lan_id Metatraffic unicast TCPv4 locator unique LAN ID.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator identifier is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -378,6 +383,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @param[in] wan_address Metatraffic unicast TCPv4 locator WAN address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/MetatrafficUnicastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/MetatrafficUnicastLocators.hpp
@@ -283,7 +283,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @param[in] kind Metatraffic unicast locator kind.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -303,7 +302,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @param[in] port Metatraffic unicast locator port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -323,7 +321,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @param[in] physical_port Metatraffic unicast locator TCP physical port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator physical port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -343,7 +340,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @param[in] address Metatraffic unicast locator IP address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -363,7 +359,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @param[in] unique_lan_id Metatraffic unicast TCPv4 locator unique LAN ID.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator identifier is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -383,7 +378,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @param[in] wan_address Metatraffic unicast TCPv4 locator WAN address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/discovery_config/DiscoveryConfig.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/discovery_config/DiscoveryConfig.hpp
@@ -36,7 +36,6 @@ namespace discovery_config {
 /**
  * @brief Parse XML file and print specific Domain Participant builtin discovery configuration section.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string XML section containing the specific Domain Participant builtin discovery configuration.
@@ -46,13 +45,11 @@ namespace discovery_config {
  *        builtin discovery configuration section does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant builtin discovery protocol.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant specific builtin discovery protocol.
@@ -62,13 +59,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  *        builtin discovery protocol element does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_discovery_protocol(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant builtin discovery ignore participant flags.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant specific builtin discovery ignore participant flags.
@@ -78,13 +73,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_discovery_protocol(
  *        builtin discovery flag does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_ignore_participant_flags(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant builtin discovery EDP flag.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant specific builtin discovery EDP flag.
@@ -94,13 +87,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_ignore_participant_flags(
  *        builtin discovery flag does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_edp(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant builtin discovery simple EDP configuration.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant specific builtin discovery simple EDP configuration.
@@ -110,13 +101,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_edp(
  *        builtin discovery simple EDP configuration does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_simple_edp(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant builtin discovery simple EDP configuration flag.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant specific builtin discovery simple EDP pubwriter_subreader flag configuration.
@@ -126,13 +115,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_simple_edp(
  *        builtin discovery simple EDP configuration flag does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_simple_edp_pubwriter_subreader(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant builtin discovery simple EDP configuration flag.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant specific builtin discovery simple EDP pubreader_subwriter flag configuration.
@@ -142,13 +129,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_simple_edp_pubwriter_subre
  *        builtin discovery simple EDP configuration flag does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_simple_edp_pubreader_subwriter(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant builtin discovery lease duration.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant specific builtin discovery lease duration.
@@ -158,13 +143,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_simple_edp_pubreader_subwr
  *        builtin discovery lease duration element does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_lease_duration(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant builtin discovery lease duration (seconds).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant specific builtin discovery lease duration (seconds member).
@@ -174,13 +157,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_lease_duration(
  *        builtin discovery lease duration seconds element does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_lease_duration_sec(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant builtin discovery lease duration (nanoseconds).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant specific builtin discovery lease duration (nanoseconds member).
@@ -190,13 +171,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_lease_duration_sec(
  *        builtin discovery lease duration nanoseconds element does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_lease_duration_nanosec(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant builtin discovery lease announcement.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant specific builtin discovery lease announcement.
@@ -206,13 +185,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_lease_duration_nanosec(
  *        builtin discovery lease announcement element does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_lease_announcement(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant builtin discovery lease announcement (seconds).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant specific builtin discovery lease announcement (seconds member).
@@ -222,13 +199,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_lease_announcement(
  *        builtin discovery lease announcement seconds element does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_lease_announcement_sec(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant builtin discovery lease announcement (nanoseconds).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant specific builtin discovery lease announcement (nanoseconds member).
@@ -238,13 +213,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_lease_announcement_sec(
  *        builtin discovery lease announcement nanoseconds element does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_lease_announcement_nanosec(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant builtin discovery initial announcements configuration.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant specific builtin discovery initial announcements configuration.
@@ -254,13 +227,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_lease_announcement_nanosec
  *        builtin discovery initial announcements element does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_initial_announcements(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant builtin discovery number of initial announcements.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant specific builtin discovery number of initial announcements.
@@ -270,13 +241,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_initial_announcements(
  *        builtin discovery initial announcements count element does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_initial_announcements_count(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant builtin discovery initial announcements duration.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant specific builtin discovery initial announcements duration.
@@ -286,14 +255,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_initial_announcements_coun
  *        builtin discovery initial announcements duration element does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_initial_announcements_period(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant builtin discovery initial announcement duration
  *        (seconds).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant specific builtin discovery initial announcement duration (seconds member).
@@ -303,14 +270,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_initial_announcements_peri
  *        builtin discovery initial announcement duration seconds element does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_initial_announcements_period_sec(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant builtin discovery lease announcement duration
  *        (nanoseconds).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant specific builtin discovery lease announcement duration (nanoseconds member).
@@ -320,14 +285,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_initial_announcements_peri
  *        builtin discovery lease announcement duration nanoseconds element does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_initial_announcements_period_nanosec(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant builtin discovery client announcement period.
  *        Discovery Server configuration.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant specific builtin discovery client announcement period.
@@ -337,13 +300,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_initial_announcements_peri
  *        builtin discovery client announcement period element does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_client_announcement_period(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant builtin discovery client announcement period (seconds).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant specific builtin discovery client announcement period (seconds member).
@@ -353,14 +314,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_client_announcement_period
  *        builtin discovery client announcement period seconds element does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_client_announcement_period_sec(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant builtin discovery client announcement period
  *        (nanoseconds).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::string Domain Participant specific builtin discovery client announcement period (nanoseconds member).
@@ -370,14 +329,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_client_announcement_period
  *        builtin discovery client announcement period nanoseconds element does not exist.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_client_announcement_period_nanosec(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Parse XML file and print specific Domain Participant builtin discovery specific Static EDP XML configuration
  *        file.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be printed. If empty, the complete collection is printed.
  *
@@ -390,7 +347,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_client_announcement_period
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_static_edp_xml_config(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -401,7 +357,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_static_edp_xml_config(
 /**
  * @brief Number of builtin discovery Static EDP XML configuration files in the Domain Participant.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return uint32_t Number of builtin discovery Static EDP XML configuration files.
@@ -411,7 +366,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_static_edp_xml_config(
  *        are no Static EDP XML files configured.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t static_edp_xml_config_size(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /************************************************************************/
@@ -421,280 +375,237 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t static_edp_xml_config_size(
 /**
  * @brief Remove specific Domain Participant builtin discovery configuration.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant builtin discovery protocol.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_discovery_protocol(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant builtin discovery ignore participant flags.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_ignore_participant_flags(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant builtin discovery EDP flag.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_edp(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant builtin discovery simple EDP configuration.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_simple_edp(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant builtin discovery simple EDP configuration flag.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_simple_edp_pubwriter_subreader(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant builtin discovery simple EDP configuration flag.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_simple_edp_edp_pubreader_subwriter(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant builtin discovery lease duration.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_lease_duration(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant builtin discovery lease duration (seconds).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_lease_duration_sec(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant builtin discovery lease duration (nanoseconds).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_lease_duration_nanosec(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant builtin discovery lease announcement.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_lease_announcement(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant builtin discovery lease announcement (seconds).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_lease_announcement_sec(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant builtin discovery lease announcement (nanoseconds).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_lease_announcement_nanosec(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant builtin discovery initial announcements configuration.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_initial_announcements(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant builtin discovery number of initial announcements.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_initial_announcements_count(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant builtin discovery initial announcements duration.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_initial_announcements_period(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant builtin discovery initial announcements duration (seconds).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_initial_announcements_period_sec(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant builtin discovery initial announcements duration (nanoseconds).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_initial_announcements_period_nanosec(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant builtin discovery client announcement period (Discovery Server specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_client_announcement_period(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant builtin discovery client announcement period (seconds).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_client_announcement_period_sec(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant builtin discovery client announcement period (nanoseconds).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_client_announcement_period_nanosec(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief Remove specific Domain Participant builtin discovery specific Static EDP XML configuration file.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete collection is erased.
  *
@@ -704,7 +615,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_client_announcement_period_nanose
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_static_edp_xml_config(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index);
 
@@ -715,196 +625,168 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_static_edp_xml_config(
 /**
  * @brief Set the Domain Participant builtin discovery protocol.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] discovery_protocol Builtin discovery protocol.
  *
  * @throw ElementInvalid Exception if the provided discovery protocol is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_discovery_protocol(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& discovery_protocol);
 
 /**
  * @brief Set the Domain Participant builtin discovery ignore participant flags.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] ignore_participant_flags Builtin discovery ignore participant flags.
  *
  * @throw ElementInvalid Exception if the provided flag is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_ignore_participant_flags(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& ignore_participant_flags);
 
 /**
  * @brief Set the Domain Participant builtin discovery EDP flag.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] edp Builtin discovery EDP flag.
  *
  * @throw ElementInvalid Exception if the provided flag is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_edp(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& edp);
 
 /**
  * @brief Set the Domain Participant builtin discovery simple EDP configuration flag.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] simple_edp_pubwriter_subreader Builtin discovery simple EDP configuration flag.
  *
  * @throw ElementInvalid Exception if the provided flag is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_simple_edp_pubwriter_subreader(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& simple_edp_pubwriter_subreader);
 
 /**
  * @brief Set the Domain Participant builtin discovery simple EDP configuration flag.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] simple_edp_pubreader_subwriter Builtin discovery simple EDP configuration flag.
  *
  * @throw ElementInvalid Exception if the provided flag is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_simple_edp_pubreader_subwriter(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& simple_edp_pubreader_subwriter);
 
 /**
  * @brief Set the Domain Participant builtin discovery lease duration (seconds).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] duration_sec Builtin discovery lease duration seconds.
  *
  * @throw ElementInvalid Exception if the provided seconds are not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_lease_duration_sec(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& duration_sec);
 
 /**
  * @brief Set the Domain Participant builtin discovery lease duration (nanoseconds).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] duration_nanosec Builtin discovery lease duration nanoseconds.
  *
  * @throw ElementInvalid Exception if the provided nanoseconds are not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_lease_duration_nanosec(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& duration_nanosec);
 
 /**
  * @brief Set the Domain Participant builtin discovery lease announcement (seconds).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] announcement_sec Builtin discovery lease announcement seconds.
  *
  * @throw ElementInvalid Exception if the provided seconds are not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_lease_announcement_sec(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& announcement_sec);
 
 /**
  * @brief Set the Domain Participant builtin discovery lease announcement (nanoseconds).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] announcement_nanosec Builtin discovery lease announcement nanoseconds.
  *
  * @throw ElementInvalid Exception if the provided nanoseconds are not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_lease_announcement_nanosec(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& announcement_nanosec);
 
 /**
  * @brief Set the Domain Participant builtin discovery number of initial announcements.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] count Builtin discovery number of initial announcements.
  *
  * @throw ElementInvalid Exception if the provided number of initial announcements is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_initial_announcements_count(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& count);
 
 /**
  * @brief Set the Domain Participant builtin discovery initial announcements duration (seconds).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] period_sec Builtin discovery initial announcements duration seconds.
  *
  * @throw ElementInvalid Exception if the provided seconds are not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_initial_announcements_period_sec(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& period_sec);
 
 /**
  * @brief Set the Domain Participant builtin discovery initial announcements duration (nanoseconds).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] period_nanosec Builtin discovery initial announcements duration nanoseconds.
  *
  * @throw ElementInvalid Exception if the provided nanoseconds are not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_initial_announcements_period_nanosec(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& period_nanosec);
 
 /**
  * @brief Set the Domain Participant builtin discovery client announcement period (seconds).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] period_sec Builtin discovery client announcement period seconds.
  *
  * @throw ElementInvalid Exception if the provided seconds are not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_client_announcement_period_sec(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& period_sec);
 
 /**
  * @brief Set the Domain Participant builtin discovery client announcement period (nanoseconds).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] period_nanosec Builtin discovery client announcement period nanoseconds.
  *
  * @throw ElementInvalid Exception if the provided nanoseconds are not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_client_announcement_period_nanosec(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& period_nanosec);
 
@@ -916,7 +798,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_client_announcement_period_nanosec(
  * @brief Append a builtin discovery Static EDP XML configuration file or update a builtin discovery Static EDP XML
  *        configuration file.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] static_edp_xml_config Builtin discovery Static EDP XML configuration file.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -928,7 +809,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_client_announcement_period_nanosec(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_static_edp_xml_config(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& static_edp_xml_config,
         const std::string& index);

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/discovery_config/DiscoveryConfig.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/discovery_config/DiscoveryConfig.hpp
@@ -628,6 +628,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_static_edp_xml_config(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] discovery_protocol Builtin discovery protocol.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided discovery protocol is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_discovery_protocol(
@@ -640,6 +641,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_discovery_protocol(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] ignore_participant_flags Builtin discovery ignore participant flags.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided flag is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_ignore_participant_flags(
@@ -652,6 +654,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_ignore_participant_flags(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] edp Builtin discovery EDP flag.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided flag is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_edp(
@@ -664,6 +667,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_edp(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] simple_edp_pubwriter_subreader Builtin discovery simple EDP configuration flag.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided flag is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_simple_edp_pubwriter_subreader(
@@ -676,6 +680,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_simple_edp_pubwriter_subreader(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] simple_edp_pubreader_subwriter Builtin discovery simple EDP configuration flag.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided flag is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_simple_edp_pubreader_subwriter(
@@ -688,6 +693,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_simple_edp_pubreader_subwriter(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] duration_sec Builtin discovery lease duration seconds.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided seconds are not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_lease_duration_sec(
@@ -700,6 +706,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_lease_duration_sec(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] duration_nanosec Builtin discovery lease duration nanoseconds.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided nanoseconds are not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_lease_duration_nanosec(
@@ -712,6 +719,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_lease_duration_nanosec(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] announcement_sec Builtin discovery lease announcement seconds.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided seconds are not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_lease_announcement_sec(
@@ -724,6 +732,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_lease_announcement_sec(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] announcement_nanosec Builtin discovery lease announcement nanoseconds.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided nanoseconds are not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_lease_announcement_nanosec(
@@ -736,6 +745,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_lease_announcement_nanosec(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] count Builtin discovery number of initial announcements.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided number of initial announcements is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_initial_announcements_count(
@@ -748,6 +758,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_initial_announcements_count(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] period_sec Builtin discovery initial announcements duration seconds.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided seconds are not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_initial_announcements_period_sec(
@@ -760,6 +771,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_initial_announcements_period_sec(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] period_nanosec Builtin discovery initial announcements duration nanoseconds.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided nanoseconds are not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_initial_announcements_period_nanosec(
@@ -772,6 +784,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_initial_announcements_period_nanose
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] period_sec Builtin discovery client announcement period seconds.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided seconds are not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_client_announcement_period_sec(
@@ -784,6 +797,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_client_announcement_period_sec(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] period_nanosec Builtin discovery client announcement period nanoseconds.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided nanoseconds are not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_client_announcement_period_nanosec(
@@ -802,6 +816,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_client_announcement_period_nanosec(
  * @param[in] static_edp_xml_config Builtin discovery Static EDP XML configuration file.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided path is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/discovery_config/DiscoveryConfig.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/discovery_config/DiscoveryConfig.hpp
@@ -40,7 +40,7 @@ namespace discovery_config {
  *
  * @return std::string XML section containing the specific Domain Participant builtin discovery configuration.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        builtin discovery configuration section does not exist.
  */
@@ -54,7 +54,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  *
  * @return std::string Domain Participant specific builtin discovery protocol.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        builtin discovery protocol element does not exist.
  */
@@ -68,7 +68,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_discovery_protocol(
  *
  * @return std::string Domain Participant specific builtin discovery ignore participant flags.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        builtin discovery flag does not exist.
  */
@@ -82,7 +82,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_ignore_participant_flags(
  *
  * @return std::string Domain Participant specific builtin discovery EDP flag.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        builtin discovery flag does not exist.
  */
@@ -96,7 +96,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_edp(
  *
  * @return std::string Domain Participant specific builtin discovery simple EDP configuration.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        builtin discovery simple EDP configuration does not exist.
  */
@@ -110,7 +110,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_simple_edp(
  *
  * @return std::string Domain Participant specific builtin discovery simple EDP pubwriter_subreader flag configuration.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        builtin discovery simple EDP configuration flag does not exist.
  */
@@ -124,7 +124,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_simple_edp_pubwriter_subre
  *
  * @return std::string Domain Participant specific builtin discovery simple EDP pubreader_subwriter flag configuration.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        builtin discovery simple EDP configuration flag does not exist.
  */
@@ -138,7 +138,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_simple_edp_pubreader_subwr
  *
  * @return std::string Domain Participant specific builtin discovery lease duration.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        builtin discovery lease duration element does not exist.
  */
@@ -152,7 +152,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_lease_duration(
  *
  * @return std::string Domain Participant specific builtin discovery lease duration (seconds member).
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        builtin discovery lease duration seconds element does not exist.
  */
@@ -166,7 +166,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_lease_duration_sec(
  *
  * @return std::string Domain Participant specific builtin discovery lease duration (nanoseconds member).
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        builtin discovery lease duration nanoseconds element does not exist.
  */
@@ -180,7 +180,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_lease_duration_nanosec(
  *
  * @return std::string Domain Participant specific builtin discovery lease announcement.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        builtin discovery lease announcement element does not exist.
  */
@@ -194,7 +194,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_lease_announcement(
  *
  * @return std::string Domain Participant specific builtin discovery lease announcement (seconds member).
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        builtin discovery lease announcement seconds element does not exist.
  */
@@ -208,7 +208,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_lease_announcement_sec(
  *
  * @return std::string Domain Participant specific builtin discovery lease announcement (nanoseconds member).
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        builtin discovery lease announcement nanoseconds element does not exist.
  */
@@ -222,7 +222,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_lease_announcement_nanosec
  *
  * @return std::string Domain Participant specific builtin discovery initial announcements configuration.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        builtin discovery initial announcements element does not exist.
  */
@@ -236,7 +236,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_initial_announcements(
  *
  * @return std::string Domain Participant specific builtin discovery number of initial announcements.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        builtin discovery initial announcements count element does not exist.
  */
@@ -250,7 +250,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_initial_announcements_coun
  *
  * @return std::string Domain Participant specific builtin discovery initial announcements duration.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        builtin discovery initial announcements duration element does not exist.
  */
@@ -265,7 +265,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_initial_announcements_peri
  *
  * @return std::string Domain Participant specific builtin discovery initial announcement duration (seconds member).
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        builtin discovery initial announcement duration seconds element does not exist.
  */
@@ -280,7 +280,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_initial_announcements_peri
  *
  * @return std::string Domain Participant specific builtin discovery lease announcement duration (nanoseconds member).
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        builtin discovery lease announcement duration nanoseconds element does not exist.
  */
@@ -295,7 +295,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_initial_announcements_peri
  *
  * @return std::string Domain Participant specific builtin discovery client announcement period.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        builtin discovery client announcement period element does not exist.
  */
@@ -309,7 +309,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_client_announcement_period
  *
  * @return std::string Domain Participant specific builtin discovery client announcement period (seconds member).
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        builtin discovery client announcement period seconds element does not exist.
  */
@@ -324,7 +324,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_client_announcement_period
  *
  * @return std::string Domain Participant specific builtin discovery client announcement period (nanoseconds member).
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        builtin discovery client announcement period nanoseconds element does not exist.
  */
@@ -340,7 +340,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_client_announcement_period
  *
  * @return std::string Domain Participant specific builtin discovery specific Static EDP XML configuration file.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        Static EDP XML configuration files element is not defined, or the list does not contain any element in index
  *        position.
@@ -361,7 +361,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_static_edp_xml_config(
  *
  * @return uint32_t Number of builtin discovery Static EDP XML configuration files.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or there
  *        are no Static EDP XML files configured.
  */
@@ -377,7 +377,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t static_edp_xml_config_size(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
@@ -388,7 +388,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_discovery_protocol(
@@ -399,7 +399,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_discovery_protocol(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_ignore_participant_flags(
@@ -410,7 +410,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_ignore_participant_flags(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_edp(
@@ -421,7 +421,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_edp(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_simple_edp(
@@ -432,7 +432,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_simple_edp(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_simple_edp_pubwriter_subreader(
@@ -443,7 +443,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_simple_edp_pubwriter_subreader(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_simple_edp_edp_pubreader_subwriter(
@@ -454,7 +454,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_simple_edp_edp_pubreader_subwrite
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_lease_duration(
@@ -465,7 +465,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_lease_duration(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_lease_duration_sec(
@@ -476,7 +476,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_lease_duration_sec(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_lease_duration_nanosec(
@@ -487,7 +487,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_lease_duration_nanosec(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_lease_announcement(
@@ -498,7 +498,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_lease_announcement(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_lease_announcement_sec(
@@ -509,7 +509,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_lease_announcement_sec(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_lease_announcement_nanosec(
@@ -520,7 +520,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_lease_announcement_nanosec(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_initial_announcements(
@@ -531,7 +531,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_initial_announcements(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_initial_announcements_count(
@@ -542,7 +542,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_initial_announcements_count(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_initial_announcements_period(
@@ -553,7 +553,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_initial_announcements_period(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_initial_announcements_period_sec(
@@ -564,7 +564,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_initial_announcements_period_sec(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_initial_announcements_period_nanosec(
@@ -575,7 +575,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_initial_announcements_period_nano
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_client_announcement_period(
@@ -586,7 +586,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_client_announcement_period(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_client_announcement_period_sec(
@@ -597,7 +597,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_client_announcement_period_sec(
  *
  * @param[in] profile_id Domain participant profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_client_announcement_period_nanosec(
@@ -609,7 +609,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_client_announcement_period_nanose
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete collection is erased.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if
  *        the element does not exist in the collection if an index is provided..
  * @throw BadParameter Exception if the index is not an integer.
@@ -805,7 +805,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_client_announcement_period_nanosec(
  * @throw ElementInvalid Exception if the provided path is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_static_edp_xml_config(

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/discovery_config/DiscoveryConfig.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/discovery_config/DiscoveryConfig.hpp
@@ -816,7 +816,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_client_announcement_period_nanosec(
  * @param[in] static_edp_xml_config Builtin discovery Static EDP XML configuration file.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided path is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/discovery_config/discovery_servers/DiscoveryServers.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/discovery_config/discovery_servers/DiscoveryServers.hpp
@@ -44,7 +44,7 @@ namespace discovery_servers {
  *
  * @return std::string Specific Domain Participant builtin remote discovery server.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or the
  *        builtin remote discovery servers list does not exist, or the list does not contain any element with the
  *        provided GUID prefix.
@@ -64,7 +64,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  *
  * @return uint32_t Number of builtin remote discovery servers.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or there
  *        are no remote discovery servers configured.
  */
@@ -79,7 +79,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
  * @return std::vector<std::string> Identifier list.
  *         Empty list if there are no remote servers.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::vector<std::string> keys(
         const std::string& profile_id);
@@ -94,7 +94,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::vector<std::string> keys(
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix GUID prefix of the remote server to be removed. If empty, the complete list is removed.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile is not found in the XML file or if the
  *        specified GUID prefix does not exist either.
  */

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/discovery_config/discovery_servers/DiscoveryServers.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/discovery_config/discovery_servers/DiscoveryServers.hpp
@@ -39,7 +39,6 @@ namespace discovery_servers {
  * @brief Parse XML file and print specific Domain Participant builtin remote discovery server (Discovery Server
  *        specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix GUID prefix of the remote server to be printed. If empty, the complete list is printed.
  *
@@ -51,7 +50,6 @@ namespace discovery_servers {
  *        provided GUID prefix.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix);
 
@@ -62,7 +60,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
 /**
  * @brief Number of builtin remote discovery servers in the Domain Participant list.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return uint32_t Number of builtin remote discovery servers.
@@ -72,13 +69,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  *        are no remote discovery servers configured.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /**
  * @brief List of the identifiers for every remote server included in the Domain Participant profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  *
  * @return std::vector<std::string> Identifier list.
@@ -87,7 +82,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::vector<std::string> keys(
-        const std::string& xml_file,
         const std::string& profile_id);
 
 /************************************************************************/
@@ -97,7 +91,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::vector<std::string> keys(
 /**
  * @brief Remove specific Domain Participant discovery remote server from the list.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix GUID prefix of the remote server to be removed. If empty, the complete list is removed.
  *
@@ -106,7 +99,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::vector<std::string> keys(
  *        specified GUID prefix does not exist either.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix);
 

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/discovery_config/discovery_servers/MetatrafficMulticastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/discovery_config/discovery_servers/MetatrafficMulticastLocators.hpp
@@ -319,7 +319,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @param[in] kind Metatraffic multicast locator kind.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
@@ -341,7 +340,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @param[in] port Metatraffic multicast locator port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
@@ -363,7 +361,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @param[in] physical_port Metatraffic multicast locator TCP physical port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator physical port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
@@ -385,7 +382,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @param[in] address Metatraffic multicast locator IP address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
@@ -407,7 +403,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @param[in] unique_lan_id Metatraffic multicast TCPv4 locator unique LAN ID.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator identifier is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
@@ -429,7 +424,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @param[in] wan_address Metatraffic multicast TCPv4 locator WAN address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/discovery_config/discovery_servers/MetatrafficMulticastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/discovery_config/discovery_servers/MetatrafficMulticastLocators.hpp
@@ -47,7 +47,7 @@ namespace metatraffic_multicast_locators {
  * @return std::string XML section containing the Domain Participant specific remote server metatraffic multicast
  *         locator.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -67,7 +67,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  *
  * @return std::string Domain Participant specific remote server metatraffic multicast locator kind.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -87,7 +87,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
  *
  * @return std::string Domain Participant specific remote server metatraffic multicast locator port.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -108,7 +108,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
  *
  * @return std::string Domain Participant specific remote server metatraffic multicast locator TCP physical port.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -128,7 +128,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_physical_port(
  *
  * @return std::string Domain Participant specific remote server metatraffic multicast locator IP address.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -149,7 +149,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
  *
  * @return std::string Domain Participant specific remote server metatraffic multicast locator TCPv4 unique LAN ID.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -170,7 +170,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_unique_lan_id(
  *
  * @return std::string Domain Participant specific remote server metatraffic multicast locator TCPv4 WAN IP address.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -192,7 +192,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_address(
  *
  * @return uint32_t Number of metatraffic multicast locators in the remote server list.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML file
  *        or the list has not been set.
  */
@@ -211,7 +211,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be removed. If empty, the complete list is removed.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML file
  *        or if the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -228,7 +228,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML file
  *        or if the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -245,7 +245,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML file
  *        or if the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -262,7 +262,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_physical_port(
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML file
  *        or if the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -279,7 +279,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML file
  *        or if the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -296,7 +296,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_unique_lan_id(
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML file
  *        or if the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -322,7 +322,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
@@ -343,7 +343,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
@@ -364,7 +364,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @throw ElementInvalid Exception if the provided locator physical port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
@@ -385,7 +385,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
@@ -406,7 +406,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @throw ElementInvalid Exception if the provided locator identifier is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
@@ -427,7 +427,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_wan_address(

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/discovery_config/discovery_servers/MetatrafficMulticastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/discovery_config/discovery_servers/MetatrafficMulticastLocators.hpp
@@ -319,6 +319,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @param[in] kind Metatraffic multicast locator kind.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
@@ -340,6 +341,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @param[in] port Metatraffic multicast locator port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
@@ -361,6 +363,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @param[in] physical_port Metatraffic multicast locator TCP physical port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator physical port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
@@ -382,6 +385,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @param[in] address Metatraffic multicast locator IP address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
@@ -403,6 +407,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @param[in] unique_lan_id Metatraffic multicast TCPv4 locator unique LAN ID.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator identifier is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
@@ -424,6 +429,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @param[in] wan_address Metatraffic multicast TCPv4 locator WAN address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/discovery_config/discovery_servers/MetatrafficMulticastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/discovery_config/discovery_servers/MetatrafficMulticastLocators.hpp
@@ -40,7 +40,6 @@ namespace metatraffic_multicast_locators {
 /**
  * @brief Parse XML file and print the specific Domain Participant specific remote server metatraffic multicast locator.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be printed. If empty, the complete list is printed.
@@ -54,7 +53,6 @@ namespace metatraffic_multicast_locators {
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index);
@@ -63,7 +61,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  * @brief Parse XML file and print the specific Domain Participant specific remote server metatraffic multicast locator
  *        kind.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be printed.
@@ -76,7 +73,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index);
@@ -85,7 +81,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
  * @brief Parse XML file and print the specific Domain Participant specific remote server metatraffic multicast locator
  *        port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be printed.
@@ -98,7 +93,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index);
@@ -108,7 +102,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
  *        physical port.
  *        TCP only.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be printed.
@@ -121,7 +114,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index);
@@ -130,7 +122,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_physical_port(
  * @brief Parse XML file and print the specific Domain Participant specific remote server metatraffic multicast locator
  *        IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be printed.
@@ -143,7 +134,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_physical_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index);
@@ -153,7 +143,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
  *        unique LAN ID.
  *        TCPv4 only.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be printed.
@@ -166,7 +155,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index);
@@ -176,7 +164,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_unique_lan_id(
  *        WAN IPv4 address.
  *        TCPv4 only.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be printed.
@@ -189,7 +176,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_unique_lan_id(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index);
@@ -201,7 +187,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_address(
 /**
  * @brief Number of metatraffic multicast locators in the specific remote server of the specified Domain Participant.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  *
@@ -212,7 +197,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_address(
  *        or the list has not been set.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix);
 
@@ -223,7 +207,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
 /**
  * @brief Remove specific Domain Participant remote server metatraffic multicast locator.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be removed. If empty, the complete list is removed.
@@ -234,7 +217,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index);
@@ -242,7 +224,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
 /**
  * @brief Remove specific Domain Participant remote server metatraffic multicast locator port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be modified.
@@ -253,7 +234,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index);
@@ -261,7 +241,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
 /**
  * @brief Remove specific Domain Participant remote server metatraffic multicast locator physical port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be modified.
@@ -272,7 +251,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index);
@@ -280,7 +258,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_physical_port(
 /**
  * @brief Remove specific Domain Participant remote server metatraffic multicast locator IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be modified.
@@ -291,7 +268,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_physical_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index);
@@ -299,7 +275,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
 /**
  * @brief Remove specific Domain Participant remote server metatraffic multicast locator unique LAN ID.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be modified.
@@ -310,7 +285,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index);
@@ -318,7 +292,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_unique_lan_id(
 /**
  * @brief Remove specific Domain Participant remote server metatraffic multicast locator WAN IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be modified.
@@ -329,7 +302,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_unique_lan_id(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index);
@@ -342,7 +314,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @brief Append a remote server metatraffic multicast locator with specified kind or update the remote server
  *        metatraffic multicast locator kind.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] kind Metatraffic multicast locator kind.
@@ -355,7 +326,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& kind,
@@ -365,7 +335,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @brief Append a remote server metatraffic multicast locator with specified portUpdate the remote server metatraffic
  *        multicast locator port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] port Metatraffic multicast locator port.
@@ -378,7 +347,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& port,
@@ -388,7 +356,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @brief Append a remote server metatraffic multicast locator with specified physical port or update the remote server
  *        metatraffic multicast locator physical port (TCP only).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] physical_port Metatraffic multicast locator TCP physical port.
@@ -401,7 +368,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& physical_port,
@@ -411,7 +377,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @brief Append a remote server metatraffic multicast locator with specified IP address or update the remote server
  *        metatraffic multicast locator IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] address Metatraffic multicast locator IP address.
@@ -424,7 +389,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& address,
@@ -434,7 +398,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @brief Append a remote server metatraffic multicast TCPv4 locator with specified unique LAN ID or update the remote
  *        server metatraffic multicast TCPv4 locator unique LAN ID.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] unique_lan_id Metatraffic multicast TCPv4 locator unique LAN ID.
@@ -447,7 +410,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& unique_lan_id,
@@ -457,7 +419,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @brief Append a remote server metatraffic multicast TCPv4 locator with specified WAN address or update the remote
  *        server metatraffic multicast TCPv4 locator WAN address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] wan_address Metatraffic multicast TCPv4 locator WAN address.
@@ -470,7 +431,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& wan_address,

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/discovery_config/discovery_servers/MetatrafficUnicastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/discovery_config/discovery_servers/MetatrafficUnicastLocators.hpp
@@ -46,7 +46,7 @@ namespace metatraffic_unicast_locators {
  *
  * @return std::string XML section containing the Domain Participant specific remote server metatraffic unicast locator.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -66,7 +66,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  *
  * @return std::string Domain Participant specific remote server metatraffic unicast locator kind.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -86,7 +86,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
  *
  * @return std::string Domain Participant specific remote server metatraffic unicast locator port.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -107,7 +107,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
  *
  * @return std::string Domain Participant specific remote server metatraffic unicast locator TCP physical port.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -127,7 +127,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_physical_port(
  *
  * @return std::string Domain Participant specific remote server metatraffic unicast locator IP address.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -148,7 +148,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
  *
  * @return std::string Domain Participant specific remote server metatraffic unicast locator TCPv4 unique LAN ID.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -169,7 +169,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_unique_lan_id(
  *
  * @return std::string Domain Participant specific remote server metatraffic unicast locator TCPv4 WAN IP address.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -191,7 +191,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_address(
  *
  * @return uint32_t Number of metatraffic unicast locators in the remote server list.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML file
  *        or the list has not been set.
  */
@@ -210,7 +210,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be removed. If empty, the complete list is removed.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML file
  *        or if the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -227,7 +227,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML file
  *        or if the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -244,7 +244,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML file
  *        or if the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -261,7 +261,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_physical_port(
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML file
  *        or if the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -278,7 +278,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML file
  *        or if the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -295,7 +295,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_unique_lan_id(
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be modified.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML file
  *        or if the element does not exist in the collection.
  * @throw BadParameter Exception if the index is not an integer.
@@ -321,7 +321,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
@@ -342,7 +342,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
@@ -363,7 +363,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @throw ElementInvalid Exception if the provided locator physical port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
@@ -384,7 +384,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
@@ -405,7 +405,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @throw ElementInvalid Exception if the provided locator identifier is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
@@ -426,7 +426,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_wan_address(

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/discovery_config/discovery_servers/MetatrafficUnicastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/discovery_config/discovery_servers/MetatrafficUnicastLocators.hpp
@@ -318,7 +318,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @param[in] kind Metatraffic unicast locator kind.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
@@ -340,7 +339,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @param[in] port Metatraffic unicast locator port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
@@ -362,7 +360,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @param[in] physical_port Metatraffic unicast locator TCP physical port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator physical port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
@@ -384,7 +381,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @param[in] address Metatraffic unicast locator IP address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
@@ -406,7 +402,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @param[in] unique_lan_id Metatraffic unicast TCPv4 locator unique LAN ID.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator identifier is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
@@ -428,7 +423,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @param[in] wan_address Metatraffic unicast TCPv4 locator WAN address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/discovery_config/discovery_servers/MetatrafficUnicastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/discovery_config/discovery_servers/MetatrafficUnicastLocators.hpp
@@ -40,7 +40,6 @@ namespace metatraffic_unicast_locators {
 /**
  * @brief Parse XML file and print the specific Domain Participant specific remote server metatraffic unicast locator.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be printed. If empty, the complete list is printed.
@@ -53,7 +52,6 @@ namespace metatraffic_unicast_locators {
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index);
@@ -62,7 +60,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  * @brief Parse XML file and print the specific Domain Participant specific remote server metatraffic unicast locator
  *        kind.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be printed.
@@ -75,7 +72,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index);
@@ -84,7 +80,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
  * @brief Parse XML file and print the specific Domain Participant specific remote server metatraffic unicast locator
  *        port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be printed.
@@ -97,7 +92,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index);
@@ -107,7 +101,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
  *        physical port.
  *        TCP only.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be printed.
@@ -120,7 +113,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index);
@@ -129,7 +121,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_physical_port(
  * @brief Parse XML file and print the specific Domain Participant specific remote server metatraffic unicast locator IP
  *        address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be printed.
@@ -142,7 +133,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_physical_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index);
@@ -152,7 +142,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
  *        unique LAN ID.
  *        TCPv4 only.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be printed.
@@ -165,7 +154,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index);
@@ -175,7 +163,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_unique_lan_id(
  *        WAN IPv4 address.
  *        TCPv4 only.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be printed.
@@ -188,7 +175,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_unique_lan_id(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index);
@@ -200,7 +186,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_address(
 /**
  * @brief Number of metatraffic unicast locators in the specific remote server of the specified Domain Participant.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  *
@@ -211,7 +196,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_address(
  *        or the list has not been set.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix);
 
@@ -222,7 +206,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
 /**
  * @brief Remove specific Domain Participant remote server metatraffic unicast locator.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be removed. If empty, the complete list is removed.
@@ -233,7 +216,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index);
@@ -241,7 +223,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
 /**
  * @brief Remove specific Domain Participant remote server metatraffic unicast locator port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be modified.
@@ -252,7 +233,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index);
@@ -260,7 +240,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
 /**
  * @brief Remove specific Domain Participant remote server metatraffic unicast locator physical port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be modified.
@@ -271,7 +250,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index);
@@ -279,7 +257,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_physical_port(
 /**
  * @brief Remove specific Domain Participant remote server metatraffic unicast locator IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be modified.
@@ -290,7 +267,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_physical_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index);
@@ -298,7 +274,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
 /**
  * @brief Remove specific Domain Participant remote server metatraffic unicast locator unique LAN ID.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be modified.
@@ -309,7 +284,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index);
@@ -317,7 +291,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_unique_lan_id(
 /**
  * @brief Remove specific Domain Participant remote server metatraffic unicast locator WAN IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] index Collection element to be modified.
@@ -328,7 +301,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_unique_lan_id(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index);
@@ -341,7 +313,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @brief Append a remote server metatraffic unicast locator with specified kind or update the remote server metatraffic
  *        unicast locator kind.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] kind Metatraffic unicast locator kind.
@@ -354,7 +325,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& kind,
@@ -364,7 +334,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @brief Append a remote server metatraffic unicast locator with specified port or update the remote server metatraffic
  *        unicast locator port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] port Metatraffic unicast locator port.
@@ -377,7 +346,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& port,
@@ -387,7 +355,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @brief Append a remote server metatraffic unicast locator with specified physical port or update the remote server
  *        metatraffic unicast locator physical port (TCP only).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] physical_port Metatraffic unicast locator TCP physical port.
@@ -400,7 +367,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& physical_port,
@@ -410,7 +376,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @brief Append a remote server metatraffic unicast locator with specified IP address or update the remote server
  *        metatraffic unicast locator IP address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] address Metatraffic unicast locator IP address.
@@ -423,7 +388,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& address,
@@ -433,7 +397,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @brief Append a remote server metatraffic unicast TCPv4 locator with specified unique LAN ID or update the remote
  *        server metatraffic unicast TCPv4 locator unique LAN ID.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] unique_lan_id Metatraffic unicast TCPv4 locator unique LAN ID.
@@ -446,7 +409,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& unique_lan_id,
@@ -456,7 +418,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @brief Append a remote server metatraffic unicast TCPv4 locator with specified WAN address or update the remote
  *        server metatraffic unicast TCPv4 locator WAN address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] profile_id Domain participant profile identifier.
  * @param[in] prefix Remote server GUID prefix.
  * @param[in] wan_address Metatraffic unicast TCPv4 locator WAN address.
@@ -469,7 +430,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& wan_address,

--- a/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/discovery_config/discovery_servers/MetatrafficUnicastLocators.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/domain_participant/builtin/discovery_config/discovery_servers/MetatrafficUnicastLocators.hpp
@@ -318,6 +318,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_address(
  * @param[in] kind Metatraffic unicast locator kind.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
@@ -339,6 +340,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @param[in] port Metatraffic unicast locator port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
@@ -360,6 +362,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port(
  * @param[in] physical_port Metatraffic unicast locator TCP physical port.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator physical port is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
@@ -381,6 +384,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_physical_port(
  * @param[in] address Metatraffic unicast locator IP address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
@@ -402,6 +406,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_address(
  * @param[in] unique_lan_id Metatraffic unicast TCPv4 locator unique LAN ID.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator identifier is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.
@@ -423,6 +428,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_unique_lan_id(
  * @param[in] wan_address Metatraffic unicast TCPv4 locator WAN address.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the specified Domain Participant profile/GUID prefix is not found in the XML
  *        file, the list element does not exist, or the list does not contain any element in index position.

--- a/lib/include/fastdds_qos_profiles_manager_lib/exception/Exception.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/exception/Exception.hpp
@@ -199,35 +199,6 @@ public:
 };
 
 /**
- * @brief Exception to signal that the provided XML file does not exist
- */
-class FileNotFound : public Exception
-{
-
-public:
-
-    // Use parent constructors.
-    using Exception::Exception;
-
-    /**
-     * @brief Copies the qosprof::FileNotFound exception into a new one
-     *
-     * @param other The original exception object to copy
-     */
-    FASTDDS_QOS_PROFILES_MANAGER_DllAPI FileNotFound(
-            const FileNotFound& other) = default;
-
-    /**
-     * @brief Copies the qosprof::FileNotFound exception into the current one
-     *
-     * @param other The original qosprof::FileNotFound exception to copy
-     * @return the current qosprof::FileNotFound exception after the copy
-     */
-    FASTDDS_QOS_PROFILES_MANAGER_DllAPI FileNotFound& operator =(
-            const FileNotFound& other) = default;
-};
-
-/**
  * @brief Exception to signal that an operation is not supported
  *
  * Query the `what` in order to have more information about the validation failure

--- a/lib/include/fastdds_qos_profiles_manager_lib/transport_descriptor/TransportDescriptor.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/transport_descriptor/TransportDescriptor.hpp
@@ -1121,6 +1121,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_rtps_dump_file(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] kind Transport descriptor kind.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided kind is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
@@ -1133,6 +1134,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] send_buffer_size Transport descriptor send buffer size.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided send buffer size is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_send_buffer_size(
@@ -1145,6 +1147,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_send_buffer_size(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] receive_buffer_size Transport descriptor receive buffer size.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided receive buffer size is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_receive_buffer_size(
@@ -1157,6 +1160,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_receive_buffer_size(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] max_message_size Transport descriptor maximum message size.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided maximum message size is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_max_message_size(
@@ -1169,6 +1173,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_max_message_size(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] max_initial_peers_range Transport descriptor maximum initial peers range.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided maximum initial peers range is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_max_initial_peers_range(
@@ -1181,6 +1186,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_max_initial_peers_range(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] ttl Transport descriptor TTL (Time to live) in number of hops.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided TTL is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_ttl(
@@ -1229,6 +1235,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_wan_addr(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] keep_alive_frequency_ms Frequency of TCP keep alive requests (in ms).
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided keep alive frequency is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_keep_alive_frequency_ms(
@@ -1242,6 +1249,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_keep_alive_frequency_ms(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] keep_alive_timeout_ms Time since the last keep alive request to consider the connection broken (in ms).
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided keep alive timeout is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_keep_alive_timeout_ms(
@@ -1255,6 +1263,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_keep_alive_timeout_ms(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] max_logical_port Maximum number of logical ports to try during TCP negotiation.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided maximum number of logical ports is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_max_logical_port(
@@ -1268,6 +1277,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_max_logical_port(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] logical_port_range Maximum number of logical ports per request to try during TCP negotiation.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided maximum number of logical ports per request is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_logical_port_range(
@@ -1281,6 +1291,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_logical_port_range(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] logical_port_increment Increment between logical ports to try during TCP negotiation.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided maximum number of logical ports per request is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_logical_port_increment(
@@ -1293,6 +1304,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_logical_port_increment(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] tls_password TCP Transport Descriptor TLS password.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided TLS password is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_password(
@@ -1305,6 +1317,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_password(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] tls_private_key_file Path to the private key certificate file.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided path is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_private_key_file(
@@ -1317,6 +1330,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_private_key_file(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] tls_rsa_private_key_file Path to the private key RSA certificate file.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided path is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_rsa_private_key_file(
@@ -1329,6 +1343,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_rsa_private_key_file(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] tls_cert_chain_file Path to the public certificate chain file.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided path is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_cert_chain_file(
@@ -1341,6 +1356,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_cert_chain_file(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] tls_tmp_dh_file Path to the Diffie-Hellman parameters file.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided path is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_tmp_dh_file(
@@ -1353,6 +1369,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_tmp_dh_file(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] tls_verify_file Path to the CA file.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided path is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_verify_file(
@@ -1366,6 +1383,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_verify_file(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] tls_verify_depth Maximum allowed depth for verifying intermediate certificates.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided depth is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_verify_depth(
@@ -1378,6 +1396,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_verify_depth(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] tls_default_verify_path Flag that enables looking for verification files on the default paths.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided flag value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_default_verify_path(
@@ -1390,6 +1409,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_default_verify_path(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] tls_handshake_role Role that the Transport will take on handshaking.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided handshake role is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_handshake_role(
@@ -1402,6 +1422,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_handshake_role(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] tls_server_name SNI (Server Name Indication) server name.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided SNI server name is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_server_name(
@@ -1414,6 +1435,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_server_name(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] calculate_crc Flag to enable CRC calculation and sending.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided CRC calculation flag is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_calculate_crc(
@@ -1426,6 +1448,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_calculate_crc(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] check_crc Flag to enable CRC checking of incoming messages.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided check CRC flag is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_check_crc(
@@ -1450,6 +1473,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_enable_tcp_nodelay(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] segment_size Shared memory segment size.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided segment size is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_segment_size(
@@ -1462,6 +1486,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_segment_size(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] port_queue_capacity Listening port capacity in number of messages.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided listening port capacity is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port_queue_capacity(
@@ -1474,6 +1499,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port_queue_capacity(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] healthy_check_timeout_ms Listening port liveliness timeout in milliseconds.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided listening port liveliness timeout is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_healthy_check_timeout_ms(
@@ -1486,6 +1512,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_healthy_check_timeout_ms(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] rtps_dump_file Path to the file where RTPS messsages will be stored for debugging purposes.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided path is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_rtps_dump_file(
@@ -1504,6 +1531,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_rtps_dump_file(
  * @param[in] ip_address IP address to be updated in the whitelist collection.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided IP address is not valid.
  * @throw ElementNotFound Exception if the specified Transport descriptor profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -1523,6 +1551,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_interface_whitelist(
  * @param[in] port Updated port to listen as server.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided port is not valid.
  * @throw ElementNotFound Exception if the specified Transport descriptor profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -1542,6 +1571,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_listening_ports(
  * @param[in] tls_verify_mode TLS verification mode to update in the mask.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided TLS verification mode is not valid.
  * @throw ElementNotFound Exception if the specified Transport descriptor profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -1561,6 +1591,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_verify_mode(
  * @param[in] tls_options TLS supported feature to update in the mask.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided TLS supported feature is not valid.
  * @throw ElementNotFound Exception if the specified Transport descriptor profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -1580,6 +1611,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_options(
  * @param[in] tls_verify_path TLS verification path to be updated in the list.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided path is not valid.
  * @throw ElementNotFound Exception if the specified Transport descriptor profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.

--- a/lib/include/fastdds_qos_profiles_manager_lib/transport_descriptor/TransportDescriptor.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/transport_descriptor/TransportDescriptor.hpp
@@ -35,7 +35,6 @@ namespace transport_descriptor {
 /**
  * @brief Parse XML file and print specific transport descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier. If empty, every transport descriptor
  *                                    profile is printed.
  *
@@ -45,13 +44,11 @@ namespace transport_descriptor {
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific Transport Descriptor kind.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string Transport Descriptor kind
@@ -60,13 +57,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific Transport Descriptor send buffer size.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string Transport descriptor send buffer size.
@@ -76,13 +71,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
  *        send buffer size element has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_send_buffer_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific Transport Descriptor receive buffer size.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string Transport descriptor receive buffer size.
@@ -92,13 +85,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_send_buffer_size(
  *        receive buffer size element has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_receive_buffer_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific Transport Descriptor maximum message size.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string Transport descriptor maximum message size.
@@ -108,13 +99,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_receive_buffer_size(
  *        maximum message size element has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_max_message_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific Transport Descriptor maximum initial peers range.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string Transport descriptor maximum initial peers range.
@@ -124,13 +113,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_max_message_size(
  *        maximum initial peers range element has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_max_initial_peers_range(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the Transport Descriptor specific whitelisted network interface element.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] index Collection element to be printed. If empty, the complete collection is printed.
  *
@@ -142,14 +129,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_max_initial_peers_range(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_interface_whitelist(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the specific Transport Descriptor TTL (Time to live).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string Transport descriptor TTL in number of hops.
@@ -159,13 +144,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_interface_whitelist(
  *        TTL element has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_ttl(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific UDP Transport Descriptor non blocking send flag.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string Transport descriptor non blocking send flag.
@@ -175,13 +158,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_ttl(
  *        non blocking send flag has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_non_blocking_send(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific UDP Transport Descriptor output port.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string UDP Transport descriptor output port.
@@ -191,13 +172,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_non_blocking_send(
  *        ouput port has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_output_port(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific TCPv4 Transport Descriptor WAN address.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::String TCPv4 Transport descriptor WAN address.
@@ -207,13 +186,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_output_port(
  *        WAN address has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_addr(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific frequency of TCP Transport Descriptor keep alive requests.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string Frequency of TCP keep alive requests (in milliseconds).
@@ -223,14 +200,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_addr(
  *        keep alive frequency has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_keep_alive_frequency_ms(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific timeout (in milliseconds) to consider a TCP connection broken if no keep
  *        alive is received.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string TCP keep alive timeout (in milliseconds).
@@ -240,13 +215,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_keep_alive_frequency_ms(
  *        keep alive timeout has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_keep_alive_timeout_ms(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific maximum number of logical ports to try during TCP negotiation.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string Maximum number of logical ports to try during TCP negotiation.
@@ -256,14 +229,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_keep_alive_timeout_ms(
  *        maximum number of logical ports has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_max_logical_port(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific maximum number of logical ports per request to try during TCP
  *        negotiation.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string Maximum number of logical ports per request to try during TCP negotiation.
@@ -273,13 +244,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_max_logical_port(
  *        maximum number of logical ports per request has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_logical_port_range(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific increment between logical ports to try during TCP negotiation.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string Increment between logical ports to try during TCP negotiation.
@@ -289,13 +258,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_logical_port_range(
  *        logical port increment has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_logical_port_increment(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the TCP Transport Descriptor specific listening port element.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] index Collection element to be printed. If empty, the complete collection is printed.
  *
@@ -307,14 +274,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_logical_port_increment(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_listening_ports(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the specific TCP Transport Descriptor TLS configuration.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string XML section containing the specific TCP Transport Descriptor TLS configuration.
@@ -324,13 +289,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_listening_ports(
  *        TLS configuration element has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific TCP Transport Descriptor TLS password.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string Specific TCP Transport Descriptor TLS password.
@@ -340,13 +303,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls(
  *        TLS password element has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_password(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific TCP Transport Descriptor TLS private key certificate path.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string Specific TCP Transport Descriptor path to the TLS private key certificate file.
@@ -356,13 +317,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_password(
  *        TLS private key certificate path element has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_private_key_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific TCP Transport Descriptor TLS private key RSA certificate path.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string Specific TCP Transport Descriptor path to the TLS private key RSA certificate file.
@@ -372,13 +331,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_private_key_file(
  *        TLS private key RSA certificate path element has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_rsa_private_key_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific TCP Transport Descriptor TLS public certificate chain file path.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string Specific TCP Transport Descriptor path to the TLS public certificate chain file.
@@ -388,13 +345,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_rsa_private_key_file(
  *        TLS public certificate chain file path element has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_cert_chain_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific TCP Transport Descriptor TLS Diffie-Hellman parameters file path.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string Specific TCP Transport Descriptor path to the TLS Diffie-Hellman parameters file.
@@ -404,13 +359,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_cert_chain_file(
  *        TLS Diffie-Hellman parameters file path element has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_tmp_dh_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific TCP Transport Descriptor TLS CA (Certification Authority) file path.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string Specific TCP Transport Descriptor path to the CA file.
@@ -420,13 +373,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_tmp_dh_file(
  *        TLS CA file path element has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_verify_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the TCP Transport Descriptor specific TLS verification mode element.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] index Collection element to be printed. If empty, the complete collection is printed.
  *
@@ -438,14 +389,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_verify_file(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_verify_mode(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the TCP Transport Descriptor specific TLS supported feature.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] index Collection element to be printed. If empty, the complete collection is printed.
  *
@@ -457,14 +406,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_verify_mode(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_options(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the TCP Transport Descriptor specific TLS path to verification files.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] index Collection element to be printed. If empty, the complete collection is printed.
  *
@@ -476,14 +423,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_options(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_verify_paths(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& index);
 
 /**
  * @brief Parse XML file and print the specific TCP Transport Descriptor TLS maximum verification depth.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string Specific TCP Transport Descriptor maximum allowed depth for verifying intermediate certificates.
@@ -493,13 +438,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_verify_paths(
  *        TLS verify depth element has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_verify_depth(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific TCP Transport Descriptor TLS verify default paths flag.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string Specific TCP Transport Descriptor verify default paths flag.
@@ -509,13 +452,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_verify_depth(
  *        TLS verify default paths flag has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_default_verify_path(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific TCP Transport Descriptor TLS handshake role.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string Specific TCP Transport Descriptor handshake role.
@@ -525,13 +466,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_default_verify_path(
  *        TLS handshake role has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_handshake_role(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific TCP Transport Descriptor TLS SNI server name.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string Specific TCP Transport Descriptor SNI server name.
@@ -541,13 +480,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_handshake_role(
  *        TLS SNI server name has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_server_name(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific TCP Transport Descriptor calculate CRC flag
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string Specific TCP Transport Descriptor calculate CRC flag.
@@ -557,13 +494,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_server_name(
  *        calculate CRC flag has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_calculate_crc(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific TCP Transport Descriptor check CRC flag
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string Specific TCP Transport Descriptor check CRC flag.
@@ -573,13 +508,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_calculate_crc(
  *        check CRC flag has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_check_crc(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific TCP Transport Descriptor TCP_NODELAY socket option flag
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string Specific TCP Transport Descriptor TCP_NODELAY socket option flag.
@@ -589,13 +522,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_check_crc(
  *        TCP_NODELAY socket option flag has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_enable_tcp_nodelay(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific SHM Transport Descriptor shared memory segment size.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string Specific SHM Transport Descriptor shared memory segment size.
@@ -605,13 +536,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_enable_tcp_nodelay(
  *        shared memory segment size has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_segment_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific SHM Transport Descriptor listening port capacity.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string Specific SHM Transport Descriptor listening port capacity in number of messages.
@@ -621,13 +550,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_segment_size(
  *        listening port capacity has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port_queue_capacity(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific SHM Transport Descriptor listening port liveliness timeout.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string Specific SHM Transport Descriptor listening port liveliness timeout (in milliseconds).
@@ -637,13 +564,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port_queue_capacity(
  *        listening port liveliness timeout has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_healthy_check_timeout_ms(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Parse XML file and print the specific SHM Transport Descriptor debugging file path.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return std::string Specific SHM Transport Descriptor debugging file path.
@@ -653,7 +578,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_healthy_check_timeout_ms(
  *        debugging file path has not been set in the profile.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_rtps_dump_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /************************************************************************/
@@ -663,32 +587,25 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_rtps_dump_file(
 /**
  * @brief Number of transport descriptor profiles contained in the XML file.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
- *
  * @return uint32_t Number of transport descriptor profiles in the XML file.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  */
-FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size(
-        const std::string& xml_file);
+FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size();
 
 /**
  * @brief List of the identifiers for every transport descriptor profile in the XML file.
- *
- * @param[in] xml_file Absolute/relative path to the XML file.
  *
  * @return std::vector<std::string> Identifier list.
  *         Empty list if there are no transport descriptor profiles.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  */
-FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::vector<std::string> keys(
-        const std::string& xml_file);
+FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::vector<std::string> keys();
 
 /**
  * @brief Number of whitelisted network interfaces in the Transport Descriptor list.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return uint32_t Number of network interfaces whitelisted in the list.
@@ -697,13 +614,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::vector<std::string> keys(
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t interface_whitelist_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Number of listening ports in the TCP Transport Descriptor list.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return uint32_t Number of listening ports in the list.
@@ -712,13 +627,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t interface_whitelist_size(
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t listening_ports_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Number of TLS verification modes enabled in the mask in the TCP Transport Descriptor.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return uint32_t Number of TLS verification modes enabled in the mask.
@@ -727,13 +640,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t listening_ports_size(
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t tls_verify_mode_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Number of TLS supported features enabled in the mask in the TCP Transport Descriptor.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return uint32_t Number of TLS supported features enabled in the mask.
@@ -742,13 +653,11 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t tls_verify_mode_size(
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t tls_options_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Number of TLS verification paths included in the TCP Transport Descriptor.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @return uint32_t Number of TLS paths to look for verification files.
@@ -757,7 +666,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t tls_options_size(
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t tls_verify_paths_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /************************************************************************/
@@ -767,7 +675,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t tls_verify_paths_size(
 /**
  * @brief Remove specific transport descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier. If empty, every transport descriptor
  *                                    profile is deleted.
  *
@@ -775,79 +682,66 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t tls_verify_paths_size(
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove transport descriptor profile kind.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
- *
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_kind(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove send buffer size element from specific Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_send_buffer_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove receive buffer size element from specific Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_receive_buffer_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove maximum message size element from specific Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_max_message_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove maximum initial peers range element from specific Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_max_initial_peers_range(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove specific whitelisted network interface from specific Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete collection is erased.
  *
@@ -857,131 +751,111 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_max_initial_peers_range(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_interface_whitelist(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& index);
 
 /**
  * @brief Remove TTL (Time to live) element from specific Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_ttl(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove non blocking send flag from specific Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_non_blocking_send(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove output port from specific Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_output_port(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove WAN address from specific Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_addr(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove TCP keep alive frequency from specific Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_keep_alive_frequency_ms(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove TCP keep alive timeout from specific Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_keep_alive_timeout_ms(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove maximum number of logical ports from specific TCP Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_max_logical_port(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove maximum number of logical ports per request from specific TCP Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_logical_port_range(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove logical port increment element from specific TCP Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_logical_port_increment(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove specific listening port from specific Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete collection is erased.
  *
@@ -991,105 +865,89 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_logical_port_increment(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_listening_ports(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& index);
 
 /**
  * @brief Remove TLS configuration from TCP Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove TLS password from TCP Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_password(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove TLS private key certificate path from TCP Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_private_key_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove TLS private key RSA certificate path from TCP Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_rsa_private_key_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove TLS public certificate chain file path from TCP Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_cert_chain_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove TLS Diffie-Hellman parameters file path from TCP Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_tmp_dh_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove TLS CA (Certification Authority) file path from TCP Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_verify_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove specific TLS verification mode from specific Transport Descriptor profile mask.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete collection is erased.
  *
@@ -1099,14 +957,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_verify_file(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_verify_mode(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& index);
 
 /**
  * @brief Remove specific TLS supported feature from specific Transport Descriptor profile mask.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete collection is erased.
  *
@@ -1116,14 +972,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_verify_mode(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_options(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& index);
 
 /**
  * @brief Remove specific TLS verification path from specific Transport Descriptor profile mask.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete collection is erased.
  *
@@ -1133,151 +987,128 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_options(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_verify_paths(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& index);
 
 /**
  * @brief Remove TLS maximum verification depth from TCP Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_verify_depth(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove TLS verify default paths flag from TCP Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_default_verify_path(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove TLS handshake role from TCP Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_handshake_role(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove TLS SNI server name from TCP Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_server_name(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove calculate CRC flag from TCP Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_calculate_crc(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove check CRC flag from TCP Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_check_crc(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove TCP_NODELAY socket option flag from TCP Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_enable_tcp_nodelay(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove shared memory segment size from SHM Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_segment_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove shared memory listening port capacity from SHM Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port_queue_capacity(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove shared memory listening port liveliness timeout from SHM Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_healthy_check_timeout_ms(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /**
  * @brief Remove shared memory debugging file path from SHM Transport Descriptor profile.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
  * @throw FileNotFound Exception if the provided XML file is not found/readable.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_rtps_dump_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id);
 
 /************************************************************************/
@@ -1287,140 +1118,120 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_rtps_dump_file(
 /**
  * @brief Set the Transport Descriptor kind.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] kind Transport descriptor kind.
  *
  * @throw ElementInvalid Exception if the provided kind is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_kind(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& kind);
 
 /**
  * @brief Set the Transport Descriptor send buffer size.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] send_buffer_size Transport descriptor send buffer size.
  *
  * @throw ElementInvalid Exception if the provided send buffer size is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_send_buffer_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& send_buffer_size);
 
 /**
  * @brief Set the Transport Descriptor receive buffer size.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] receive_buffer_size Transport descriptor receive buffer size.
  *
  * @throw ElementInvalid Exception if the provided receive buffer size is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_receive_buffer_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& receive_buffer_size);
 
 /**
  * @brief Set the Transport Descriptor maximum message size.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] max_message_size Transport descriptor maximum message size.
  *
  * @throw ElementInvalid Exception if the provided maximum message size is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_max_message_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& max_message_size);
 
 /**
  * @brief Set the Transport Descriptor maximum initial peers range.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] max_initial_peers_range Transport descriptor maximum initial peers range.
  *
  * @throw ElementInvalid Exception if the provided maximum initial peers range is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_max_initial_peers_range(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& max_initial_peers_range);
 
 /**
  * @brief Set the Transport Descriptor TTL (Time to live).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] ttl Transport descriptor TTL (Time to live) in number of hops.
  *
  * @throw ElementInvalid Exception if the provided TTL is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_ttl(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& ttl);
 
 /**
  * @brief Set the Transport Descriptor non blocking send flag (UDP Transport specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] non_blocking_send Enable/disable this flag in the Transport Descriptor.
  *
  * @throw ElementInvalid Exception if the flag does not apply to the Transport Descriptor.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_non_blocking_send(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& non_blocking_send);
 
 /**
  * @brief Set the Transport Descriptor output port (UDP Transport specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] output_port UDP Transport output port.
  *
  * @throw ElementInvalid Exception if the output port provided is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_output_port(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& output_port);
 
 /**
  * @brief Set the Transport Descriptor WAN address (TCPv4 Transport specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] wan_addr TCPv4 Transport WAN address.
  *
  * @throw ElementInvalid Exception if the output port provided is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_wan_addr(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& wan_addr);
 
 /**
  * @brief Set the TCP Transport Descriptor frequency for keep alive requests in milliseconds (TCP Transport specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] keep_alive_frequency_ms Frequency of TCP keep alive requests (in ms).
  *
  * @throw ElementInvalid Exception if the provided keep alive frequency is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_keep_alive_frequency_ms(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& keep_alive_frequency_ms);
 
@@ -1428,14 +1239,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_keep_alive_frequency_ms(
  * @brief Set the TCP Transport Descriptor timeout to consider a connection broken if no keep alive request is received
  *       in milliseconds (TCP Transport specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] keep_alive_timeout_ms Time since the last keep alive request to consider the connection broken (in ms).
  *
  * @throw ElementInvalid Exception if the provided keep alive timeout is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_keep_alive_timeout_ms(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& keep_alive_timeout_ms);
 
@@ -1443,14 +1252,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_keep_alive_timeout_ms(
  * @brief Set the TCP Transport Descriptor maximum number of logical ports to try during TCP negotiation (TCP Transport
  *        specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] max_logical_port Maximum number of logical ports to try during TCP negotiation.
  *
  * @throw ElementInvalid Exception if the provided maximum number of logical ports is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_max_logical_port(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& max_logical_port);
 
@@ -1458,14 +1265,12 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_max_logical_port(
  * @brief Set the TCP Transport Descriptor maximum number of logical ports per request to try during TCP negotiation
  *        (TCP Transport specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] logical_port_range Maximum number of logical ports per request to try during TCP negotiation.
  *
  * @throw ElementInvalid Exception if the provided maximum number of logical ports per request is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_logical_port_range(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& logical_port_range);
 
@@ -1473,98 +1278,84 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_logical_port_range(
  * @brief Set the TCP Transport Descriptor increment between logical ports to try during TCP negotiation (TCP Transport
  *        specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] logical_port_increment Increment between logical ports to try during TCP negotiation.
  *
  * @throw ElementInvalid Exception if the provided maximum number of logical ports per request is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_logical_port_increment(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& logical_port_increment);
 
 /**
  * @brief Set the TCP Transport Descriptor TLS password (TCP Transport specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] tls_password TCP Transport Descriptor TLS password.
  *
  * @throw ElementInvalid Exception if the provided TLS password is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_password(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& tls_password);
 
 /**
  * @brief Set the TCP Transport Descriptor TLS private key certificate path (TCP Transport specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] tls_private_key_file Path to the private key certificate file.
  *
  * @throw ElementInvalid Exception if the provided path is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_private_key_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& tls_private_key_file);
 
 /**
  * @brief Set the TCP Transport Descriptor TLS private key RSA certificate path (TCP Transport specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] tls_rsa_private_key_file Path to the private key RSA certificate file.
  *
  * @throw ElementInvalid Exception if the provided path is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_rsa_private_key_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& tls_rsa_private_key_file);
 
 /**
  * @brief Set the TCP Transport Descriptor TLS public certificate chain file path (TCP Transport specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] tls_cert_chain_file Path to the public certificate chain file.
  *
  * @throw ElementInvalid Exception if the provided path is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_cert_chain_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& tls_cert_chain_file);
 
 /**
  * @brief Set the TCP Transport Descriptor TLS Diffie-Hellman parameters file path (TCP Transport specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] tls_tmp_dh_file Path to the Diffie-Hellman parameters file.
  *
  * @throw ElementInvalid Exception if the provided path is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_tmp_dh_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& tls_tmp_dh_file);
 
 /**
  * @brief Set the TCP Transport Descriptor TLS CA (Certification Authority) file path (TCP Transport specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] tls_verify_file Path to the CA file.
  *
  * @throw ElementInvalid Exception if the provided path is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_verify_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& tls_verify_file);
 
@@ -1572,154 +1363,132 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_verify_file(
  * @brief Set the TCP Transport Descriptor TLS maximum allowed depth for verifying intermediate certificates (TCP
  *        Transport specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] tls_verify_depth Maximum allowed depth for verifying intermediate certificates.
  *
  * @throw ElementInvalid Exception if the provided depth is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_verify_depth(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& tls_verify_depth);
 
 /**
  * @brief Set the TCP Transport Descriptor TLS verify default paths flag (TCP Transport specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] tls_default_verify_path Flag that enables looking for verification files on the default paths.
  *
  * @throw ElementInvalid Exception if the provided flag value is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_default_verify_path(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& tls_default_verify_path);
 
 /**
  * @brief Set the TCP Transport Descriptor TLS handshake role (TCP Transport specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] tls_handshake_role Role that the Transport will take on handshaking.
  *
  * @throw ElementInvalid Exception if the provided handshake role is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_handshake_role(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& tls_handshake_role);
 
 /**
  * @brief Set the TCP Transport Descriptor TLS SNI server name (TCP Transport specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] tls_server_name SNI (Server Name Indication) server name.
  *
  * @throw ElementInvalid Exception if the provided SNI server name is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_server_name(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& tls_server_name);
 
 /**
  * @brief Set the TCP Transport Descriptor calculate CRC flag (TCP Transport specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] calculate_crc Flag to enable CRC calculation and sending.
  *
  * @throw ElementInvalid Exception if the provided CRC calculation flag is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_calculate_crc(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& calculate_crc);
 
 /**
  * @brief Set the TCP Transport Descriptor check CRC flag (TCP Transport specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] check_crc Flag to enable CRC checking of incoming messages.
  *
  * @throw ElementInvalid Exception if the provided check CRC flag is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_check_crc(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& check_crc);
 
 /**
  * @brief Enable the TCP Transport Descriptor TCP_NODELAY socket option (TCP Transport specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] enable_tcp_nodelay Flag to enable TCP_NODELAY socket option.
  *
  * @throw ElementInvalid Exception if the TCP_NODELAY flag is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_enable_tcp_nodelay(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& enable_tcp_nodelay);
 
 /**
  * @brief Set the SHM Transport Descriptor shared memory segment size (SHM Transport specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] segment_size Shared memory segment size.
  *
  * @throw ElementInvalid Exception if the provided segment size is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_segment_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& segment_size);
 
 /**
  * @brief Set the SHM Transport Descriptor listening port capacity (SHM Transport specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] port_queue_capacity Listening port capacity in number of messages.
  *
  * @throw ElementInvalid Exception if the provided listening port capacity is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_port_queue_capacity(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& port_queue_capacity);
 
 /**
  * @brief Set the SHM Transport Descriptor listening port liveliness timeout (SHM Transport specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] healthy_check_timeout_ms Listening port liveliness timeout in milliseconds.
  *
  * @throw ElementInvalid Exception if the provided listening port liveliness timeout is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_healthy_check_timeout_ms(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& healthy_check_timeout_ms);
 
 /**
  * @brief Set the SHM Transport Descriptor path to the debug file (SHM Transport specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] rtps_dump_file Path to the file where RTPS messsages will be stored for debugging purposes.
  *
  * @throw ElementInvalid Exception if the provided path is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_rtps_dump_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& rtps_dump_file);
 
@@ -1731,7 +1500,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_rtps_dump_file(
  * @brief Append an IP address to the whitelisted network interfaces collection or update IP address in the whitelisted
  *        network interfaces collection.
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] ip_address IP address to be updated in the whitelist collection.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -1743,7 +1511,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_rtps_dump_file(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_interface_whitelist(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& ip_address,
         const std::string& index);
@@ -1752,7 +1519,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_interface_whitelist(
  * @brief Append a listening port to the TCP Transport Descriptor collection or update a listening port to the TCP
  *        Transport Descriptor collection (TCP Transport specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] port Updated port to listen as server.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -1764,7 +1530,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_interface_whitelist(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_listening_ports(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& port,
         const std::string& index);
@@ -1773,7 +1538,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_listening_ports(
  * @brief Append a TLS verification mode to the TCP Transport Descriptor mask or update a TLS verification mode to the
  *        TCP Transport Descriptor mask (TCP Transport specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] tls_verify_mode TLS verification mode to update in the mask.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -1785,7 +1549,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_listening_ports(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_verify_mode(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& tls_verify_mode,
         const std::string& index);
@@ -1794,7 +1557,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_verify_mode(
  * @brief Append TLS supported features to the TCP Transport Descriptor mask or update a TLS supported feature to the
  *        TCP Transport Descriptor mask (TCP Transport specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] tls_options TLS supported feature to update in the mask.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -1806,7 +1568,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_verify_mode(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_options(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& tls_options,
         const std::string& index);
@@ -1815,7 +1576,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_options(
  * @brief Append TLS verification path to the TCP Transport Descriptor or update a TLS verification path to the TCP
  *        Transport Descriptor (TCP Transport specific).
  *
- * @param[in] xml_file Absolute/relative path to the XML file.
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] tls_verify_path TLS verification path to be updated in the list.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
@@ -1827,7 +1587,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_options(
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_verify_path(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& tls_verify_path,
         const std::string& index);

--- a/lib/include/fastdds_qos_profiles_manager_lib/transport_descriptor/TransportDescriptor.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/transport_descriptor/TransportDescriptor.hpp
@@ -1199,6 +1199,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_ttl(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] non_blocking_send Enable/disable this flag in the Transport Descriptor.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the flag does not apply to the Transport Descriptor.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_non_blocking_send(
@@ -1211,6 +1212,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_non_blocking_send(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] output_port UDP Transport output port.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the output port provided is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_output_port(
@@ -1223,6 +1225,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_output_port(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] wan_addr TCPv4 Transport WAN address.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the output port provided is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_wan_addr(
@@ -1461,6 +1464,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_check_crc(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] enable_tcp_nodelay Flag to enable TCP_NODELAY socket option.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the TCP_NODELAY flag is not valid.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_enable_tcp_nodelay(
@@ -1531,7 +1535,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_rtps_dump_file(
  * @param[in] ip_address IP address to be updated in the whitelist collection.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided IP address is not valid.
  * @throw ElementNotFound Exception if the specified Transport descriptor profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -1551,7 +1554,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_interface_whitelist(
  * @param[in] port Updated port to listen as server.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided port is not valid.
  * @throw ElementNotFound Exception if the specified Transport descriptor profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -1571,7 +1573,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_listening_ports(
  * @param[in] tls_verify_mode TLS verification mode to update in the mask.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided TLS verification mode is not valid.
  * @throw ElementNotFound Exception if the specified Transport descriptor profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -1591,7 +1592,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_verify_mode(
  * @param[in] tls_options TLS supported feature to update in the mask.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided TLS supported feature is not valid.
  * @throw ElementNotFound Exception if the specified Transport descriptor profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
@@ -1611,7 +1611,6 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_options(
  * @param[in] tls_verify_path TLS verification path to be updated in the list.
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided path is not valid.
  * @throw ElementNotFound Exception if the specified Transport descriptor profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.

--- a/lib/include/fastdds_qos_profiles_manager_lib/transport_descriptor/TransportDescriptor.hpp
+++ b/lib/include/fastdds_qos_profiles_manager_lib/transport_descriptor/TransportDescriptor.hpp
@@ -40,7 +40,7 @@ namespace transport_descriptor {
  *
  * @return std::string XML section containing the specific transport descriptor profile.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
@@ -53,7 +53,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print(
  *
  * @return std::string Transport Descriptor kind
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
@@ -66,7 +66,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_kind(
  *
  * @return std::string Transport descriptor send buffer size.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        send buffer size element has not been set in the profile.
  */
@@ -80,7 +80,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_send_buffer_size(
  *
  * @return std::string Transport descriptor receive buffer size.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        receive buffer size element has not been set in the profile.
  */
@@ -94,7 +94,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_receive_buffer_size(
  *
  * @return std::string Transport descriptor maximum message size.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        maximum message size element has not been set in the profile.
  */
@@ -108,7 +108,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_max_message_size(
  *
  * @return std::string Transport descriptor maximum initial peers range.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        maximum initial peers range element has not been set in the profile.
  */
@@ -123,7 +123,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_max_initial_peers_range(
  *
  * @return std::string Transport descriptor specific network interface whitelisted.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -139,7 +139,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_interface_whitelist(
  *
  * @return std::string Transport descriptor TTL in number of hops.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        TTL element has not been set in the profile.
  */
@@ -153,7 +153,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_ttl(
  *
  * @return std::string Transport descriptor non blocking send flag.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        non blocking send flag has not been set in the profile.
  */
@@ -167,7 +167,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_non_blocking_send(
  *
  * @return std::string UDP Transport descriptor output port.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        ouput port has not been set in the profile.
  */
@@ -181,7 +181,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_output_port(
  *
  * @return std::String TCPv4 Transport descriptor WAN address.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        WAN address has not been set in the profile.
  */
@@ -195,7 +195,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_wan_addr(
  *
  * @return std::string Frequency of TCP keep alive requests (in milliseconds).
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        keep alive frequency has not been set in the profile.
  */
@@ -210,7 +210,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_keep_alive_frequency_ms(
  *
  * @return std::string TCP keep alive timeout (in milliseconds).
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        keep alive timeout has not been set in the profile.
  */
@@ -224,7 +224,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_keep_alive_timeout_ms(
  *
  * @return std::string Maximum number of logical ports to try during TCP negotiation.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        maximum number of logical ports has not been set in the profile.
  */
@@ -239,7 +239,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_max_logical_port(
  *
  * @return std::string Maximum number of logical ports per request to try during TCP negotiation.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        maximum number of logical ports per request has not been set in the profile.
  */
@@ -253,7 +253,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_logical_port_range(
  *
  * @return std::string Increment between logical ports to try during TCP negotiation.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        logical port increment has not been set in the profile.
  */
@@ -268,7 +268,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_logical_port_increment(
  *
  * @return std::string TCP Transport descriptor specific listening port.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -284,7 +284,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_listening_ports(
  *
  * @return std::string XML section containing the specific TCP Transport Descriptor TLS configuration.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        TLS configuration element has not been set in the profile.
  */
@@ -298,7 +298,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls(
  *
  * @return std::string Specific TCP Transport Descriptor TLS password.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        TLS password element has not been set in the profile.
  */
@@ -312,7 +312,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_password(
  *
  * @return std::string Specific TCP Transport Descriptor path to the TLS private key certificate file.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        TLS private key certificate path element has not been set in the profile.
  */
@@ -326,7 +326,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_private_key_file(
  *
  * @return std::string Specific TCP Transport Descriptor path to the TLS private key RSA certificate file.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        TLS private key RSA certificate path element has not been set in the profile.
  */
@@ -340,7 +340,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_rsa_private_key_file(
  *
  * @return std::string Specific TCP Transport Descriptor path to the TLS public certificate chain file.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        TLS public certificate chain file path element has not been set in the profile.
  */
@@ -354,7 +354,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_cert_chain_file(
  *
  * @return std::string Specific TCP Transport Descriptor path to the TLS Diffie-Hellman parameters file.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        TLS Diffie-Hellman parameters file path element has not been set in the profile.
  */
@@ -368,7 +368,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_tmp_dh_file(
  *
  * @return std::string Specific TCP Transport Descriptor path to the CA file.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        TLS CA file path element has not been set in the profile.
  */
@@ -383,7 +383,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_verify_file(
  *
  * @return std::string TCP Transport descriptor specific TLS verification mode.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -400,7 +400,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_verify_mode(
  *
  * @return std::string TCP Transport descriptor specific TLS supported feature.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -417,7 +417,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_options(
  *
  * @return std::string TCP Transport descriptor specific TLS verification path.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        list does not contain any element in index position.
  * @throw BadParameter Exception if the index is not an integer.
@@ -433,7 +433,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_verify_paths(
  *
  * @return std::string Specific TCP Transport Descriptor maximum allowed depth for verifying intermediate certificates.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        TLS verify depth element has not been set in the profile.
  */
@@ -447,7 +447,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_verify_depth(
  *
  * @return std::string Specific TCP Transport Descriptor verify default paths flag.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        TLS verify default paths flag has not been set in the profile.
  */
@@ -461,7 +461,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_default_verify_path(
  *
  * @return std::string Specific TCP Transport Descriptor handshake role.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        TLS handshake role has not been set in the profile.
  */
@@ -475,7 +475,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_handshake_role(
  *
  * @return std::string Specific TCP Transport Descriptor SNI server name.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        TLS SNI server name has not been set in the profile.
  */
@@ -489,7 +489,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_tls_server_name(
  *
  * @return std::string Specific TCP Transport Descriptor calculate CRC flag.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        calculate CRC flag has not been set in the profile.
  */
@@ -503,7 +503,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_calculate_crc(
  *
  * @return std::string Specific TCP Transport Descriptor check CRC flag.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        check CRC flag has not been set in the profile.
  */
@@ -517,7 +517,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_check_crc(
  *
  * @return std::string Specific TCP Transport Descriptor TCP_NODELAY socket option flag.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        TCP_NODELAY socket option flag has not been set in the profile.
  */
@@ -531,7 +531,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_enable_tcp_nodelay(
  *
  * @return std::string Specific SHM Transport Descriptor shared memory segment size.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        shared memory segment size has not been set in the profile.
  */
@@ -545,7 +545,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_segment_size(
  *
  * @return std::string Specific SHM Transport Descriptor listening port capacity in number of messages.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        listening port capacity has not been set in the profile.
  */
@@ -559,7 +559,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_port_queue_capacity(
  *
  * @return std::string Specific SHM Transport Descriptor listening port liveliness timeout (in milliseconds).
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        listening port liveliness timeout has not been set in the profile.
  */
@@ -573,7 +573,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_healthy_check_timeout_ms(
  *
  * @return std::string Specific SHM Transport Descriptor debugging file path.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or the
  *        debugging file path has not been set in the profile.
  */
@@ -589,7 +589,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::string print_rtps_dump_file(
  *
  * @return uint32_t Number of transport descriptor profiles in the XML file.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size();
 
@@ -599,7 +599,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t size();
  * @return std::vector<std::string> Identifier list.
  *         Empty list if there are no transport descriptor profiles.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::vector<std::string> keys();
 
@@ -610,7 +610,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI std::vector<std::string> keys();
  *
  * @return uint32_t Number of network interfaces whitelisted in the list.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t interface_whitelist_size(
@@ -623,7 +623,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t interface_whitelist_size(
  *
  * @return uint32_t Number of listening ports in the list.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t listening_ports_size(
@@ -636,7 +636,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t listening_ports_size(
  *
  * @return uint32_t Number of TLS verification modes enabled in the mask.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t tls_verify_mode_size(
@@ -649,7 +649,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t tls_verify_mode_size(
  *
  * @return uint32_t Number of TLS supported features enabled in the mask.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t tls_options_size(
@@ -662,7 +662,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t tls_options_size(
  *
  * @return uint32_t Number of TLS paths to look for verification files.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t tls_verify_paths_size(
@@ -678,7 +678,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI uint32_t tls_verify_paths_size(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier. If empty, every transport descriptor
  *                                    profile is deleted.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
@@ -689,7 +689,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_kind(
@@ -700,7 +700,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_kind(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_send_buffer_size(
@@ -711,7 +711,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_send_buffer_size(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_receive_buffer_size(
@@ -722,7 +722,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_receive_buffer_size(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_max_message_size(
@@ -733,7 +733,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_max_message_size(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_max_initial_peers_range(
@@ -745,7 +745,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_max_initial_peers_range(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete collection is erased.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or if
  *        the element does not exist in the collection if an index is provided.
  * @throw BadParameter Exception if the index is not an integer.
@@ -759,7 +759,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_interface_whitelist(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_ttl(
@@ -770,7 +770,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_ttl(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_non_blocking_send(
@@ -781,7 +781,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_non_blocking_send(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_output_port(
@@ -792,7 +792,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_output_port(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_addr(
@@ -803,7 +803,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_wan_addr(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_keep_alive_frequency_ms(
@@ -814,7 +814,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_keep_alive_frequency_ms(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_keep_alive_timeout_ms(
@@ -825,7 +825,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_keep_alive_timeout_ms(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_max_logical_port(
@@ -836,7 +836,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_max_logical_port(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_logical_port_range(
@@ -847,7 +847,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_logical_port_range(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_logical_port_increment(
@@ -859,7 +859,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_logical_port_increment(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete collection is erased.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or if
  *        the element does not exist in the collection if an index is provided.
  * @throw BadParameter Exception if the index is not an integer.
@@ -873,7 +873,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_listening_ports(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls(
@@ -884,7 +884,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_password(
@@ -895,7 +895,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_password(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_private_key_file(
@@ -906,7 +906,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_private_key_file(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_rsa_private_key_file(
@@ -917,7 +917,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_rsa_private_key_file(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_cert_chain_file(
@@ -928,7 +928,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_cert_chain_file(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_tmp_dh_file(
@@ -939,7 +939,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_tmp_dh_file(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_verify_file(
@@ -951,7 +951,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_verify_file(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete collection is erased.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or if
  *        the element does not exist in the collection if an index is provided.
  * @throw BadParameter Exception if the index is not an integer.
@@ -966,7 +966,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_verify_mode(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete collection is erased.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or if
  *        the element does not exist in the collection if an index is provided.
  * @throw BadParameter Exception if the index is not an integer.
@@ -981,7 +981,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_options(
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  * @param[in] index Collection element to be removed. If empty, the complete collection is erased.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file or if
  *        the element does not exist in the collection if an index is provided.
  * @throw BadParameter Exception if the index is not an integer.
@@ -995,7 +995,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_verify_paths(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_verify_depth(
@@ -1006,7 +1006,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_verify_depth(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_default_verify_path(
@@ -1017,7 +1017,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_default_verify_path(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_handshake_role(
@@ -1028,7 +1028,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_handshake_role(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_server_name(
@@ -1039,7 +1039,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_tls_server_name(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_calculate_crc(
@@ -1050,7 +1050,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_calculate_crc(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_check_crc(
@@ -1061,7 +1061,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_check_crc(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_enable_tcp_nodelay(
@@ -1072,7 +1072,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_enable_tcp_nodelay(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_segment_size(
@@ -1083,7 +1083,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_segment_size(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port_queue_capacity(
@@ -1094,7 +1094,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_port_queue_capacity(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_healthy_check_timeout_ms(
@@ -1105,7 +1105,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_healthy_check_timeout_ms(
  *
  * @param[in] transport_descriptor_id Transport descriptor profile identifier.
  *
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementNotFound Exception if the specified transport descriptor profile is not found in the XML file.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void clear_rtps_dump_file(
@@ -1507,7 +1507,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_rtps_dump_file(
  * @throw ElementInvalid Exception if the provided IP address is not valid.
  * @throw ElementNotFound Exception if the specified Transport descriptor profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_interface_whitelist(
@@ -1526,7 +1526,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_interface_whitelist(
  * @throw ElementInvalid Exception if the provided port is not valid.
  * @throw ElementNotFound Exception if the specified Transport descriptor profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_listening_ports(
@@ -1545,7 +1545,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_listening_ports(
  * @throw ElementInvalid Exception if the provided TLS verification mode is not valid.
  * @throw ElementNotFound Exception if the specified Transport descriptor profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_verify_mode(
@@ -1564,7 +1564,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_verify_mode(
  * @throw ElementInvalid Exception if the provided TLS supported feature is not valid.
  * @throw ElementNotFound Exception if the specified Transport descriptor profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_options(
@@ -1583,7 +1583,7 @@ FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_options(
  * @throw ElementInvalid Exception if the provided path is not valid.
  * @throw ElementNotFound Exception if the specified Transport descriptor profile is not found in the XML file, the list
  *        element does not exist, or the list does not contain any element in index position.
- * @throw FileNotFound Exception if the provided XML file is not found/readable.
+ * @throw Error Exception if the workspace was not initialized.
  * @throw BadParameter Exception if the index is not an integer.
  */
 FASTDDS_QOS_PROFILES_MANAGER_DllAPI void set_tls_verify_path(

--- a/lib/src/cpp/QosProfileManager.cpp
+++ b/lib/src/cpp/QosProfileManager.cpp
@@ -1,0 +1,65 @@
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file
+ */
+
+#include <fastdds_qos_profiles_manager_lib/QoSProfileManager.hpp>
+
+#include <string>
+
+#include <fastdds_qos_profiles_manager_lib/exception/Exception.hpp>
+
+#include <utils/XMLManager.hpp>
+
+namespace eprosima {
+namespace qosprof {
+
+void initialize(
+        const std::string& xml_file,
+        const bool create_file)
+{
+    // Try to initialize XML workspace
+    try
+    {
+        xercesc::XMLPlatformUtils::Initialize();
+    }
+    catch (const xercesc::XMLException& toCatch)
+    {
+        // Unable to initialize XML workspace
+        throw Error(xercesc::XMLString::transcode(toCatch.getMessage()));
+    }
+
+    // Create singleton instance of manager
+    eprosima::qosprof::utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
+
+    // Set up with the basic information
+    manager.initialize(xml_file, create_file);
+}
+
+void terminate()
+{
+    // Create singleton instance of manager
+    eprosima::qosprof::utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
+
+    // write if needed the final XML in the given path
+    manager.save_xml();
+
+    // Close XML workspace
+    xercesc::XMLPlatformUtils::Terminate();
+}
+
+} // qosprof
+} // eprosima

--- a/lib/src/cpp/QosProfilesManager.cpp
+++ b/lib/src/cpp/QosProfilesManager.cpp
@@ -28,14 +28,13 @@ namespace eprosima {
 namespace qosprof {
 
 void initialize(
-        const std::string& xml_file,
-        const bool create_file)
+        const std::string& xml_file)
 {
     // Get singleton instance of manager
     eprosima::qosprof::utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Initialize workspace and set up the manager with required information
-    manager.initialize(xml_file, create_file);
+    manager.initialize(xml_file);
 }
 
 void terminate()

--- a/lib/src/cpp/QosProfilesManager.cpp
+++ b/lib/src/cpp/QosProfilesManager.cpp
@@ -39,7 +39,7 @@ void initialize(
 
 void terminate()
 {
-    // Create singleton instance of manager
+    // Get singleton instance of manager
     eprosima::qosprof::utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // terminate the workspace and write the final XML in the given path if needed

--- a/lib/src/cpp/QosProfilesManager.cpp
+++ b/lib/src/cpp/QosProfilesManager.cpp
@@ -31,21 +31,10 @@ void initialize(
         const std::string& xml_file,
         const bool create_file)
 {
-    // Try to initialize XML workspace
-    try
-    {
-        xercesc::XMLPlatformUtils::Initialize();
-    }
-    catch (const xercesc::XMLException& toCatch)
-    {
-        // Unable to initialize XML workspace
-        throw Error(xercesc::XMLString::transcode(toCatch.getMessage()));
-    }
-
     // Get singleton instance of manager
     eprosima::qosprof::utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
-    // Set up with the basic information
+    // Initialize workspace and set up the manager with required information
     manager.initialize(xml_file, create_file);
 }
 
@@ -54,11 +43,8 @@ void terminate()
     // Create singleton instance of manager
     eprosima::qosprof::utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
-    // write if needed the final XML in the given path
-    manager.save_xml();
-
-    // Close XML workspace
-    xercesc::XMLPlatformUtils::Terminate();
+    // terminate the workspace and write the final XML in the given path if needed
+    manager.terminate();
 }
 
 } // qosprof

--- a/lib/src/cpp/QosProfilesManager.cpp
+++ b/lib/src/cpp/QosProfilesManager.cpp
@@ -16,7 +16,7 @@
  * @file
  */
 
-#include <fastdds_qos_profiles_manager_lib/QoSProfileManager.hpp>
+#include <fastdds_qos_profiles_manager_lib/QoSProfilesManager.hpp>
 
 #include <string>
 
@@ -42,7 +42,7 @@ void initialize(
         throw Error(xercesc::XMLString::transcode(toCatch.getMessage()));
     }
 
-    // Create singleton instance of manager
+    // Get singleton instance of manager
     eprosima::qosprof::utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Set up with the basic information

--- a/lib/src/cpp/common/Duration.cpp
+++ b/lib/src/cpp/common/Duration.cpp
@@ -33,7 +33,7 @@ void set_sec(
         const std::string& sec)
 {
     // Obtain second node
-    manager.get_node(utils::tag::SEC, true);
+    manager.move_to_node(utils::tag::SEC, true);
 
     // Set duration value to node
     manager.set_value_to_node(sec);
@@ -44,7 +44,7 @@ void set_nanosec(
         const std::string& nanosec)
 {
     // Obtain nanosecond node
-    manager.get_node(utils::tag::NANOSEC, true);
+    manager.move_to_node(utils::tag::NANOSEC, true);
 
     // Set duration value to node
     manager.set_value_to_node(nanosec);

--- a/lib/src/cpp/common/LocatorList.cpp
+++ b/lib/src/cpp/common/LocatorList.cpp
@@ -155,10 +155,10 @@ void set_port(
         const bool is_external)
 {
     // get the kind node
-    manager.get_locator_node(index, is_external, true);
+    manager.move_to_locator_node(index, is_external, true);
 
     // add port node to the kind node
-    manager.get_node(utils::tag::PORT, true);
+    manager.move_to_node(utils::tag::PORT, true);
 
     // set port node value
     manager.set_value_to_node(port);
@@ -180,10 +180,10 @@ void set_address(
         const bool is_external)
 {
     // get the kind node
-    manager.get_locator_node(index, is_external, true);
+    manager.move_to_locator_node(index, is_external, true);
 
     // add address node to the kind node
-    manager.get_node(utils::tag::ADDRESS, true);
+    manager.move_to_node(utils::tag::ADDRESS, true);
 
     // set address node value
     manager.set_value_to_node(address);

--- a/lib/src/cpp/common/LocatorList.hpp
+++ b/lib/src/cpp/common/LocatorList.hpp
@@ -288,6 +288,7 @@ void clear_wan_address(
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the element does not exist in the collection if an index is provided.
  * @throw BadParameter Exception if the index is not an integer.
@@ -306,6 +307,7 @@ void set_kind(
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the element does not exist in the collection if an index is provided.
  * @throw BadParameter Exception if the index is not an integer.
@@ -325,6 +327,7 @@ void set_port(
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator physical port is not valid.
  * @throw ElementNotFound Exception if the element does not exist in the collection if an index is provided.
  * @throw BadParameter Exception if the index is not an integer.
@@ -343,6 +346,7 @@ void set_physical_port(
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the element does not exist in the collection if an index is provided.
  * @throw BadParameter Exception if the index is not an integer.
@@ -362,6 +366,7 @@ void set_address(
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator identifier is not valid.
  * @throw ElementNotFound Exception if the element does not exist in the collection if an index is provided.
  * @throw BadParameter Exception if the index is not an integer.
@@ -380,6 +385,7 @@ void set_unique_lan_id(
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
+ * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the element does not exist in the collection if an index is provided.
  * @throw BadParameter Exception if the index is not an integer.

--- a/lib/src/cpp/common/LocatorList.hpp
+++ b/lib/src/cpp/common/LocatorList.hpp
@@ -288,7 +288,6 @@ void clear_wan_address(
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator kind is not valid.
  * @throw ElementNotFound Exception if the element does not exist in the collection if an index is provided.
  * @throw BadParameter Exception if the index is not an integer.
@@ -307,7 +306,6 @@ void set_kind(
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator port is not valid.
  * @throw ElementNotFound Exception if the element does not exist in the collection if an index is provided.
  * @throw BadParameter Exception if the index is not an integer.
@@ -327,7 +325,6 @@ void set_port(
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator physical port is not valid.
  * @throw ElementNotFound Exception if the element does not exist in the collection if an index is provided.
  * @throw BadParameter Exception if the index is not an integer.
@@ -346,7 +343,6 @@ void set_physical_port(
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the element does not exist in the collection if an index is provided.
  * @throw BadParameter Exception if the index is not an integer.
@@ -366,7 +362,6 @@ void set_address(
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator identifier is not valid.
  * @throw ElementNotFound Exception if the element does not exist in the collection if an index is provided.
  * @throw BadParameter Exception if the index is not an integer.
@@ -385,7 +380,6 @@ void set_unique_lan_id(
  * @param[in] index Collection element to be changed. If empty, a new element is added to the list.
  * @param[in] is_external bool to determine if locator managed is external locator or common locator.
  *
- * @throw Error Exception if the workspace was not initialized.
  * @throw ElementInvalid Exception if the provided locator IP address is not valid.
  * @throw ElementNotFound Exception if the element does not exist in the collection if an index is provided.
  * @throw BadParameter Exception if the index is not an integer.

--- a/lib/src/cpp/common/qos/Reliability.cpp
+++ b/lib/src/cpp/common/qos/Reliability.cpp
@@ -35,7 +35,7 @@ void set_kind(
         const std::string& kind)
 {
     // Obtain kind node
-    manager.get_node(utils::tag::KIND, true);
+    manager.move_to_node(utils::tag::KIND, true);
 
     // Set value to node
     manager.set_value_to_node(kind);
@@ -46,7 +46,7 @@ void set_max_blocking_time_sec(
         const std::string& sec)
 {
     // Obtain max blocking time node
-    manager.get_node(utils::tag::MAX_BLOCKING_TIME, true);
+    manager.move_to_node(utils::tag::MAX_BLOCKING_TIME, true);
 
     // Use the common api
     common::duration::set_sec(manager, sec);
@@ -57,7 +57,7 @@ void set_max_blocking_time_nanosec(
         const std::string& nanosec)
 {
     // Obtain max blocking time node
-    manager.get_node(utils::tag::MAX_BLOCKING_TIME, true);
+    manager.move_to_node(utils::tag::MAX_BLOCKING_TIME, true);
 
     // Use the common api
     common::duration::set_nanosec(manager, nanosec);

--- a/lib/src/cpp/data_reader/DataReader.cpp
+++ b/lib/src/cpp/data_reader/DataReader.cpp
@@ -50,7 +50,7 @@ void initialize_namespace(
     manager.is_initialized();
 
     // Iterate through required elements, and create them if not existent
-    manager.move_to_root_node();
+    manager.move_to_root_node(create_if_not_existent);
     manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
     manager.move_to_node(utils::tag::DATA_READER, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
     if (!additional_tag.empty())

--- a/lib/src/cpp/data_reader/DataReader.cpp
+++ b/lib/src/cpp/data_reader/DataReader.cpp
@@ -37,6 +37,7 @@ namespace data_reader {
  * @param[in] create_if_not_existent flag that enables the creation of the  element if it does not exist
  * @param[in] additional_tag Additional required TAG
  *
+ * @throw Error exception if XML workspace was not initialized
  * @throw ElementNotFound exception if expected node was not found and node creation was not required
  */
 void initialize_namespace(
@@ -45,6 +46,9 @@ void initialize_namespace(
         const bool create_if_not_existent,
         const std::string& additional_tag)
 {
+    // Check if workspace was initialized
+    manager.is_initialized();
+
     // Iterate through required elements, and create them if not existent
     manager.move_to_root_node();
     manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
@@ -56,7 +60,6 @@ void initialize_namespace(
 }
 
 void set_default_profile(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     // Create XML manager and initialize the document

--- a/lib/src/cpp/data_reader/DataReader.cpp
+++ b/lib/src/cpp/data_reader/DataReader.cpp
@@ -46,11 +46,12 @@ void initialize_namespace(
         const std::string& additional_tag)
 {
     // Iterate through required elements, and create them if not existent
-    manager.get_node(utils::tag::PROFILES, create_if_not_existent);
-    manager.get_node(utils::tag::DATA_READER, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
+    manager.move_to_root_node();
+    manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
+    manager.move_to_node(utils::tag::DATA_READER, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
     if (!additional_tag.empty())
     {
-        manager.get_node(additional_tag, create_if_not_existent);
+        manager.move_to_node(additional_tag, create_if_not_existent);
     }
 }
 
@@ -59,7 +60,7 @@ void set_default_profile(
         const std::string& profile_id)
 {
     // Create XML manager and initialize the document
-    utils::XMLManager manager(xml_file, false);
+    utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Obtain base node position
     initialize_namespace(manager, profile_id, false, "");

--- a/lib/src/cpp/data_reader/Qos.cpp
+++ b/lib/src/cpp/data_reader/Qos.cpp
@@ -53,7 +53,7 @@ void initialize_namespace(
     manager.is_initialized();
 
     // Iterate through required elements, and create them if not existent
-    manager.move_to_root_node();
+    manager.move_to_root_node(create_if_not_existent);
     manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
     manager.move_to_node(utils::tag::DATA_READER, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
     manager.move_to_node(utils::tag::QOS, create_if_not_existent);

--- a/lib/src/cpp/data_reader/Qos.cpp
+++ b/lib/src/cpp/data_reader/Qos.cpp
@@ -40,6 +40,7 @@ namespace qos {
  * @param[in] create_if_not_existent flag that enables the creation of the  element if it does not exist
  * @param[in] required_qos Required QoS TAG
  *
+ * @throw Error exception if XML workspace was not initialized
  * @throw ElementNotFound exception if expected node was not found and node creation was not required
  */
 void initialize_namespace(
@@ -48,6 +49,9 @@ void initialize_namespace(
         const bool create_if_not_existent,
         const std::string& required_qos)
 {
+    // Check if workspace was initialized
+    manager.is_initialized();
+
     // Iterate through required elements, and create them if not existent
     manager.move_to_root_node();
     manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
@@ -57,7 +61,6 @@ void initialize_namespace(
 }
 
 void set_durability_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& kind)
 {
@@ -75,7 +78,6 @@ void set_durability_kind(
 }
 
 void set_reliability_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& kind)
 {
@@ -93,7 +95,6 @@ void set_reliability_kind(
 }
 
 void set_reliability_max_blocking_time_sec(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& sec)
 {
@@ -111,7 +112,6 @@ void set_reliability_max_blocking_time_sec(
 }
 
 void set_reliability_max_blocking_time_nanosec(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& nanosec)
 {

--- a/lib/src/cpp/data_reader/Qos.cpp
+++ b/lib/src/cpp/data_reader/Qos.cpp
@@ -49,10 +49,11 @@ void initialize_namespace(
         const std::string& required_qos)
 {
     // Iterate through required elements, and create them if not existent
-    manager.get_node(utils::tag::PROFILES, create_if_not_existent);
-    manager.get_node(utils::tag::DATA_READER, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
-    manager.get_node(utils::tag::QOS, create_if_not_existent);
-    manager.get_node(required_qos, create_if_not_existent);
+    manager.move_to_root_node();
+    manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
+    manager.move_to_node(utils::tag::DATA_READER, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
+    manager.move_to_node(utils::tag::QOS, create_if_not_existent);
+    manager.move_to_node(required_qos, create_if_not_existent);
 }
 
 void set_durability_kind(
@@ -61,7 +62,7 @@ void set_durability_kind(
         const std::string& kind)
 {
     // Create XML manager and initialize the document
-    utils::XMLManager manager(xml_file, true);
+    utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Obtain base node position
     initialize_namespace(manager, profile_id, true, utils::tag::DURABILITY);
@@ -79,7 +80,7 @@ void set_reliability_kind(
         const std::string& kind)
 {
     // Create XML manager and initialize the document
-    utils::XMLManager manager(xml_file, true);
+    utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Obtain base node position
     initialize_namespace(manager, profile_id, true, utils::tag::RELIABILITY);
@@ -97,7 +98,7 @@ void set_reliability_max_blocking_time_sec(
         const std::string& sec)
 {
     // Create XML manager and initialize the document
-    utils::XMLManager manager(xml_file, true);
+    utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Obtain base node position
     initialize_namespace(manager, profile_id, true, utils::tag::RELIABILITY);
@@ -115,7 +116,7 @@ void set_reliability_max_blocking_time_nanosec(
         const std::string& nanosec)
 {
     // Create XML manager and initialize the document
-    utils::XMLManager manager(xml_file, true);
+    utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Obtain base node position
     initialize_namespace(manager, profile_id, true, utils::tag::RELIABILITY);

--- a/lib/src/cpp/data_writer/DataWriter.cpp
+++ b/lib/src/cpp/data_writer/DataWriter.cpp
@@ -50,7 +50,7 @@ void initialize_namespace(
     manager.is_initialized();
 
     // Iterate through required elements, and create them if not existent
-    manager.move_to_root_node();
+    manager.move_to_root_node(create_if_not_existent);
     manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
     manager.move_to_node(utils::tag::DATA_WRITER, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
     if (!additional_tag.empty())

--- a/lib/src/cpp/data_writer/DataWriter.cpp
+++ b/lib/src/cpp/data_writer/DataWriter.cpp
@@ -46,11 +46,12 @@ void initialize_namespace(
         const std::string& additional_tag)
 {
     // Iterate through required elements, and create them if not existent
-    manager.get_node(utils::tag::PROFILES, create_if_not_existent);
-    manager.get_node(utils::tag::DATA_WRITER, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
+    manager.move_to_root_node();
+    manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
+    manager.move_to_node(utils::tag::DATA_WRITER, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
     if (!additional_tag.empty())
     {
-        manager.get_node(additional_tag, create_if_not_existent);
+        manager.move_to_node(additional_tag, create_if_not_existent);
     }
 }
 
@@ -59,7 +60,7 @@ void set_default_profile(
         const std::string& profile_id)
 {
     // Create XML manager and initialize the document
-    utils::XMLManager manager(xml_file, false);
+    utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Obtain base node position
     initialize_namespace(manager, profile_id, false, "");

--- a/lib/src/cpp/data_writer/DataWriter.cpp
+++ b/lib/src/cpp/data_writer/DataWriter.cpp
@@ -37,6 +37,7 @@ namespace data_writer {
  * @param[in] create_if_not_existent flag that enables the creation of the  element if it does not exist
  * @param[in] additional_tag Additional required TAG
  *
+ * @throw Error exception if XML workspace was not initialized
  * @throw ElementNotFound exception if expected node was not found and node creation was not required
  */
 void initialize_namespace(
@@ -45,6 +46,9 @@ void initialize_namespace(
         const bool create_if_not_existent,
         const std::string& additional_tag)
 {
+    // Check if workspace was initialized
+    manager.is_initialized();
+
     // Iterate through required elements, and create them if not existent
     manager.move_to_root_node();
     manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
@@ -56,7 +60,6 @@ void initialize_namespace(
 }
 
 void set_default_profile(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     // Create XML manager and initialize the document

--- a/lib/src/cpp/data_writer/Qos.cpp
+++ b/lib/src/cpp/data_writer/Qos.cpp
@@ -49,10 +49,11 @@ void initialize_namespace(
         const std::string& required_qos)
 {
     // Iterate through required elements, and create them if not existent
-    manager.get_node(utils::tag::PROFILES, create_if_not_existent);
-    manager.get_node(utils::tag::DATA_WRITER, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
-    manager.get_node(utils::tag::QOS, create_if_not_existent);
-    manager.get_node(required_qos, create_if_not_existent);
+    manager.move_to_root_node();
+    manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
+    manager.move_to_node(utils::tag::DATA_WRITER, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
+    manager.move_to_node(utils::tag::QOS, create_if_not_existent);
+    manager.move_to_node(required_qos, create_if_not_existent);
 }
 
 void set_durability_kind(
@@ -61,7 +62,7 @@ void set_durability_kind(
         const std::string& kind)
 {
     // Create XML manager and initialize the document
-    utils::XMLManager manager(xml_file, true);
+    utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Obtain base node position
     initialize_namespace(manager, profile_id, true, utils::tag::DURABILITY);
@@ -79,7 +80,7 @@ void set_reliability_kind(
         const std::string& kind)
 {
     // Create XML manager and initialize the document
-    utils::XMLManager manager(xml_file, true);
+    utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Obtain base node position
     initialize_namespace(manager, profile_id, true, utils::tag::RELIABILITY);
@@ -97,7 +98,7 @@ void set_reliability_max_blocking_time_sec(
         const std::string& sec)
 {
     // Create XML manager and initialize the document
-    utils::XMLManager manager(xml_file, true);
+    utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Obtain base node position
     initialize_namespace(manager, profile_id, true, utils::tag::RELIABILITY);
@@ -115,7 +116,7 @@ void set_reliability_max_blocking_time_nanosec(
         const std::string& nanosec)
 {
     // Create XML manager and initialize the document
-    utils::XMLManager manager(xml_file, true);
+    utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Obtain base node position
     initialize_namespace(manager, profile_id, true, utils::tag::RELIABILITY);

--- a/lib/src/cpp/data_writer/Qos.cpp
+++ b/lib/src/cpp/data_writer/Qos.cpp
@@ -40,6 +40,7 @@ namespace qos {
  * @param[in] create_if_not_existent flag that enables the creation of the  element if it does not exist
  * @param[in] required_qos Required QoS TAG
  *
+ * @throw Error exception if XML workspace was not initialized
  * @throw ElementNotFound exception if expected node was not found and node creation was not required
  */
 void initialize_namespace(
@@ -48,6 +49,9 @@ void initialize_namespace(
         const bool create_if_not_existent,
         const std::string& required_qos)
 {
+    // Check if workspace was initialized
+    manager.is_initialized();
+
     // Iterate through required elements, and create them if not existent
     manager.move_to_root_node();
     manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
@@ -57,7 +61,6 @@ void initialize_namespace(
 }
 
 void set_durability_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& kind)
 {
@@ -75,7 +78,6 @@ void set_durability_kind(
 }
 
 void set_reliability_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& kind)
 {
@@ -93,7 +95,6 @@ void set_reliability_kind(
 }
 
 void set_reliability_max_blocking_time_sec(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& sec)
 {
@@ -111,7 +112,6 @@ void set_reliability_max_blocking_time_sec(
 }
 
 void set_reliability_max_blocking_time_nanosec(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& nanosec)
 {

--- a/lib/src/cpp/data_writer/Qos.cpp
+++ b/lib/src/cpp/data_writer/Qos.cpp
@@ -53,7 +53,7 @@ void initialize_namespace(
     manager.is_initialized();
 
     // Iterate through required elements, and create them if not existent
-    manager.move_to_root_node();
+    manager.move_to_root_node(create_if_not_existent);
     manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
     manager.move_to_node(utils::tag::DATA_WRITER, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
     manager.move_to_node(utils::tag::QOS, create_if_not_existent);

--- a/lib/src/cpp/domain_participant/Allocation.cpp
+++ b/lib/src/cpp/domain_participant/Allocation.cpp
@@ -28,315 +28,270 @@ namespace domain_participant {
 namespace allocations {
 
 std::string print(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_remote_locators(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_remote_locators_max_unicast(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_remote_locators_max_multicast(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_total_participants(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_total_participants_initial(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_total_participants_maximum(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_total_participants_increment(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_total_readers(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_total_readers_initial(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_total_readers_maximum(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_total_readers_increment(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_total_writers(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_total_writers_initial(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_total_writers_maximum(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_total_writers_increment(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_max_partitions(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_max_user_data(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_max_properties(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_send_buffers(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_send_buffers_preallocated_number(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_send_buffers_dynamic(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_remote_locators(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_remote_locators_max_unicast(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_remote_locators_max_multicast(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_total_participants(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_total_participants_initial(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_total_participants_maximum(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_total_participants_increment(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_total_readers(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_total_readers_initial(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_total_readers_maximum(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_total_readers_increment(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_total_writers(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_total_writers_initial(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_total_writers_maximum(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_total_writers_increment(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_max_partitions(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_max_user_data(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_max_properties(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_send_buffers(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_send_buffers_preallocated_number(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_send_buffers_preallocated_dynamic(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void set_remote_locators_max_unicast(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& max_unicast)
 {
@@ -344,7 +299,6 @@ void set_remote_locators_max_unicast(
 }
 
 void set_remote_locators_max_multicast(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& max_multicast)
 {
@@ -352,7 +306,6 @@ void set_remote_locators_max_multicast(
 }
 
 void set_total_participants_initial(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& initial)
 {
@@ -360,7 +313,6 @@ void set_total_participants_initial(
 }
 
 void set_total_participants_maximum(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& maximum)
 {
@@ -368,7 +320,6 @@ void set_total_participants_maximum(
 }
 
 void set_total_participants_increment(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& increment)
 {
@@ -376,7 +327,6 @@ void set_total_participants_increment(
 }
 
 void set_total_readers_initial(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& initial)
 {
@@ -384,7 +334,6 @@ void set_total_readers_initial(
 }
 
 void set_total_readers_maximum(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& maximum)
 {
@@ -392,7 +341,6 @@ void set_total_readers_maximum(
 }
 
 void set_total_readers_increment(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& increment)
 {
@@ -400,7 +348,6 @@ void set_total_readers_increment(
 }
 
 void set_total_writers_initial(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& initial)
 {
@@ -408,7 +355,6 @@ void set_total_writers_initial(
 }
 
 void set_total_writers_maximum(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& maximum)
 {
@@ -416,7 +362,6 @@ void set_total_writers_maximum(
 }
 
 void set_total_writers_increment(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& increment)
 {
@@ -424,7 +369,6 @@ void set_total_writers_increment(
 }
 
 void set_max_partitions(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& max_partitions)
 {
@@ -432,7 +376,6 @@ void set_max_partitions(
 }
 
 void set_max_user_data(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& max_user_data)
 {
@@ -440,7 +383,6 @@ void set_max_user_data(
 }
 
 void set_max_properties(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& max_properties)
 {
@@ -448,7 +390,6 @@ void set_max_properties(
 }
 
 void set_send_buffers_preallocated_number(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& send_buffers_preallocated_number)
 {
@@ -456,7 +397,6 @@ void set_send_buffers_preallocated_number(
 }
 
 void set_send_buffers_dynamic(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& send_buffers_dynamic)
 {

--- a/lib/src/cpp/domain_participant/DefaultExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/DefaultExternalUnicastLocators.cpp
@@ -46,10 +46,11 @@ void initialize_namespace(
         const bool create_if_not_existent)
 {
     // Iterate through required elements, and create them if not existent
-    manager.get_node(utils::tag::PROFILES, create_if_not_existent);
-    manager.get_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
-    manager.get_node(utils::tag::RTPS, create_if_not_existent);
-    manager.get_node(utils::tag::DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST, create_if_not_existent);
+    manager.move_to_root_node();
+    manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
+    manager.move_to_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
+    manager.move_to_node(utils::tag::RTPS, create_if_not_existent);
+    manager.move_to_node(utils::tag::DEFAULT_EXTERNAL_UNICAST_LOCATOR_LIST, create_if_not_existent);
 }
 
 std::string print(
@@ -179,7 +180,7 @@ void set_port(
         const std::string& index)
 {
     // Create XML manager and initialize the document
-    utils::XMLManager manager(xml_file, true);
+    utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Obtain base node position
     initialize_namespace(manager, profile_id, true);
@@ -198,7 +199,7 @@ void set_address(
         const std::string& index)
 {
     // Create XML manager and initialize the document
-    utils::XMLManager manager(xml_file, true);
+    utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Obtain base node position
     initialize_namespace(manager, profile_id, true);
@@ -217,13 +218,13 @@ void set_externality(
         const std::string& index)
 {
     // Create XML manager and initialize the document
-    utils::XMLManager manager(xml_file, true);
+    utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Obtain base node position
     initialize_namespace(manager, profile_id, true);
 
     // Iterate through required elements, and create them if not existent
-    manager.get_locator_node(index, true, true);
+    manager.move_to_locator_node(index, true, true);
 
     // Set the externality value
     manager.set_attribute_to_node(utils::tag::EXTERNALITY, externality);

--- a/lib/src/cpp/domain_participant/DefaultExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/DefaultExternalUnicastLocators.cpp
@@ -50,7 +50,7 @@ void initialize_namespace(
     manager.is_initialized();
 
     // Iterate through required elements, and create them if not existent
-    manager.move_to_root_node();
+    manager.move_to_root_node(create_if_not_existent);
     manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
     manager.move_to_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
     manager.move_to_node(utils::tag::RTPS, create_if_not_existent);

--- a/lib/src/cpp/domain_participant/DefaultExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/DefaultExternalUnicastLocators.cpp
@@ -38,6 +38,7 @@ namespace default_external_unicast_locators {
  * @param[in] profile_id Domain participant profile identifier
  * @param[in] create_if_not_existent flag that enables the creation of the  element if it does not exist
  *
+ * @throw Error exception if XML workspace was not initialized
  * @throw ElementNotFound exception if expected node was not found and node creation was not required
  */
 void initialize_namespace(
@@ -45,6 +46,9 @@ void initialize_namespace(
         const std::string& profile_id,
         const bool create_if_not_existent)
 {
+    // Check if workspace was initialized
+    manager.is_initialized();
+
     // Iterate through required elements, and create them if not existent
     manager.move_to_root_node();
     manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
@@ -54,7 +58,6 @@ void initialize_namespace(
 }
 
 std::string print(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -62,7 +65,6 @@ std::string print(
 }
 
 std::string print_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -70,7 +72,6 @@ std::string print_kind(
 }
 
 std::string print_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -78,7 +79,6 @@ std::string print_port(
 }
 
 std::string print_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -86,7 +86,6 @@ std::string print_address(
 }
 
 std::string print_externality(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -94,7 +93,6 @@ std::string print_externality(
 }
 
 std::string print_cost(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -102,7 +100,6 @@ std::string print_cost(
 }
 
 std::string print_mask(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -110,14 +107,12 @@ std::string print_mask(
 }
 
 uint32_t size(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -125,7 +120,6 @@ void clear(
 }
 
 void clear_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -133,7 +127,6 @@ void clear_port(
 }
 
 void clear_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -141,7 +134,6 @@ void clear_address(
 }
 
 void clear_externality(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -149,7 +141,6 @@ void clear_externality(
 }
 
 void clear_cost(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -157,7 +148,6 @@ void clear_cost(
 }
 
 void clear_mask(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -165,7 +155,6 @@ void clear_mask(
 }
 
 void set_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& kind,
         const std::string& index)
@@ -174,7 +163,6 @@ void set_kind(
 }
 
 void set_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& port,
         const std::string& index)
@@ -193,7 +181,6 @@ void set_port(
 }
 
 void set_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& address,
         const std::string& index)
@@ -212,7 +199,6 @@ void set_address(
 }
 
 void set_externality(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& externality,
         const std::string& index)
@@ -234,7 +220,6 @@ void set_externality(
 }
 
 void set_cost(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& cost,
         const std::string& index)
@@ -243,7 +228,6 @@ void set_cost(
 }
 
 void set_mask(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& mask,
         const std::string& index)

--- a/lib/src/cpp/domain_participant/DefaultMulticastLocators.cpp
+++ b/lib/src/cpp/domain_participant/DefaultMulticastLocators.cpp
@@ -28,7 +28,6 @@ namespace domain_participant {
 namespace default_multicast_locators {
 
 std::string print(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -36,7 +35,6 @@ std::string print(
 }
 
 std::string print_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -44,7 +42,6 @@ std::string print_kind(
 }
 
 std::string print_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -52,7 +49,6 @@ std::string print_port(
 }
 
 std::string print_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -60,7 +56,6 @@ std::string print_physical_port(
 }
 
 std::string print_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -68,7 +63,6 @@ std::string print_address(
 }
 
 std::string print_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -76,7 +70,6 @@ std::string print_unique_lan_id(
 }
 
 std::string print_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -84,14 +77,12 @@ std::string print_wan_address(
 }
 
 uint32_t size(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -99,7 +90,6 @@ void clear(
 }
 
 void clear_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -107,7 +97,6 @@ void clear_port(
 }
 
 void clear_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -115,7 +104,6 @@ void clear_physical_port(
 }
 
 void clear_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -123,7 +111,6 @@ void clear_address(
 }
 
 void clear_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -131,7 +118,6 @@ void clear_unique_lan_id(
 }
 
 void clear_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -139,7 +125,6 @@ void clear_wan_address(
 }
 
 void set_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& kind,
         const std::string& index)
@@ -148,7 +133,6 @@ void set_kind(
 }
 
 void set_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& port,
         const std::string& index)
@@ -157,7 +141,6 @@ void set_port(
 }
 
 void set_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& physical_port,
         const std::string& index)
@@ -166,7 +149,6 @@ void set_physical_port(
 }
 
 void set_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& address,
         const std::string& index)
@@ -175,7 +157,6 @@ void set_address(
 }
 
 void set_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& unique_lan_id,
         const std::string& index)
@@ -184,7 +165,6 @@ void set_unique_lan_id(
 }
 
 void set_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& wan_address,
         const std::string& index)

--- a/lib/src/cpp/domain_participant/DefaultUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/DefaultUnicastLocators.cpp
@@ -28,7 +28,6 @@ namespace domain_participant {
 namespace default_unicast_locators {
 
 std::string print(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -36,7 +35,6 @@ std::string print(
 }
 
 std::string print_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -44,7 +42,6 @@ std::string print_kind(
 }
 
 std::string print_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -52,7 +49,6 @@ std::string print_port(
 }
 
 std::string print_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -60,7 +56,6 @@ std::string print_physical_port(
 }
 
 std::string print_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -68,7 +63,6 @@ std::string print_address(
 }
 
 std::string print_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -76,7 +70,6 @@ std::string print_unique_lan_id(
 }
 
 std::string print_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -84,14 +77,12 @@ std::string print_wan_address(
 }
 
 uint32_t size(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -99,7 +90,6 @@ void clear(
 }
 
 void clear_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -107,7 +97,6 @@ void clear_port(
 }
 
 void clear_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -115,7 +104,6 @@ void clear_physical_port(
 }
 
 void clear_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -123,7 +111,6 @@ void clear_address(
 }
 
 void clear_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -131,7 +118,6 @@ void clear_unique_lan_id(
 }
 
 void clear_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -139,7 +125,6 @@ void clear_wan_address(
 }
 
 void set_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& kind,
         const std::string& index)
@@ -148,7 +133,6 @@ void set_kind(
 }
 
 void set_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& port,
         const std::string& index)
@@ -157,7 +141,6 @@ void set_port(
 }
 
 void set_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& physical_port,
         const std::string& index)
@@ -166,7 +149,6 @@ void set_physical_port(
 }
 
 void set_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& address,
         const std::string& index)
@@ -175,7 +157,6 @@ void set_address(
 }
 
 void set_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& unique_lan_id,
         const std::string& index)
@@ -184,7 +165,6 @@ void set_unique_lan_id(
 }
 
 void set_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& wan_address,
         const std::string& index)

--- a/lib/src/cpp/domain_participant/DomainParticipant.cpp
+++ b/lib/src/cpp/domain_participant/DomainParticipant.cpp
@@ -38,6 +38,7 @@ namespace domain_participant {
  * @param[in] create_if_not_existent flag that enables the creation of the  element if it does not exist
  * @param[in] additional_RTPS_tag additional RTPS tag to initialize directly
  *
+ * @throw Error exception if XML workspace was not initialized
  * @throw ElementNotFound exception if expected node was not found and node creation was not required
  */
 void initialize_namespace(
@@ -46,6 +47,9 @@ void initialize_namespace(
         const bool create_if_not_existent,
         const std::string& additional_RTPS_tag)
 {
+    // Check if workspace was initialized
+    manager.is_initialized();
+
     // Iterate through required elements, and create them if not existent
     manager.move_to_root_node();
     manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
@@ -60,62 +64,53 @@ void initialize_namespace(
 }
 
 std::string print(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
-std::string print_default_profile(
-        const std::string& xml_file)
+std::string print_default_profile()
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_domain_id(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_name(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_ignore_non_matching_locators(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_send_socket_buffer_size(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_listen_socket_buffer_size(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_participant_id(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_user_transports(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -123,14 +118,12 @@ std::string print_user_transports(
 }
 
 std::string print_use_builtin_transports(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_user_data(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -138,83 +131,71 @@ std::string print_user_data(
 }
 
 std::string print_prefix(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 uint32_t user_transports_size(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 uint32_t user_data_size(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
-void clear_default_profile(
-        const std::string& xml_file)
+void clear_default_profile()
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_domain_id(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_name(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_ignore_non_matching_locators(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_send_socket_buffer_size(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_listen_socket_buffer_size(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_participant_id(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_user_transports(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -222,14 +203,12 @@ void clear_user_transports(
 }
 
 void clear_use_builtin_transports(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_user_data(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -237,14 +216,12 @@ void clear_user_data(
 }
 
 void clear_prefix(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void set_default_profile(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     // Create XML manager and initialize the document
@@ -278,7 +255,6 @@ void set_default_profile(
 }
 
 void set_domain_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& domain_id)
 {
@@ -286,7 +262,6 @@ void set_domain_id(
 }
 
 void set_name(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& name)
 {
@@ -304,7 +279,6 @@ void set_name(
 }
 
 void set_ignore_non_matching_locators(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& ignore_non_matching_locators)
 {
@@ -312,7 +286,6 @@ void set_ignore_non_matching_locators(
 }
 
 void set_send_socket_buffer_size(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& send_socket_buffer_size)
 {
@@ -320,7 +293,6 @@ void set_send_socket_buffer_size(
 }
 
 void set_listen_socket_buffer_size(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& listen_socket_buffer_size)
 {
@@ -328,7 +300,6 @@ void set_listen_socket_buffer_size(
 }
 
 void set_participant_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& participant_id)
 {
@@ -336,7 +307,6 @@ void set_participant_id(
 }
 
 void set_use_builtin_transports(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& use_builtin_transports)
 {
@@ -354,7 +324,6 @@ void set_use_builtin_transports(
 }
 
 void set_prefix(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix)
 {
@@ -362,7 +331,6 @@ void set_prefix(
 }
 
 void set_user_transports(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& transport_id,
         const std::string& index)
@@ -384,7 +352,6 @@ void set_user_transports(
 }
 
 void set_user_data(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& user_data,
         const std::string& index)

--- a/lib/src/cpp/domain_participant/DomainParticipant.cpp
+++ b/lib/src/cpp/domain_participant/DomainParticipant.cpp
@@ -47,14 +47,15 @@ void initialize_namespace(
         const std::string& additional_RTPS_tag)
 {
     // Iterate through required elements, and create them if not existent
-    manager.get_node(utils::tag::PROFILES, create_if_not_existent);
-    manager.get_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
+    manager.move_to_root_node();
+    manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
+    manager.move_to_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
 
     // there are additional tags to obtain
     if (!additional_RTPS_tag.empty())
     {
-        manager.get_node(utils::tag::RTPS, create_if_not_existent);
-        manager.get_node(additional_RTPS_tag, create_if_not_existent);
+        manager.move_to_node(utils::tag::RTPS, create_if_not_existent);
+        manager.move_to_node(additional_RTPS_tag, create_if_not_existent);
     }
 }
 
@@ -247,7 +248,7 @@ void set_default_profile(
         const std::string& profile_id)
 {
     // Create XML manager and initialize the document
-    utils::XMLManager manager(xml_file, false);
+    utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Obtain base node position
     initialize_namespace(manager, profile_id, false, "");
@@ -290,7 +291,7 @@ void set_name(
         const std::string& name)
 {
     // Create XML manager and initialize the document
-    utils::XMLManager manager(xml_file, true);
+    utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Obtain base node position
     initialize_namespace(manager, profile_id, true, utils::tag::NAME);
@@ -340,7 +341,7 @@ void set_use_builtin_transports(
         const std::string& use_builtin_transports)
 {
     // Create XML manager and initialize the document
-    utils::XMLManager manager(xml_file, true);
+    utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Obtain base node position
     initialize_namespace(manager, profile_id, true, utils::tag::USE_BUILTIN_TRANSPORTS);
@@ -367,13 +368,13 @@ void set_user_transports(
         const std::string& index)
 {
     // Create XML manager and initialize the document
-    utils::XMLManager manager(xml_file, true);
+    utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Obtain base node position
     initialize_namespace(manager, profile_id, true, utils::tag::USER_TRANSPORTS);
 
     // Obtain / create the transport located at the index position in the collection
-    manager.get_node(index, utils::tag::TRANSPORT_ID, true);
+    manager.move_to_node(index, utils::tag::TRANSPORT_ID, true);
 
     // set node value
     manager.set_value_to_node(transport_id);

--- a/lib/src/cpp/domain_participant/DomainParticipant.cpp
+++ b/lib/src/cpp/domain_participant/DomainParticipant.cpp
@@ -51,7 +51,7 @@ void initialize_namespace(
     manager.is_initialized();
 
     // Iterate through required elements, and create them if not existent
-    manager.move_to_root_node();
+    manager.move_to_root_node(create_if_not_existent);
     manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
     manager.move_to_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
 

--- a/lib/src/cpp/domain_participant/Port.cpp
+++ b/lib/src/cpp/domain_participant/Port.cpp
@@ -28,119 +28,102 @@ namespace domain_participant {
 namespace port {
 
 std::string print(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_base(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_domain_id_gain(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_participant_id_gain(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_offset_d0(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_offset_d1(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_offset_d2(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_offset_d3(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_base(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_domain_id_gain(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_participant_id_gain(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_offset_d0(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_offset_d1(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_offset_d2(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_offset_d3(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void set_base(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& port_base)
 {
@@ -148,7 +131,6 @@ void set_base(
 }
 
 void set_domain_id_gain(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& domain_id_gain)
 {
@@ -156,7 +138,6 @@ void set_domain_id_gain(
 }
 
 void set_participant_id_gain(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& domain_id_gain)
 {
@@ -164,7 +145,6 @@ void set_participant_id_gain(
 }
 
 void set_offset_d0(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& offset_d0)
 {
@@ -172,7 +152,6 @@ void set_offset_d0(
 }
 
 void set_offset_d1(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& offset_d1)
 {
@@ -180,7 +159,6 @@ void set_offset_d1(
 }
 
 void set_offset_d2(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& offset_d2)
 {
@@ -188,7 +166,6 @@ void set_offset_d2(
 }
 
 void set_offset_d3(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& offset_d3)
 {

--- a/lib/src/cpp/domain_participant/PropertiesPolicy.cpp
+++ b/lib/src/cpp/domain_participant/PropertiesPolicy.cpp
@@ -29,7 +29,6 @@ namespace domain_participant {
 namespace properties_policy {
 
 std::string print(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& property_id)
 {
@@ -37,7 +36,6 @@ std::string print(
 }
 
 std::string print_value(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& property_id)
 {
@@ -45,7 +43,6 @@ std::string print_value(
 }
 
 std::string print_propagate(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& property_id)
 {
@@ -53,21 +50,18 @@ std::string print_propagate(
 }
 
 uint32_t size(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::vector<std::string> keys(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& property_id)
 {
@@ -75,7 +69,6 @@ void clear(
 }
 
 void clear_value(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& property_id)
 {
@@ -83,7 +76,6 @@ void clear_value(
 }
 
 void clear_propagate(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& property_id)
 {
@@ -91,7 +83,6 @@ void clear_propagate(
 }
 
 void set_value(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& property_id,
         const std::string& value)
@@ -100,7 +91,6 @@ void set_value(
 }
 
 void set_propagate(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& property_id,
         const std::string& propagate)
@@ -109,7 +99,6 @@ void set_propagate(
 }
 
 void push(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& property_id)
 {

--- a/lib/src/cpp/domain_participant/builtin/Builtin.cpp
+++ b/lib/src/cpp/domain_participant/builtin/Builtin.cpp
@@ -28,119 +28,102 @@ namespace domain_participant {
 namespace builtin {
 
 std::string print(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_avoid_builtin_multicast(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_use_writer_liveliness_protocol(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_reader_history_memory_policy(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_writer_history_memory_policy(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_reader_payload_size(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_writer_payload_size(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_mutation_tries(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_avoid_builtin_multicast(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_use_writer_liveliness_protocol(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_reader_history_memory_policy(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_writer_history_memory_policy(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_reader_payload_size(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_witer_payload_size(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_mutation_tries(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void set_avoid_builtin_multicast(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& avoid_builtin_multicast)
 {
@@ -148,7 +131,6 @@ void set_avoid_builtin_multicast(
 }
 
 void set_use_writer_liveliness_protocol(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& use_writer_liveliness_protocol)
 {
@@ -156,7 +138,6 @@ void set_use_writer_liveliness_protocol(
 }
 
 void set_reader_history_memory_policy(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& reader_history_memory_policy)
 {
@@ -164,7 +145,6 @@ void set_reader_history_memory_policy(
 }
 
 void set_writer_history_memory_policy(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& writer_history_memory_policy)
 {
@@ -172,7 +152,6 @@ void set_writer_history_memory_policy(
 }
 
 void set_reader_payload_size(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& reader_payload_size)
 {
@@ -180,7 +159,6 @@ void set_reader_payload_size(
 }
 
 void set_writer_payload_size(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& writer_payload_size)
 {
@@ -188,7 +166,6 @@ void set_writer_payload_size(
 }
 
 void set_mutation_tries(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& mutation_tries)
 {

--- a/lib/src/cpp/domain_participant/builtin/InitialPeers.cpp
+++ b/lib/src/cpp/domain_participant/builtin/InitialPeers.cpp
@@ -51,7 +51,7 @@ void initialize_namespace(
     manager.is_initialized();
 
     // Iterate through required elements, and create them if not existent
-    manager.move_to_root_node();
+    manager.move_to_root_node(create_if_not_existent);
     manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
     manager.move_to_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
     manager.move_to_node(utils::tag::RTPS, create_if_not_existent);

--- a/lib/src/cpp/domain_participant/builtin/InitialPeers.cpp
+++ b/lib/src/cpp/domain_participant/builtin/InitialPeers.cpp
@@ -47,11 +47,12 @@ void initialize_namespace(
         const bool create_if_not_existent)
 {
     // Iterate through required elements, and create them if not existent
-    manager.get_node(utils::tag::PROFILES, create_if_not_existent);
-    manager.get_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
-    manager.get_node(utils::tag::RTPS, create_if_not_existent);
-    manager.get_node(utils::tag::BUILTIN, create_if_not_existent);
-    manager.get_node(utils::tag::INITIAL_PEERS_LIST, create_if_not_existent);
+    manager.move_to_root_node();
+    manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
+    manager.move_to_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
+    manager.move_to_node(utils::tag::RTPS, create_if_not_existent);
+    manager.move_to_node(utils::tag::BUILTIN, create_if_not_existent);
+    manager.move_to_node(utils::tag::INITIAL_PEERS_LIST, create_if_not_existent);
 }
 
 std::string print(
@@ -181,7 +182,7 @@ void set_port(
         const std::string& index)
 {
     // Create XML manager and initialize the document
-    utils::XMLManager manager(xml_file, true);
+    utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Obtain base node position
     initialize_namespace(manager, profile_id, true);
@@ -209,7 +210,7 @@ void set_address(
         const std::string& index)
 {
     // Create XML manager and initialize the document
-    utils::XMLManager manager(xml_file, true);
+    utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Obtain base node position
     initialize_namespace(manager, profile_id, true);

--- a/lib/src/cpp/domain_participant/builtin/InitialPeers.cpp
+++ b/lib/src/cpp/domain_participant/builtin/InitialPeers.cpp
@@ -39,6 +39,7 @@ namespace initial_peers {
  * @param[in] profile_id Domain participant profile identifier
  * @param[in] create_if_not_existent flag that enables the creation of the  element if it does not exist
  *
+ * @throw Error exception if XML workspace was not initialized
  * @throw ElementNotFound exception if expected node was not found and node creation was not required
  */
 void initialize_namespace(
@@ -46,6 +47,9 @@ void initialize_namespace(
         const std::string& profile_id,
         const bool create_if_not_existent)
 {
+    // Check if workspace was initialized
+    manager.is_initialized();
+
     // Iterate through required elements, and create them if not existent
     manager.move_to_root_node();
     manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
@@ -56,7 +60,6 @@ void initialize_namespace(
 }
 
 std::string print(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -64,7 +67,6 @@ std::string print(
 }
 
 std::string print_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -72,7 +74,6 @@ std::string print_kind(
 }
 
 std::string print_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -80,7 +81,6 @@ std::string print_port(
 }
 
 std::string print_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -88,7 +88,6 @@ std::string print_physical_port(
 }
 
 std::string print_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -96,7 +95,6 @@ std::string print_address(
 }
 
 std::string print_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -104,7 +102,6 @@ std::string print_unique_lan_id(
 }
 
 std::string print_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -112,14 +109,12 @@ std::string print_wan_address(
 }
 
 uint32_t size(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -127,7 +122,6 @@ void clear(
 }
 
 void clear_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -135,7 +129,6 @@ void clear_port(
 }
 
 void clear_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -143,7 +136,6 @@ void clear_physical_port(
 }
 
 void clear_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -151,7 +143,6 @@ void clear_address(
 }
 
 void clear_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -159,7 +150,6 @@ void clear_unique_lan_id(
 }
 
 void clear_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -167,7 +157,6 @@ void clear_wan_address(
 }
 
 void set_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& kind,
         const std::string& index)
@@ -176,7 +165,6 @@ void set_kind(
 }
 
 void set_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& port,
         const std::string& index)
@@ -195,7 +183,6 @@ void set_port(
 }
 
 void set_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& physical_port,
         const std::string& index)
@@ -204,7 +191,6 @@ void set_physical_port(
 }
 
 void set_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& address,
         const std::string& index)
@@ -223,7 +209,6 @@ void set_address(
 }
 
 void set_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& unique_lan_id,
         const std::string& index)
@@ -232,7 +217,6 @@ void set_unique_lan_id(
 }
 
 void set_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& wan_address,
         const std::string& index)

--- a/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
@@ -51,7 +51,7 @@ void initialize_namespace(
     manager.is_initialized();
 
     // Iterate through required elements, and create them if not existent
-    manager.move_to_root_node();
+    manager.move_to_root_node(create_if_not_existent);
     manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
     manager.move_to_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
     manager.move_to_node(utils::tag::RTPS, create_if_not_existent);

--- a/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
@@ -47,11 +47,12 @@ void initialize_namespace(
         const bool create_if_not_existent)
 {
     // Iterate through required elements, and create them if not existent
-    manager.get_node(utils::tag::PROFILES, create_if_not_existent);
-    manager.get_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
-    manager.get_node(utils::tag::RTPS, create_if_not_existent);
-    manager.get_node(utils::tag::BUILTIN, create_if_not_existent);
-    manager.get_node(utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST, create_if_not_existent);
+    manager.move_to_root_node();
+    manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
+    manager.move_to_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
+    manager.move_to_node(utils::tag::RTPS, create_if_not_existent);
+    manager.move_to_node(utils::tag::BUILTIN, create_if_not_existent);
+    manager.move_to_node(utils::tag::METATRAFFIC_EXTERNAL_UNICAST_LOCATOR_LIST, create_if_not_existent);
 }
 
 std::string print(
@@ -181,7 +182,7 @@ void set_port(
         const std::string& index)
 {
     // Create XML manager and initialize the document
-    utils::XMLManager manager(xml_file, true);
+    utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Obtain base node position
     initialize_namespace(manager, profile_id, true);
@@ -200,7 +201,7 @@ void set_address(
         const std::string& index)
 {
     // Create XML manager and initialize the document
-    utils::XMLManager manager(xml_file, true);
+    utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Obtain base node position
     initialize_namespace(manager, profile_id, true);
@@ -219,13 +220,13 @@ void set_externality(
         const std::string& index)
 {
     // Create XML manager and initialize the document
-    utils::XMLManager manager(xml_file, true);
+    utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Obtain base node position
     initialize_namespace(manager, profile_id, true);
 
     // Iterate through required elements, and create them if not existent
-    manager.get_locator_node(index, true, true);
+    manager.move_to_locator_node(index, true, true);
 
     // Set the externality value
     manager.set_attribute_to_node(utils::tag::EXTERNALITY, externality);

--- a/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/builtin/MetatrafficExternalUnicastLocators.cpp
@@ -39,6 +39,7 @@ namespace metatraffic_external_unicast_locators {
  * @param[in] profile_id Domain participant profile identifier
  * @param[in] create_if_not_existent flag that enables the creation of the  element if it does not exist
  *
+ * @throw Error exception if XML workspace was not initialized
  * @throw ElementNotFound exception if expected node was not found and node creation was not required
  */
 void initialize_namespace(
@@ -46,6 +47,9 @@ void initialize_namespace(
         const std::string& profile_id,
         const bool create_if_not_existent)
 {
+    // Check if workspace was initialized
+    manager.is_initialized();
+
     // Iterate through required elements, and create them if not existent
     manager.move_to_root_node();
     manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
@@ -56,7 +60,6 @@ void initialize_namespace(
 }
 
 std::string print(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -64,7 +67,6 @@ std::string print(
 }
 
 std::string print_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -72,7 +74,6 @@ std::string print_kind(
 }
 
 std::string print_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -80,7 +81,6 @@ std::string print_port(
 }
 
 std::string print_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -88,7 +88,6 @@ std::string print_address(
 }
 
 std::string print_externality(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -96,7 +95,6 @@ std::string print_externality(
 }
 
 std::string print_cost(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -104,7 +102,6 @@ std::string print_cost(
 }
 
 std::string print_mask(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -112,14 +109,12 @@ std::string print_mask(
 }
 
 uint32_t size(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -127,7 +122,6 @@ void clear(
 }
 
 void clear_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -135,7 +129,6 @@ void clear_port(
 }
 
 void clear_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -143,7 +136,6 @@ void clear_address(
 }
 
 void clear_externality(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -151,7 +143,6 @@ void clear_externality(
 }
 
 void clear_cost(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -159,7 +150,6 @@ void clear_cost(
 }
 
 void clear_mask(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -167,7 +157,6 @@ void clear_mask(
 }
 
 void set_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& kind,
         const std::string& index)
@@ -176,7 +165,6 @@ void set_kind(
 }
 
 void set_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& port,
         const std::string& index)
@@ -195,7 +183,6 @@ void set_port(
 }
 
 void set_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& address,
         const std::string& index)
@@ -214,7 +201,6 @@ void set_address(
 }
 
 void set_externality(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& externality,
         const std::string& index)
@@ -236,7 +222,6 @@ void set_externality(
 }
 
 void set_cost(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& cost,
         const std::string& index)
@@ -245,7 +230,6 @@ void set_cost(
 }
 
 void set_mask(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& mask,
         const std::string& index)

--- a/lib/src/cpp/domain_participant/builtin/MetatrafficMulticastLocators.cpp
+++ b/lib/src/cpp/domain_participant/builtin/MetatrafficMulticastLocators.cpp
@@ -29,7 +29,6 @@ namespace builtin {
 namespace metatraffic_multicast_locators {
 
 std::string print(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -37,7 +36,6 @@ std::string print(
 }
 
 std::string print_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -45,7 +43,6 @@ std::string print_kind(
 }
 
 std::string print_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -53,7 +50,6 @@ std::string print_port(
 }
 
 std::string print_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -61,7 +57,6 @@ std::string print_physical_port(
 }
 
 std::string print_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -69,7 +64,6 @@ std::string print_address(
 }
 
 std::string print_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -77,7 +71,6 @@ std::string print_unique_lan_id(
 }
 
 std::string print_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -85,14 +78,12 @@ std::string print_wan_address(
 }
 
 uint32_t size(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -100,7 +91,6 @@ void clear(
 }
 
 void clear_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -108,7 +98,6 @@ void clear_port(
 }
 
 void clear_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -116,7 +105,6 @@ void clear_physical_port(
 }
 
 void clear_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -124,7 +112,6 @@ void clear_address(
 }
 
 void clear_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -132,7 +119,6 @@ void clear_unique_lan_id(
 }
 
 void clear_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -140,7 +126,6 @@ void clear_wan_address(
 }
 
 void set_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& kind,
         const std::string& index)
@@ -149,7 +134,6 @@ void set_kind(
 }
 
 void set_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& port,
         const std::string& index)
@@ -158,7 +142,6 @@ void set_port(
 }
 
 void set_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& physical_port,
         const std::string& index)
@@ -167,7 +150,6 @@ void set_physical_port(
 }
 
 void set_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& address,
         const std::string& index)
@@ -176,7 +158,6 @@ void set_address(
 }
 
 void set_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& unique_lan_id,
         const std::string& index)
@@ -185,7 +166,6 @@ void set_unique_lan_id(
 }
 
 void set_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& wan_address,
         const std::string& index)

--- a/lib/src/cpp/domain_participant/builtin/MetatrafficUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/builtin/MetatrafficUnicastLocators.cpp
@@ -29,7 +29,6 @@ namespace builtin {
 namespace metatraffic_unicast_locators {
 
 std::string print(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -37,7 +36,6 @@ std::string print(
 }
 
 std::string print_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -45,7 +43,6 @@ std::string print_kind(
 }
 
 std::string print_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -53,7 +50,6 @@ std::string print_port(
 }
 
 std::string print_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -61,7 +57,6 @@ std::string print_physical_port(
 }
 
 std::string print_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -69,7 +64,6 @@ std::string print_address(
 }
 
 std::string print_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -77,7 +71,6 @@ std::string print_unique_lan_id(
 }
 
 std::string print_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -85,14 +78,12 @@ std::string print_wan_address(
 }
 
 uint32_t size(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -100,7 +91,6 @@ void clear(
 }
 
 void clear_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -108,7 +98,6 @@ void clear_port(
 }
 
 void clear_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -116,7 +105,6 @@ void clear_physical_port(
 }
 
 void clear_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -124,7 +112,6 @@ void clear_address(
 }
 
 void clear_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -132,7 +119,6 @@ void clear_unique_lan_id(
 }
 
 void clear_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -140,7 +126,6 @@ void clear_wan_address(
 }
 
 void set_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& kind,
         const std::string& index)
@@ -149,7 +134,6 @@ void set_kind(
 }
 
 void set_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& port,
         const std::string& index)
@@ -158,7 +142,6 @@ void set_port(
 }
 
 void set_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& physical_port,
         const std::string& index)
@@ -167,7 +150,6 @@ void set_physical_port(
 }
 
 void set_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& address,
         const std::string& index)
@@ -176,7 +158,6 @@ void set_address(
 }
 
 void set_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& unique_lan_id,
         const std::string& index)
@@ -185,7 +166,6 @@ void set_unique_lan_id(
 }
 
 void set_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& wan_address,
         const std::string& index)

--- a/lib/src/cpp/domain_participant/builtin/discovery_config/DiscoveryConfig.cpp
+++ b/lib/src/cpp/domain_participant/builtin/discovery_config/DiscoveryConfig.cpp
@@ -53,7 +53,7 @@ void initialize_namespace(
     manager.is_initialized();
 
     // Iterate through required elements, and create them if not existent
-    manager.move_to_root_node();
+    manager.move_to_root_node(create_if_not_existent);
     manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
     manager.move_to_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
     manager.move_to_node(utils::tag::RTPS, create_if_not_existent);

--- a/lib/src/cpp/domain_participant/builtin/discovery_config/DiscoveryConfig.cpp
+++ b/lib/src/cpp/domain_participant/builtin/discovery_config/DiscoveryConfig.cpp
@@ -49,14 +49,15 @@ void initialize_namespace(
         const std::string& additional_tag)
 {
     // Iterate through required elements, and create them if not existent
-    manager.get_node(utils::tag::PROFILES, create_if_not_existent);
-    manager.get_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
-    manager.get_node(utils::tag::RTPS, create_if_not_existent);
-    manager.get_node(utils::tag::BUILTIN, create_if_not_existent);
-    manager.get_node(utils::tag::DISCOVERY_CONFIG, create_if_not_existent);
+    manager.move_to_root_node();
+    manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
+    manager.move_to_node(utils::tag::PARTICIPANT, utils::tag::PROFILE_NAME, profile_id, create_if_not_existent);
+    manager.move_to_node(utils::tag::RTPS, create_if_not_existent);
+    manager.move_to_node(utils::tag::BUILTIN, create_if_not_existent);
+    manager.move_to_node(utils::tag::DISCOVERY_CONFIG, create_if_not_existent);
     if (!additional_tag.empty())
     {
-        manager.get_node(additional_tag, create_if_not_existent);
+        manager.move_to_node(additional_tag, create_if_not_existent);
     }
 }
 
@@ -423,7 +424,7 @@ void set_lease_duration_sec(
         const std::string& duration_sec)
 {
     // Create XML manager and initialize the document
-    utils::XMLManager manager(xml_file, true);
+    utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Obtain base node position
     initialize_namespace(manager, profile_id, true, utils::tag::LEASE_DURATION);
@@ -441,7 +442,7 @@ void set_lease_duration_nanosec(
         const std::string& duration_nanosec)
 {
     // Create XML manager and initialize the document
-    utils::XMLManager manager(xml_file, true);
+    utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Obtain base node position
     initialize_namespace(manager, profile_id, true, utils::tag::LEASE_DURATION);
@@ -459,7 +460,7 @@ void set_lease_announcement_sec(
         const std::string& announcement_sec)
 {
     // Create XML manager and initialize the document
-    utils::XMLManager manager(xml_file, true);
+    utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Obtain base node position
     initialize_namespace(manager, profile_id, true, utils::tag::LEASE_ANNOUNCEMENT);
@@ -477,7 +478,7 @@ void set_lease_announcement_nanosec(
         const std::string& announcement_nanosec)
 {
     // Create XML manager and initialize the document
-    utils::XMLManager manager(xml_file, true);
+    utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Obtain base node position
     initialize_namespace(manager, profile_id, true, utils::tag::LEASE_ANNOUNCEMENT);

--- a/lib/src/cpp/domain_participant/builtin/discovery_config/DiscoveryConfig.cpp
+++ b/lib/src/cpp/domain_participant/builtin/discovery_config/DiscoveryConfig.cpp
@@ -40,6 +40,7 @@ namespace discovery_config {
  * @param[in] create_if_not_existent flag that enables the creation of the  element if it does not exist
  * @param[in] additional_tag additional tag to obtain base node
  *
+ * @throw Error exception if XML workspace was not initialized
  * @throw ElementNotFound exception if expected node was not found and node creation was not required
  */
 void initialize_namespace(
@@ -48,6 +49,9 @@ void initialize_namespace(
         const bool create_if_not_existent,
         const std::string& additional_tag)
 {
+    // Check if workspace was initialized
+    manager.is_initialized();
+
     // Iterate through required elements, and create them if not existent
     manager.move_to_root_node();
     manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
@@ -62,154 +66,132 @@ void initialize_namespace(
 }
 
 std::string print(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_discovery_protocol(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_ignore_participant_flags(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_edp(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_simple_edp(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_simple_edp_pubwriter_subreader(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_simple_edp_pubreader_subwriter(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_lease_duration(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_lease_duration_sec(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_lease_duration_nanosec(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_lease_announcement(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_lease_announcement_sec(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_lease_announcement_nanosec(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_initial_announcements(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_initial_announcements_count(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_initial_announcements_period(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_initial_announcements_period_sec(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_initial_announcements_period_nanosec(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_client_announcement_period(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_client_announcement_period_sec(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_client_announcement_period_nanosec(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_static_edp_xml_config(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -217,161 +199,138 @@ std::string print_static_edp_xml_config(
 }
 
 uint32_t static_edp_xml_config_size(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_discovery_protocol(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_ignore_participant_flags(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_edp(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_simple_edp(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_simple_edp_pubwriter_subreader(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_simple_edp_edp_pubreader_subwriter(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_lease_duration(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_lease_duration_sec(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_lease_duration_nanosec(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_lease_announcement(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_lease_announcement_sec(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_lease_announcement_nanosec(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_initial_announcements(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_initial_announcements_count(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_initial_announcements_period(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_initial_announcements_period_sec(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_initial_announcements_period_nanosec(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_client_announcement_period(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_client_announcement_period_sec(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_client_announcement_period_nanosec(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_static_edp_xml_config(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -379,7 +338,6 @@ void clear_static_edp_xml_config(
 }
 
 void set_discovery_protocol(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& discovery_protocol)
 {
@@ -387,7 +345,6 @@ void set_discovery_protocol(
 }
 
 void set_ignore_participant_flags(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& ignore_participant_flags)
 {
@@ -395,7 +352,6 @@ void set_ignore_participant_flags(
 }
 
 void set_edp(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& edp)
 {
@@ -403,7 +359,6 @@ void set_edp(
 }
 
 void set_simple_edp_pubwriter_subreader(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& simple_edp_pubwriter_subreader)
 {
@@ -411,7 +366,6 @@ void set_simple_edp_pubwriter_subreader(
 }
 
 void set_simple_edp_pubreader_subwriter(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& simple_edp_pubreader_subwriter)
 {
@@ -419,7 +373,6 @@ void set_simple_edp_pubreader_subwriter(
 }
 
 void set_lease_duration_sec(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& duration_sec)
 {
@@ -437,7 +390,6 @@ void set_lease_duration_sec(
 }
 
 void set_lease_duration_nanosec(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& duration_nanosec)
 {
@@ -455,7 +407,6 @@ void set_lease_duration_nanosec(
 }
 
 void set_lease_announcement_sec(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& announcement_sec)
 {
@@ -473,7 +424,6 @@ void set_lease_announcement_sec(
 }
 
 void set_lease_announcement_nanosec(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& announcement_nanosec)
 {
@@ -491,7 +441,6 @@ void set_lease_announcement_nanosec(
 }
 
 void set_initial_announcements_count(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& count)
 {
@@ -499,7 +448,6 @@ void set_initial_announcements_count(
 }
 
 void set_initial_announcements_period_sec(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& period_sec)
 {
@@ -507,7 +455,6 @@ void set_initial_announcements_period_sec(
 }
 
 void set_initial_announcements_period_nanosec(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& period_nanosec)
 {
@@ -515,7 +462,6 @@ void set_initial_announcements_period_nanosec(
 }
 
 void set_client_announcement_period_sec(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& period_sec)
 {
@@ -523,7 +469,6 @@ void set_client_announcement_period_sec(
 }
 
 void set_client_announcement_period_nanosec(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& period_nanosec)
 {
@@ -531,7 +476,6 @@ void set_client_announcement_period_nanosec(
 }
 
 void set_static_edp_xml_config(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& static_edp_xml_config,
         const std::string& index)

--- a/lib/src/cpp/domain_participant/builtin/discovery_config/discovery_servers/DiscoveryServers.cpp
+++ b/lib/src/cpp/domain_participant/builtin/discovery_config/discovery_servers/DiscoveryServers.cpp
@@ -32,7 +32,6 @@ namespace discovery_config {
 namespace discovery_servers {
 
 std::string print(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& index)
 {
@@ -40,21 +39,18 @@ std::string print(
 }
 
 uint32_t size(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::vector<std::string> keys(
-        const std::string& xml_file,
         const std::string& profile_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix)
 {

--- a/lib/src/cpp/domain_participant/builtin/discovery_config/discovery_servers/MetatrafficMulticastLocators.cpp
+++ b/lib/src/cpp/domain_participant/builtin/discovery_config/discovery_servers/MetatrafficMulticastLocators.cpp
@@ -32,7 +32,6 @@ namespace discovery_servers {
 namespace metatraffic_multicast_locators {
 
 std::string print(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index)
@@ -41,7 +40,6 @@ std::string print(
 }
 
 std::string print_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index)
@@ -50,7 +48,6 @@ std::string print_kind(
 }
 
 std::string print_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index)
@@ -59,7 +56,6 @@ std::string print_port(
 }
 
 std::string print_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index)
@@ -68,7 +64,6 @@ std::string print_physical_port(
 }
 
 std::string print_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index)
@@ -77,7 +72,6 @@ std::string print_address(
 }
 
 std::string print_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index)
@@ -86,7 +80,6 @@ std::string print_unique_lan_id(
 }
 
 std::string print_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index)
@@ -95,7 +88,6 @@ std::string print_wan_address(
 }
 
 uint32_t size(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix)
 {
@@ -103,7 +95,6 @@ uint32_t size(
 }
 
 void clear(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index)
@@ -112,7 +103,6 @@ void clear(
 }
 
 void clear_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index)
@@ -121,7 +111,6 @@ void clear_port(
 }
 
 void clear_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index)
@@ -130,7 +119,6 @@ void clear_physical_port(
 }
 
 void clear_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index)
@@ -139,7 +127,6 @@ void clear_address(
 }
 
 void clear_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index)
@@ -148,7 +135,6 @@ void clear_unique_lan_id(
 }
 
 void clear_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index)
@@ -157,7 +143,6 @@ void clear_wan_address(
 }
 
 void set_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& kind,
@@ -167,7 +152,6 @@ void set_kind(
 }
 
 void set_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& port,
@@ -177,7 +161,6 @@ void set_port(
 }
 
 void set_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& physical_port,
@@ -187,7 +170,6 @@ void set_physical_port(
 }
 
 void set_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& address,
@@ -197,7 +179,6 @@ void set_address(
 }
 
 void set_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& unique_lan_id,
@@ -207,7 +188,6 @@ void set_unique_lan_id(
 }
 
 void set_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& wan_address,

--- a/lib/src/cpp/domain_participant/builtin/discovery_config/discovery_servers/MetatrafficUnicastLocators.cpp
+++ b/lib/src/cpp/domain_participant/builtin/discovery_config/discovery_servers/MetatrafficUnicastLocators.cpp
@@ -32,7 +32,6 @@ namespace discovery_servers {
 namespace metatraffic_unicast_locators {
 
 std::string print(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index)
@@ -41,7 +40,6 @@ std::string print(
 }
 
 std::string print_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index)
@@ -50,7 +48,6 @@ std::string print_kind(
 }
 
 std::string print_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index)
@@ -59,7 +56,6 @@ std::string print_port(
 }
 
 std::string print_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index)
@@ -68,7 +64,6 @@ std::string print_physical_port(
 }
 
 std::string print_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index)
@@ -77,7 +72,6 @@ std::string print_address(
 }
 
 std::string print_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index)
@@ -86,7 +80,6 @@ std::string print_unique_lan_id(
 }
 
 std::string print_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index)
@@ -95,7 +88,6 @@ std::string print_wan_address(
 }
 
 uint32_t size(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix)
 {
@@ -103,7 +95,6 @@ uint32_t size(
 }
 
 void clear(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index)
@@ -112,7 +103,6 @@ void clear(
 }
 
 void clear_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index)
@@ -121,7 +111,6 @@ void clear_port(
 }
 
 void clear_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index)
@@ -130,7 +119,6 @@ void clear_physical_port(
 }
 
 void clear_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index)
@@ -139,7 +127,6 @@ void clear_address(
 }
 
 void clear_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index)
@@ -148,7 +135,6 @@ void clear_unique_lan_id(
 }
 
 void clear_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& index)
@@ -157,7 +143,6 @@ void clear_wan_address(
 }
 
 void set_kind(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& kind,
@@ -167,7 +152,6 @@ void set_kind(
 }
 
 void set_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& port,
@@ -177,7 +161,6 @@ void set_port(
 }
 
 void set_physical_port(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& physical_port,
@@ -187,7 +170,6 @@ void set_physical_port(
 }
 
 void set_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& address,
@@ -197,7 +179,6 @@ void set_address(
 }
 
 void set_unique_lan_id(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& unique_lan_id,
@@ -207,7 +188,6 @@ void set_unique_lan_id(
 }
 
 void set_wan_address(
-        const std::string& xml_file,
         const std::string& profile_id,
         const std::string& prefix,
         const std::string& wan_address,

--- a/lib/src/cpp/transport_descriptor/TransportDescriptor.cpp
+++ b/lib/src/cpp/transport_descriptor/TransportDescriptor.cpp
@@ -38,6 +38,7 @@ namespace transport_descriptor {
  * @param[in] create_if_not_existent flag that enables the creation of the  element if it does not exist
  * @param[in] additional_tag additional tag to obtain node
  *
+ * @throw Error exception if XML workspace was not initialized
  * @throw ElementNotFound exception if expected node was not found and node creation was not required
  */
 void initialize_namespace(
@@ -46,6 +47,9 @@ void initialize_namespace(
         const bool create_if_not_existent,
         const std::string& additional_tag)
 {
+    // Check if workspace was initialized
+    manager.is_initialized();
+
     // Iterate through required elements, and create them if not existent
     manager.move_to_root_node();
     manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
@@ -57,49 +61,42 @@ void initialize_namespace(
 }
 
 std::string print(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_kind(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_send_buffer_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_receive_buffer_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_max_message_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_max_initial_peers_range(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_interface_whitelist(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& index)
 {
@@ -107,70 +104,60 @@ std::string print_interface_whitelist(
 }
 
 std::string print_ttl(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_non_blocking_send(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_output_port(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_wan_addr(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_keep_alive_frequency_ms(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_keep_alive_timeout_ms(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_max_logical_port(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_logical_port_range(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_logical_port_increment(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_listening_ports(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& index)
 {
@@ -178,56 +165,48 @@ std::string print_listening_ports(
 }
 
 std::string print_tls(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_tls_password(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_tls_private_key_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_tls_rsa_private_key_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_tls_cert_chain_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_tls_tmp_dh_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_tls_verify_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_tls_verify_mode(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& index)
 {
@@ -235,7 +214,6 @@ std::string print_tls_verify_mode(
 }
 
 std::string print_tls_options(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& index)
 {
@@ -243,7 +221,6 @@ std::string print_tls_options(
 }
 
 std::string print_tls_verify_paths(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& index)
 {
@@ -251,173 +228,148 @@ std::string print_tls_verify_paths(
 }
 
 std::string print_tls_verify_depth(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_tls_default_verify_path(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_tls_handshake_role(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_tls_server_name(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_calculate_crc(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_check_crc(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_enable_tcp_nodelay(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_segment_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_port_queue_capacity(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_healthy_check_timeout_ms(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 std::string print_rtps_dump_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
-uint32_t size(
-        const std::string& xml_file)
+uint32_t size()
 {
     throw Unsupported("Unsupported");
 }
 
-std::vector<std::string> keys(
-        const std::string& xml_file)
+std::vector<std::string> keys()
 {
     throw Unsupported("Unsupported");
 }
 
 uint32_t interface_whitelist_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 uint32_t listening_ports_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 uint32_t tls_verify_mode_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 uint32_t tls_options_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 uint32_t tls_verify_paths_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_kind(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_send_buffer_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_receive_buffer_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_max_message_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_max_initial_peers_range(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_interface_whitelist(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& index)
 {
@@ -425,70 +377,60 @@ void clear_interface_whitelist(
 }
 
 void clear_ttl(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_non_blocking_send(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_output_port(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_wan_addr(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_keep_alive_frequency_ms(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_keep_alive_timeout_ms(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_max_logical_port(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_logical_port_range(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_logical_port_increment(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_listening_ports(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& index)
 {
@@ -496,56 +438,48 @@ void clear_listening_ports(
 }
 
 void clear_tls(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_tls_password(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_tls_private_key_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_tls_rsa_private_key_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_tls_cert_chain_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_tls_tmp_dh_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_tls_verify_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_tls_verify_mode(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& index)
 {
@@ -553,7 +487,6 @@ void clear_tls_verify_mode(
 }
 
 void clear_tls_options(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& index)
 {
@@ -561,7 +494,6 @@ void clear_tls_options(
 }
 
 void clear_tls_verify_paths(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& index)
 {
@@ -569,84 +501,72 @@ void clear_tls_verify_paths(
 }
 
 void clear_tls_verify_depth(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_tls_default_verify_path(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_tls_handshake_role(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_tls_server_name(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_calculate_crc(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_check_crc(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_enable_tcp_nodelay(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_segment_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_port_queue_capacity(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_healthy_check_timeout_ms(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void clear_rtps_dump_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id)
 {
     throw Unsupported("Unsupported");
 }
 
 void set_kind(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& kind)
 {
@@ -664,7 +584,6 @@ void set_kind(
 }
 
 void set_send_buffer_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& send_buffer_size)
 {
@@ -672,7 +591,6 @@ void set_send_buffer_size(
 }
 
 void set_receive_buffer_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& receive_buffer_size)
 {
@@ -680,7 +598,6 @@ void set_receive_buffer_size(
 }
 
 void set_max_message_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& max_message_size)
 {
@@ -688,7 +605,6 @@ void set_max_message_size(
 }
 
 void set_max_initial_peers_range(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& max_initial_peers_range)
 {
@@ -696,7 +612,6 @@ void set_max_initial_peers_range(
 }
 
 void set_ttl(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& ttl)
 {
@@ -704,7 +619,6 @@ void set_ttl(
 }
 
 void set_non_blocking_send(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& non_blocking_send)
 {
@@ -712,7 +626,6 @@ void set_non_blocking_send(
 }
 
 void set_output_port(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& output_port)
 {
@@ -720,7 +633,6 @@ void set_output_port(
 }
 
 void set_wan_addr(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& wan_addr)
 {
@@ -728,7 +640,6 @@ void set_wan_addr(
 }
 
 void set_keep_alive_frequency_ms(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& keep_alive_frequency_ms)
 {
@@ -736,7 +647,6 @@ void set_keep_alive_frequency_ms(
 }
 
 void set_keep_alive_timeout_ms(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& keep_alive_timeout_ms)
 {
@@ -744,7 +654,6 @@ void set_keep_alive_timeout_ms(
 }
 
 void set_max_logical_port(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& max_logical_port)
 {
@@ -752,7 +661,6 @@ void set_max_logical_port(
 }
 
 void set_logical_port_range(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& logical_port_range)
 {
@@ -760,7 +668,6 @@ void set_logical_port_range(
 }
 
 void set_logical_port_increment(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& logical_port_increment)
 {
@@ -768,7 +675,6 @@ void set_logical_port_increment(
 }
 
 void set_tls_password(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& tls_password)
 {
@@ -776,7 +682,6 @@ void set_tls_password(
 }
 
 void set_tls_private_key_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& tls_private_key_file)
 {
@@ -784,7 +689,6 @@ void set_tls_private_key_file(
 }
 
 void set_tls_rsa_private_key_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& tls_rsa_private_key_file)
 {
@@ -792,7 +696,6 @@ void set_tls_rsa_private_key_file(
 }
 
 void set_tls_cert_chain_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& tls_cert_chain_file)
 {
@@ -800,7 +703,6 @@ void set_tls_cert_chain_file(
 }
 
 void set_tls_tmp_dh_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& tls_tmp_dh_file)
 {
@@ -808,7 +710,6 @@ void set_tls_tmp_dh_file(
 }
 
 void set_tls_verify_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& tls_verify_file)
 {
@@ -816,7 +717,6 @@ void set_tls_verify_file(
 }
 
 void set_tls_verify_depth(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& tls_verify_depth)
 {
@@ -824,7 +724,6 @@ void set_tls_verify_depth(
 }
 
 void set_tls_default_verify_path(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& tls_default_verify_path)
 {
@@ -832,7 +731,6 @@ void set_tls_default_verify_path(
 }
 
 void set_tls_handshake_role(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& tls_handshake_role)
 {
@@ -840,7 +738,6 @@ void set_tls_handshake_role(
 }
 
 void set_tls_server_name(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& tls_server_name)
 {
@@ -848,7 +745,6 @@ void set_tls_server_name(
 }
 
 void set_calculate_crc(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& calculate_crc)
 {
@@ -856,7 +752,6 @@ void set_calculate_crc(
 }
 
 void set_check_crc(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& check_crc)
 {
@@ -864,7 +759,6 @@ void set_check_crc(
 }
 
 void set_enable_tcp_nodelay(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& enable_tcp_nodelay)
 {
@@ -872,7 +766,6 @@ void set_enable_tcp_nodelay(
 }
 
 void set_segment_size(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& segment_size)
 {
@@ -880,7 +773,6 @@ void set_segment_size(
 }
 
 void set_port_queue_capacity(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& port_queue_capacity)
 {
@@ -888,7 +780,6 @@ void set_port_queue_capacity(
 }
 
 void set_healthy_check_timeout_ms(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& healthy_check_timeout_ms)
 {
@@ -896,7 +787,6 @@ void set_healthy_check_timeout_ms(
 }
 
 void set_rtps_dump_file(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& rtps_dump_file)
 {
@@ -904,7 +794,6 @@ void set_rtps_dump_file(
 }
 
 void set_interface_whitelist(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& ip_address,
         const std::string& index)
@@ -926,7 +815,6 @@ void set_interface_whitelist(
 }
 
 void set_listening_ports(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& port,
         const std::string& index)
@@ -935,7 +823,6 @@ void set_listening_ports(
 }
 
 void set_tls_verify_mode(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& tls_verify_mode,
         const std::string& index)
@@ -944,7 +831,6 @@ void set_tls_verify_mode(
 }
 
 void set_tls_options(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& tls_options,
         const std::string& index)
@@ -953,7 +839,6 @@ void set_tls_options(
 }
 
 void set_tls_verify_path(
-        const std::string& xml_file,
         const std::string& transport_descriptor_id,
         const std::string& tls_verify_path,
         const std::string& index)

--- a/lib/src/cpp/transport_descriptor/TransportDescriptor.cpp
+++ b/lib/src/cpp/transport_descriptor/TransportDescriptor.cpp
@@ -47,11 +47,12 @@ void initialize_namespace(
         const std::string& additional_tag)
 {
     // Iterate through required elements, and create them if not existent
-    manager.get_node(utils::tag::PROFILES, create_if_not_existent);
-    manager.get_transport_node(transport_id, create_if_not_existent);
+    manager.move_to_root_node();
+    manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
+    manager.move_to_transport_node(transport_id, create_if_not_existent);
     if (!additional_tag.empty())
     {
-        manager.get_node(additional_tag, create_if_not_existent);
+        manager.move_to_node(additional_tag, create_if_not_existent);
     }
 }
 
@@ -650,7 +651,7 @@ void set_kind(
         const std::string& kind)
 {
     // Create XML manager and initialize the document
-    utils::XMLManager manager(xml_file, true);
+    utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Obtain base node position
     initialize_namespace(manager, transport_descriptor_id, true, utils::tag::TRANSPORT_KIND);
@@ -909,13 +910,13 @@ void set_interface_whitelist(
         const std::string& index)
 {
     // Create XML manager and initialize the document
-    utils::XMLManager manager(xml_file, true);
+    utils::XMLManager& manager = eprosima::qosprof::utils::XMLManager::get_instance();
 
     // Obtain base node position
     initialize_namespace(manager, transport_descriptor_id, true, utils::tag::INTERFACE_WHITELIST);
 
     // Obtain the address located in the index position
-    manager.get_node(index, utils::tag::ADDRESS, true);
+    manager.move_to_node(index, utils::tag::ADDRESS, true);
 
     // Set the node value
     manager.set_value_to_node(ip_address);

--- a/lib/src/cpp/transport_descriptor/TransportDescriptor.cpp
+++ b/lib/src/cpp/transport_descriptor/TransportDescriptor.cpp
@@ -51,7 +51,7 @@ void initialize_namespace(
     manager.is_initialized();
 
     // Iterate through required elements, and create them if not existent
-    manager.move_to_root_node();
+    manager.move_to_root_node(create_if_not_existent);
     manager.move_to_node(utils::tag::PROFILES, create_if_not_existent);
     manager.move_to_transport_node(transport_id, create_if_not_existent);
     if (!additional_tag.empty())

--- a/lib/src/cpp/utils/ErrorHandlerXMLManager.cpp
+++ b/lib/src/cpp/utils/ErrorHandlerXMLManager.cpp
@@ -64,11 +64,8 @@ void ErrorHandlerXMLManager::report_parse_exception(
             throw ElementInvalid(xercesc::XMLString::transcode(ex.getMessage()));
             break;
         case Kind::ElementNotFound:
-            throw ElementNotFound(xercesc::XMLString::transcode(ex.getMessage()));
-            break;
-        case Kind::FileNotFound:
         default:
-            throw FileNotFound(xercesc::XMLString::transcode(ex.getMessage()));
+            throw ElementNotFound(xercesc::XMLString::transcode(ex.getMessage()));
             break;
     }
 }

--- a/lib/src/cpp/utils/ErrorHandlerXMLManager.hpp
+++ b/lib/src/cpp/utils/ErrorHandlerXMLManager.hpp
@@ -43,7 +43,6 @@ public:
      */
     enum class Kind
     {
-        FileNotFound,
         ElementInvalid,
         ElementNotFound,
     };
@@ -54,7 +53,7 @@ public:
      * @param Kind kind of exception to be thrown
      */
     ErrorHandlerXMLManager(
-            Kind kind = Kind::FileNotFound);
+            Kind kind = Kind::ElementNotFound);
 
     /**
      * @brief Destroy the Parse XML Error Handler object

--- a/lib/src/cpp/utils/XMLManager.cpp
+++ b/lib/src/cpp/utils/XMLManager.cpp
@@ -32,7 +32,7 @@ namespace utils {
 void XMLManager::initialize (
         const std::string& file_name)
 {
-    // Check if workspace already initialized to avoid initializing it twice
+    // Check if workspace has been already initialized to avoid initializing it twice
     if (alive)
     {
         // XML workspace already initialized
@@ -94,10 +94,10 @@ void XMLManager::initialize (
         // Obtain first document node
         reference_node = static_cast<xercesc::DOMNode*>(doc->getDocumentElement());
     }
-    // Given file does not exist
+    // Error parsing the document: root element not found
     catch (const ElementNotFound& ex)
     {
-        // Create new document if required
+        // There is no file in filesystem
         if (!file_exists)
         {
             // Implementation would create an empty document
@@ -105,6 +105,12 @@ void XMLManager::initialize (
 
             // There is no reference
             reference_node = nullptr;
+        }
+        // file exists in filesystem but it cannot be parsed
+        else
+        {
+            // Throw exception
+            throw ElementNotFound(ex);
         }
     }
 
@@ -165,7 +171,7 @@ void XMLManager::terminate()
             throw_error = ex.what();
         }
 
-        // IMPORTANT: set class as not longer initialized (terminated)
+        // IMPORTANT: set class as no longer initialized (terminated)
         alive = false;
 
         // Close XML workspace
@@ -587,6 +593,9 @@ void XMLManager::move_to_node(
         exception_message += " XML element.\n";
         throw ElementNotFound(exception_message);
     }
+
+    // TODO add a error check if any of the 'tag_name', 'name' and 'value' parameters are empty.
+    //      If happens, throw a BadParameter exception
 
     // Obtain list of nodes based on the target tag
     xercesc::DOMNodeList* node_list = static_cast<xercesc::DOMElement*>(reference_node)->getElementsByTagName(

--- a/lib/src/cpp/utils/XMLManager.cpp
+++ b/lib/src/cpp/utils/XMLManager.cpp
@@ -594,8 +594,7 @@ void XMLManager::move_to_node(
         throw ElementNotFound(exception_message);
     }
 
-    // TODO add a error check if any of the 'tag_name', 'name' and 'value' parameters are empty.
-    //      If happens, throw a BadParameter exception
+    // TODO add a check if 'name' parameter is empty, return (do not update) actual reference_node
 
     // Obtain list of nodes based on the target tag
     xercesc::DOMNodeList* node_list = static_cast<xercesc::DOMElement*>(reference_node)->getElementsByTagName(

--- a/lib/src/cpp/utils/XMLManager.cpp
+++ b/lib/src/cpp/utils/XMLManager.cpp
@@ -228,7 +228,8 @@ void XMLManager::create_node(
     xercesc::DOMNode* parent_node = reference_node;
 
     // Create new node and save it as last node
-    reference_node = static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(tag_name.c_str())));
+    reference_node =
+            static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(tag_name.c_str())));
 
     // Append new node to parent node
     parent_node->appendChild(reference_node);

--- a/lib/src/cpp/utils/XMLManager.cpp
+++ b/lib/src/cpp/utils/XMLManager.cpp
@@ -37,7 +37,9 @@ void XMLManager::initialize (
     if (alive)
     {
         // XML workspace already initialized
-        throw Error("XML workspace already initialized with file: " + xml_file + "\nTo terminate it, please call eprosima::qosprof::terminate() method\n");
+        throw Error(
+                  "XML workspace already initialized with file: " + xml_file +
+                  "\nTo terminate it, please call eprosima::qosprof::terminate() method\n");
     }
 
     // File exists flag
@@ -144,7 +146,8 @@ bool XMLManager::is_initialized()
     if (!alive)
     {
         // XML workspace has not been initialized
-        throw Error("XML workspace has not been initialized!\nPlease call eprosima::qosprof::initialize(std::string xml_file, bool create_file) method\n");
+        throw Error(
+                  "XML workspace has not been initialized!\nPlease call eprosima::qosprof::initialize(std::string xml_file, bool create_file) method\n");
     }
 
     // Return state. If false, this return would never be executed

--- a/lib/src/cpp/utils/XMLManager.cpp
+++ b/lib/src/cpp/utils/XMLManager.cpp
@@ -154,31 +154,21 @@ bool XMLManager::is_initialized()
 void XMLManager::terminate()
 {
     // Check if workspace was initialized
-    try
+    if (alive)
     {
-        is_initialized();
+        // write the final XML in the given path if needed
+        save_xml();
+
+        // IMPORTANT: set class as not longer initialized (terminated)
+        alive = false;
+
+        // Close XML workspace
+        xercesc::XMLPlatformUtils::Terminate();
     }
-    // Silent error management
-    catch (const Error& ex)
-    {
-        return;
-    }
-
-    // write the final XML in the given path if needed
-    save_xml();
-
-    // IMPORTANT: set class as not longer initialized (terminated)
-    alive = false;
-
-    // Close XML workspace
-    xercesc::XMLPlatformUtils::Terminate();
 }
 
 void XMLManager::transform_standalone_to_rooted_structure()
 {
-    // Check if workspace was initialized
-    is_initialized();
-
     std::string root_name = xercesc::XMLString::transcode(reference_node->getNodeName());
 
     // If NOT rooted structure (standalone structure)
@@ -220,9 +210,6 @@ void XMLManager::transform_standalone_to_rooted_structure()
 
 void XMLManager::validate_and_save_document()
 {
-    // Check if workspace was initialized
-    is_initialized();
-
     // Set the write required as false by default
     write_required = false;
 
@@ -235,9 +222,6 @@ void XMLManager::validate_and_save_document()
 
 bool XMLManager::validate_xml()
 {
-    // Check if workspace was initialized
-    is_initialized();
-
     // Set ElementInvalid error handler
     error_handler = new utils::ErrorHandlerXMLManager(
         utils::ErrorHandlerXMLManager::Kind::ElementInvalid);
@@ -260,9 +244,6 @@ bool XMLManager::validate_xml()
 
 bool XMLManager::save_xml()
 {
-    // Check if workspace was initialized
-    is_initialized();
-
     // write the final XML in the given path if needed
     if (write_required)
     {
@@ -283,9 +264,6 @@ bool XMLManager::save_xml()
 void XMLManager::create_node(
         const std::string& tag_name)
 {
-    // Check if workspace was initialized
-    is_initialized();
-
     // Save parent node
     xercesc::DOMNode* parent_node = reference_node;
 
@@ -299,9 +277,6 @@ void XMLManager::create_node(
 
 void XMLManager::clear_node()
 {
-    // Check if workspace was initialized
-    is_initialized();
-
     // Remove node from parent
     xercesc::DOMNode* parent_node = reference_node->getParentNode();
 
@@ -341,9 +316,6 @@ void XMLManager::clear_node()
 
 void XMLManager::reset_node()
 {
-    // Check if workspace was initialized
-    is_initialized();
-
     // Loop for childs
     while (reference_node->hasChildNodes())
     {
@@ -361,9 +333,6 @@ void XMLManager::reset_node()
 void XMLManager::set_value_to_node(
         const std::string& value)
 {
-    // Check if workspace was initialized
-    is_initialized();
-
     // Remove all childs
     reset_node();
 
@@ -376,9 +345,6 @@ void XMLManager::set_attribute_to_node(
         const std::string& name,
         const std::string& value)
 {
-    // Check if workspace was initialized
-    is_initialized();
-
     // Set the attribute value
     static_cast<xercesc::DOMElement*>(reference_node)->setAttribute(
         xercesc::XMLString::transcode(name.c_str()),
@@ -389,9 +355,6 @@ void XMLManager::set_siblings_attribute(
         const std::string& name,
         const std::string& value)
 {
-    // Check if workspace was initialized
-    is_initialized();
-
     // Obtain all siblings
     xercesc::DOMNodeList* siblings_node_list = reference_node->getParentNode()->getChildNodes();
 
@@ -415,9 +378,6 @@ void XMLManager::set_siblings_attribute(
 
 std::string XMLManager::get_node_value()
 {
-    // Check if workspace was initialized
-    is_initialized();
-
     if (xercesc::XMLString::transcode(reference_node->getNodeValue()) != nullptr)
     {
         return xercesc::XMLString::transcode(reference_node->getNodeValue());
@@ -431,9 +391,6 @@ std::string XMLManager::get_node_value()
 std::string XMLManager::get_node_attribute_value(
         const std::string& name)
 {
-    // Check if workspace was initialized
-    is_initialized();
-
     xercesc::DOMNode* attribute_node = reference_node->getAttributes()->getNamedItem(
         xercesc::XMLString::transcode(name.c_str()));
     if (attribute_node != nullptr)
@@ -455,9 +412,6 @@ void XMLManager::move_to_node(
         const std::string& tag_name,
         const bool create_if_not_existent)
 {
-    // Check if workspace was initialized
-    is_initialized();
-
     // Obtain list of nodes based on the target tag
     xercesc::DOMNodeList* node_list = static_cast<xercesc::DOMElement*>(reference_node)->getElementsByTagName(
         xercesc::XMLString::transcode(tag_name.c_str()));
@@ -493,9 +447,6 @@ void XMLManager::move_to_node(
         const std::string& default_tag_name,
         const bool create_if_not_existent)
 {
-    // Check if workspace was initialized
-    is_initialized();
-
     // Index not empty
     if (!index.empty())
     {
@@ -556,9 +507,6 @@ void XMLManager::move_to_node(
         const std::string& value,
         const bool create_if_not_existent)
 {
-    // Check if workspace was initialized
-    is_initialized();
-
     // Obtain list of nodes based on the target tag
     xercesc::DOMNodeList* node_list = static_cast<xercesc::DOMElement*>(reference_node)->getElementsByTagName(
         xercesc::XMLString::transcode(tag_name.c_str()));
@@ -606,9 +554,6 @@ void XMLManager::move_to_node(
 
 void XMLManager::move_to_root_node()
 {
-    // Check if workspace was initialized
-    is_initialized();
-
     // Set the last node as the root node
     reference_node = doc->getElementsByTagName(xercesc::XMLString::transcode(tag::ROOT))->item(0);
 }
@@ -618,9 +563,6 @@ void XMLManager::move_to_locator_node(
         const bool is_external,
         const bool create_if_not_existent)
 {
-    // Check if workspace was initialized
-    is_initialized();
-
     // Set default tag name for locator
     std::string default_tag_name = utils::tag::LOCATOR;
 
@@ -668,9 +610,6 @@ void XMLManager::move_to_transport_node(
         const std::string& transport_id,
         const bool create_if_not_existent)
 {
-    // Check if workspace was initialized
-    is_initialized();
-
     // Obtain list node
     move_to_node(utils::tag::TRANSPORT_DESCRIPTOR_LIST, create_if_not_existent);
 
@@ -786,9 +725,6 @@ std::string XMLManager::get_absolute_path(
 std::unique_ptr<std::vector<uint>> XMLManager::get_real_index(
         xercesc::DOMNodeList*& node_list)
 {
-    // Check if workspace was initialized
-    is_initialized();
-
     // Create new list
     std::unique_ptr<std::vector<uint>> index_list (new std::vector<uint>());
 

--- a/lib/src/cpp/utils/XMLManager.cpp
+++ b/lib/src/cpp/utils/XMLManager.cpp
@@ -33,9 +33,6 @@ void XMLManager::initialize (
         const std::string& file_name,
         bool create_file)
 {
-    // Write required flag
-    write_required = false;
-
     // File exists flag
     bool file_exists = false;
 

--- a/lib/src/cpp/utils/XMLManager.cpp
+++ b/lib/src/cpp/utils/XMLManager.cpp
@@ -197,7 +197,8 @@ void XMLManager::transform_standalone_to_rooted_structure()
                 xercesc::XMLString::transcode(utils::tag::EPROSIMA_URL));
 
             // Create copy of node
-            xercesc::DOMNode* copy_node = static_cast<xercesc::DOMNode*>(doc->createElement(reference_node->getNodeName()));
+            xercesc::DOMNode* copy_node =
+                    static_cast<xercesc::DOMNode*>(doc->createElement(reference_node->getNodeName()));
 
             // Recursive adoption to all child nodes:
             xercesc::DOMNodeList* root_child_nodes = reference_node->getChildNodes();

--- a/lib/src/cpp/utils/XMLManager.cpp
+++ b/lib/src/cpp/utils/XMLManager.cpp
@@ -157,7 +157,7 @@ bool XMLManager::is_initialized()
 void XMLManager::terminate()
 {
     std::string throw_error;
-    
+
     // Check if workspace was initialized
     if (alive)
     {

--- a/lib/src/cpp/utils/XMLManager.hpp
+++ b/lib/src/cpp/utils/XMLManager.hpp
@@ -44,33 +44,59 @@ namespace utils {
  */
 class XMLManager
 {
+//======================//
+// Singleton management //
+//======================//
 public:
+    /**
+     * @brief Get the instance object of the singleton class
+     *
+     * @return XMLManager&
+     */
+    static XMLManager& get_instance()
+    {
+        static XMLManager instance;
+        return instance;
+    }
 
     /**
      * @brief Construct a new Parse XML object, which initializes Xerces required tools,
      *  and reads given xml_file document.
      *
      * @param[in] xml_file string with the file path
-     * @param[in] create_file bool (optional) create file if the flag is set
+     * @param[in] create_file bool create file if the flag is set
      *
      * @throw Error exception if Xerces XML workspace could not be initialized
      */
-    XMLManager(
+    void initialize(
             const std::string& xml_file,
-            bool create_file = false);
+            bool create_file);
+
 
     /**
-     * @brief Pase XML Destructor
-     *
-     */
-    ~XMLManager();
-
-    /**
-     * @brief Validate the document, and save to disk if valid.
+     * @brief Validate the document, and set flag to save to disk later if valid.
      *
      * @throw ElementInvalid exception if document does not pass parser validation
      */
     void validate_and_save_document();
+
+    /**
+     * @brief Save the document as string and validate.
+     *
+     * @throw ElementInvalid exception if document does not pass parser validation
+     *
+     * @return true document passes parser validation
+     * @return false document does not pass parser validation
+     */
+    bool validate_xml();
+
+    /**
+     * @brief  Save the document in the target file path.
+     *
+     * @return true document saved
+     * @return false failure saving document
+     */
+    bool save_xml();
 
     /**
      * @brief Remove the selected node.
@@ -137,7 +163,7 @@ public:
      *
      * @throw ElementNotFound exception if expected node was not found and node creation was not required
      */
-    void get_node(
+    void move_to_node(
             const std::string& tag_name,
             const bool create_if_not_existent);
 
@@ -151,7 +177,7 @@ public:
      * @throw ElementNotFound exception if expected node was not found and node creation was not required
      * @throw BadParameter exception if expected node could not be found by using the given index.
      */
-    void get_node(
+    void move_to_node(
             const std::string& index,
             const std::string& default_tag_name,
             const bool create_if_not_existent);
@@ -167,11 +193,16 @@ public:
      *
      * @throw ElementNotFound exception if expected node was not found and node creation was not required
      */
-    void get_node(
+    void move_to_node(
             const std::string& tag_name,
             const std::string& name,
             const std::string& value,
             const bool create_if_not_existent);
+
+    /**
+     * @brief Gets the root node of the document
+     */
+    void move_to_root_node();
 
     /**
      * @brief Get the locator node object found at index position. If empty index, current node is kept.
@@ -183,7 +214,7 @@ public:
      * @throw ElementNotFound exception if expected node was not found and node creation was not required
      * @throw BadParameter exception if expected node could not be found by using the given index.
      */
-    void get_locator_node(
+    void move_to_locator_node(
             const std::string& index,
             const bool is_external,
             const bool create_if_not_existent);
@@ -196,34 +227,17 @@ public:
      *
      * @throw ElementNotFound exception if expected node was not found and node creation was not required
      */
-    void get_transport_node(
+    void move_to_transport_node(
             const std::string& transport_id,
             const bool create_if_not_existent);
 
 private:
+    XMLManager() {}
 
     /**
      * @brief Transforms standalone XML document structure to rooted.
      */
     void transform_standalone_to_rooted_structure();
-
-    /**
-     * @brief Save the document as string and validate.
-     *
-     * @throw ElementInvalid exception if document does not pass parser validation
-     *
-     * @return true document passes parser validation
-     * @return false document does not pass parser validation
-     */
-    bool validate_xml();
-
-    /**
-     * @brief  Save the document in the target file path.
-     *
-     * @return true document saved
-     * @return false failure saving document
-     */
-    bool save_xml();
 
     /**
      * @brief Auxiliar method that creates a new node with the given tag and appends it to the last node.
@@ -283,6 +297,9 @@ private:
 
     // Latest node navigated to
     xercesc::DOMNode* last_node = nullptr;
+
+    // Flag to write before exit
+    bool write_required = false;
 };
 
 } /* parse */

--- a/lib/src/cpp/utils/XMLManager.hpp
+++ b/lib/src/cpp/utils/XMLManager.hpp
@@ -87,7 +87,6 @@ public:
      * @throw Error exception if XML workspace was not initialized
      *
      * @return true if XML workspace already initialized
-     * @return false if XML workspace has not been initialized
      */
     bool is_initialized();
 
@@ -104,7 +103,6 @@ public:
      * @throw ElementInvalid exception if document does not pass parser validation
      *
      * @return true document passes parser validation
-     * @return false document does not pass parser validation
      */
     bool validate_xml();
 

--- a/lib/src/cpp/utils/XMLManager.hpp
+++ b/lib/src/cpp/utils/XMLManager.hpp
@@ -66,13 +66,11 @@ public:
      *  and reads given xml_file document.
      *
      * @param[in] xml_file string with the file path
-     * @param[in] create_file bool create file if the flag is set
      *
      * @throw Error exception if Xerces XML workspace could not be initialized, or it was already initialized
      */
     void initialize(
-            const std::string& xml_file,
-            bool create_file);
+            const std::string& xml_file);
 
     /**
      * @brief Terminate XML workspace. If required to save or update the XML configuration in the filesystem,
@@ -177,7 +175,7 @@ public:
             const std::string& name);
 
     /**
-     * @brief Get the (unique) child node object that matches the given tag name.
+     * @brief Move the reference node to the (unique) child node object that matches the given tag name.
      *
      * @param[in] tag_name string with the node (<tag>) name
      * @param[in] create_if_not_existent flag to create node if it is not found
@@ -189,7 +187,8 @@ public:
             const bool create_if_not_existent);
 
     /**
-     * @brief Get the node object located in the index position. If empty index, current node is kept.
+     * @brief Move the reference node to  the node object located in the index position. If empty index, current
+     *        node is kept.
      *
      * @param[in] index string index of the node element
      * @param[in] default_tag_name string with the default node (<tag>) name required to create the node if required.
@@ -204,8 +203,8 @@ public:
             const bool create_if_not_existent);
 
     /**
-     * @brief Get the node object that matches the given tag name, and has the same attribute key-value pair
-     *        set as the given name-value pair.
+     * @brief Move the reference node to the node object that matches the given tag name, and has the same attribute
+     *        key-value pair set as the given name-value pair.
      *
      * @param[in] tag_name string with the node (<tag>) name
      * @param[in] name string key (attribute) name of the node element
@@ -221,12 +220,18 @@ public:
             const bool create_if_not_existent);
 
     /**
-     * @brief Gets the root node of the document
+     * @brief Move the reference node to the document root node.
+     *
+     * @param[in] create_if_not_existent flag to create node if it is not found
+     *
+     * @throw ElementNotFound exception if expected node was not found and node creation was not required
      */
-    void move_to_root_node();
+    void move_to_root_node(
+            const bool create_if_not_existent);
 
     /**
-     * @brief Get the locator node object found at index position. If empty index, current node is kept.
+     * @brief Move the reference node to  the locator node object found at index position. If empty index,
+     *        current node is kept.
      *
      * @param[in] index string index of the node element
      * @param[in] is_external flag to determine if the locator node is external or common
@@ -241,7 +246,8 @@ public:
             const bool create_if_not_existent);
 
     /**
-     * @brief Get the transport node object associated to the given identifier. New node is created if required.
+     * @brief Move the reference node to  the transport node object associated to the given identifier.
+     *        New node is created if required.
      *
      * @param[in] transport_id string with the node identifier
      * @param[in] create_if_not_existent flag to create node if it is not found

--- a/lib/src/cpp/utils/XMLManager.hpp
+++ b/lib/src/cpp/utils/XMLManager.hpp
@@ -299,7 +299,7 @@ private:
     utils::ErrorHandlerXMLManager* error_handler = nullptr;
 
     // Latest node navigated to
-    xercesc::DOMNode* last_node = nullptr;
+    xercesc::DOMNode* reference_node = nullptr;
 
     // Flag to write before exit
     bool write_required = false;

--- a/lib/src/cpp/utils/XMLManager.hpp
+++ b/lib/src/cpp/utils/XMLManager.hpp
@@ -44,10 +44,12 @@ namespace utils {
  */
 class XMLManager
 {
-//======================//
-// Singleton management //
-//======================//
+    //======================//
+    // Singleton management //
+    //======================//
+
 public:
+
     /**
      * @brief Get the instance object of the singleton class
      *
@@ -232,7 +234,10 @@ public:
             const bool create_if_not_existent);
 
 private:
-    XMLManager() {}
+
+    XMLManager()
+    {
+    }
 
     /**
      * @brief Transforms standalone XML document structure to rooted.

--- a/lib/src/cpp/utils/XMLManager.hpp
+++ b/lib/src/cpp/utils/XMLManager.hpp
@@ -235,9 +235,7 @@ public:
 
 private:
 
-    XMLManager()
-    {
-    }
+    XMLManager() = default;
 
     /**
      * @brief Transforms standalone XML document structure to rooted.

--- a/lib/src/cpp/utils/XMLManager.hpp
+++ b/lib/src/cpp/utils/XMLManager.hpp
@@ -84,7 +84,7 @@ public:
     /**
      * @brief Method that checks if the XML workspace has been initialized.
      *
-     * @throw Error exception if Xerces XML workspace was not initialized
+     * @throw Error exception if XML workspace was not initialized
      *
      * @return true if XML workspace already initialized
      * @return false if XML workspace has not been initialized

--- a/lib/src/cpp/utils/XMLManager.hpp
+++ b/lib/src/cpp/utils/XMLManager.hpp
@@ -78,6 +78,8 @@ public:
      * @brief Terminate XML workspace. If required to save or update the XML configuration in the filesystem,
      *  this method must be called to save them.
      *  If error occurred or resultant XML configuration is not valid, it will not save the XML configuration.
+     *
+     * @throw Error Exception if the XML file could not be written in filesystem
      */
     void terminate();
 
@@ -94,7 +96,6 @@ public:
     /**
      * @brief Validate the document, and set flag to save to disk later if valid.
      *
-     * @throw Error exception if Xerces XML workspace was not initialized
      * @throw ElementInvalid exception if document does not pass parser validation
      */
     void validate_and_save_document();
@@ -102,7 +103,6 @@ public:
     /**
      * @brief Save the document as string and validate.
      *
-     * @throw Error exception if Xerces XML workspace was not initialized
      * @throw ElementInvalid exception if document does not pass parser validation
      *
      * @return true document passes parser validation
@@ -113,7 +113,7 @@ public:
     /**
      * @brief  Save the document in the target file path.
      *
-     * @throw Error exception if Xerces XML workspace was not initialized
+     * @throw Error Exception if the XML file could not be written in filesystem
      *
      * @return true document saved
      * @return false failure saving document
@@ -123,7 +123,6 @@ public:
     /**
      * @brief Remove the selected node.
      *
-     * @throw Error exception if Xerces XML workspace was not initialized
      * @throw ElementInvalid exception if node is the last node element (could not be deleted)
      */
     void clear_node();
@@ -132,8 +131,6 @@ public:
      * @brief Set the value to node object.
      *
      * @param[in] value to be set in the node
-     *
-     * @throw Error exception if Xerces XML workspace was not initialized
      */
     void set_value_to_node(
             const std::string& value);
@@ -143,8 +140,6 @@ public:
      *
      * @param[in] name of the attribute to be set
      * @param[in] value to be set in the node attribute
-     *
-     * @throw Error exception if Xerces XML workspace was not initialized
      */
     void set_attribute_to_node(
             const std::string& name,
@@ -155,18 +150,14 @@ public:
      *
      * @param[in] name of the node attribute to be set
      * @param[in] value to be set in the node attribute
-     *
-     * @throw Error exception if Xerces XML workspace was not initialized
      */
     void set_siblings_attribute(
             const std::string& name,
             const std::string& value);
 
-
     /**
      * @brief Get the node value (only for simple cases)
      *
-     * @throw Error exception if Xerces XML workspace was not initialized
      * @throw ElementNotFound exception if the node value could not be obtained
      *
      * @return std::string node value
@@ -178,7 +169,6 @@ public:
      *
      * @param[in] name attribute name
      *
-     * @throw Error exception if Xerces XML workspace was not initialized
      * @throw ElementNotFound exception if the attribute value could not be obtained from the node
      *
      * @return std::string node attribute value (Empty string if error)
@@ -192,7 +182,6 @@ public:
      * @param[in] tag_name string with the node (<tag>) name
      * @param[in] create_if_not_existent flag to create node if it is not found
      *
-     * @throw Error exception if Xerces XML workspace was not initialized
      * @throw ElementNotFound exception if expected node was not found and node creation was not required
      */
     void move_to_node(
@@ -206,7 +195,6 @@ public:
      * @param[in] default_tag_name string with the default node (<tag>) name required to create the node if required.
      * @param[in] create_if_not_existent flag to create node if it is not found
      *
-     * @throw Error exception if Xerces XML workspace was not initialized
      * @throw ElementNotFound exception if expected node was not found and node creation was not required
      * @throw BadParameter exception if expected node could not be found by using the given index.
      */
@@ -224,7 +212,6 @@ public:
      * @param[in] value string value (attribute) value of the node element
      * @param[in] create_if_not_existent flag to create node if it is not found
      *
-     * @throw Error exception if Xerces XML workspace was not initialized
      * @throw ElementNotFound exception if expected node was not found and node creation was not required
      */
     void move_to_node(
@@ -245,7 +232,6 @@ public:
      * @param[in] is_external flag to determine if the locator node is external or common
      * @param[in] create_if_not_existent flag to create node if it is not found
      *
-     * @throw Error exception if Xerces XML workspace was not initialized
      * @throw ElementNotFound exception if expected node was not found and node creation was not required
      * @throw BadParameter exception if expected node could not be found by using the given index.
      */
@@ -260,7 +246,6 @@ public:
      * @param[in] transport_id string with the node identifier
      * @param[in] create_if_not_existent flag to create node if it is not found
      *
-     * @throw Error exception if Xerces XML workspace was not initialized
      * @throw ElementNotFound exception if expected node was not found and node creation was not required
      */
     void move_to_transport_node(
@@ -273,8 +258,6 @@ private:
 
     /**
      * @brief Transforms standalone XML document structure to rooted.
-     *
-     * @throw Error exception if Xerces XML workspace was not initialized
      */
     void transform_standalone_to_rooted_structure();
 
@@ -282,8 +265,6 @@ private:
      * @brief Auxiliar method that creates a new node with the given tag and appends it to the last node.
      *
      * @param tag_name string with the new node (<tag>) name
-     *
-     * @throw Error exception if Xerces XML workspace was not initialized
      */
     void create_node(
             const std::string& tag_name);
@@ -293,8 +274,6 @@ private:
      *
      * @param[in]  xml_file string with the given file name
      * @param[out] file_exists bool reference to save file existence status
-     *
-     * @throw Error exception if Xerces XML workspace was not initialized
      *
      * @return std::string with the absolute path
      */
@@ -307,8 +286,6 @@ private:
      *
      * @param[in]  node_list with the nodes to be filtered
      *
-     * @throw Error exception if Xerces XML workspace was not initialized
-     *
      * @return std::unique_ptr<std::vector<uint>> with the indexes of the non-empty nodes
      */
     std::unique_ptr<std::vector<uint>>  get_real_index(
@@ -316,8 +293,6 @@ private:
 
     /**
      * @brief Clear node. Usage: remove all DOMText children from node.
-     *
-     * @throw Error exception if Xerces XML workspace was not initialized
      */
     void reset_node();
 

--- a/lib/src/cpp/utils/XMLManager.hpp
+++ b/lib/src/cpp/utils/XMLManager.hpp
@@ -68,16 +68,33 @@ public:
      * @param[in] xml_file string with the file path
      * @param[in] create_file bool create file if the flag is set
      *
-     * @throw Error exception if Xerces XML workspace could not be initialized
+     * @throw Error exception if Xerces XML workspace could not be initialized, or it was already initialized
      */
     void initialize(
             const std::string& xml_file,
             bool create_file);
 
+    /**
+     * @brief Terminate XML workspace. If required to save or update the XML configuration in the filesystem,
+     *  this method must be called to save them.
+     *  If error occurred or resultant XML configuration is not valid, it will not save the XML configuration.
+     */
+    void terminate();
+
+    /**
+     * @brief Method that checks if the XML workspace has been initialized.
+     *
+     * @throw Error exception if Xerces XML workspace was not initialized
+     *
+     * @return true if XML workspace already initialized
+     * @return false if XML workspace has not been initialized
+     */
+    bool is_initialized();
 
     /**
      * @brief Validate the document, and set flag to save to disk later if valid.
      *
+     * @throw Error exception if Xerces XML workspace was not initialized
      * @throw ElementInvalid exception if document does not pass parser validation
      */
     void validate_and_save_document();
@@ -85,6 +102,7 @@ public:
     /**
      * @brief Save the document as string and validate.
      *
+     * @throw Error exception if Xerces XML workspace was not initialized
      * @throw ElementInvalid exception if document does not pass parser validation
      *
      * @return true document passes parser validation
@@ -95,6 +113,8 @@ public:
     /**
      * @brief  Save the document in the target file path.
      *
+     * @throw Error exception if Xerces XML workspace was not initialized
+     *
      * @return true document saved
      * @return false failure saving document
      */
@@ -103,6 +123,7 @@ public:
     /**
      * @brief Remove the selected node.
      *
+     * @throw Error exception if Xerces XML workspace was not initialized
      * @throw ElementInvalid exception if node is the last node element (could not be deleted)
      */
     void clear_node();
@@ -111,6 +132,8 @@ public:
      * @brief Set the value to node object.
      *
      * @param[in] value to be set in the node
+     *
+     * @throw Error exception if Xerces XML workspace was not initialized
      */
     void set_value_to_node(
             const std::string& value);
@@ -120,6 +143,8 @@ public:
      *
      * @param[in] name of the attribute to be set
      * @param[in] value to be set in the node attribute
+     *
+     * @throw Error exception if Xerces XML workspace was not initialized
      */
     void set_attribute_to_node(
             const std::string& name,
@@ -130,6 +155,8 @@ public:
      *
      * @param[in] name of the node attribute to be set
      * @param[in] value to be set in the node attribute
+     *
+     * @throw Error exception if Xerces XML workspace was not initialized
      */
     void set_siblings_attribute(
             const std::string& name,
@@ -139,6 +166,7 @@ public:
     /**
      * @brief Get the node value (only for simple cases)
      *
+     * @throw Error exception if Xerces XML workspace was not initialized
      * @throw ElementNotFound exception if the node value could not be obtained
      *
      * @return std::string node value
@@ -150,6 +178,7 @@ public:
      *
      * @param[in] name attribute name
      *
+     * @throw Error exception if Xerces XML workspace was not initialized
      * @throw ElementNotFound exception if the attribute value could not be obtained from the node
      *
      * @return std::string node attribute value (Empty string if error)
@@ -163,6 +192,7 @@ public:
      * @param[in] tag_name string with the node (<tag>) name
      * @param[in] create_if_not_existent flag to create node if it is not found
      *
+     * @throw Error exception if Xerces XML workspace was not initialized
      * @throw ElementNotFound exception if expected node was not found and node creation was not required
      */
     void move_to_node(
@@ -176,6 +206,7 @@ public:
      * @param[in] default_tag_name string with the default node (<tag>) name required to create the node if required.
      * @param[in] create_if_not_existent flag to create node if it is not found
      *
+     * @throw Error exception if Xerces XML workspace was not initialized
      * @throw ElementNotFound exception if expected node was not found and node creation was not required
      * @throw BadParameter exception if expected node could not be found by using the given index.
      */
@@ -193,6 +224,7 @@ public:
      * @param[in] value string value (attribute) value of the node element
      * @param[in] create_if_not_existent flag to create node if it is not found
      *
+     * @throw Error exception if Xerces XML workspace was not initialized
      * @throw ElementNotFound exception if expected node was not found and node creation was not required
      */
     void move_to_node(
@@ -213,6 +245,7 @@ public:
      * @param[in] is_external flag to determine if the locator node is external or common
      * @param[in] create_if_not_existent flag to create node if it is not found
      *
+     * @throw Error exception if Xerces XML workspace was not initialized
      * @throw ElementNotFound exception if expected node was not found and node creation was not required
      * @throw BadParameter exception if expected node could not be found by using the given index.
      */
@@ -227,6 +260,7 @@ public:
      * @param[in] transport_id string with the node identifier
      * @param[in] create_if_not_existent flag to create node if it is not found
      *
+     * @throw Error exception if Xerces XML workspace was not initialized
      * @throw ElementNotFound exception if expected node was not found and node creation was not required
      */
     void move_to_transport_node(
@@ -239,6 +273,8 @@ private:
 
     /**
      * @brief Transforms standalone XML document structure to rooted.
+     *
+     * @throw Error exception if Xerces XML workspace was not initialized
      */
     void transform_standalone_to_rooted_structure();
 
@@ -246,6 +282,8 @@ private:
      * @brief Auxiliar method that creates a new node with the given tag and appends it to the last node.
      *
      * @param tag_name string with the new node (<tag>) name
+     *
+     * @throw Error exception if Xerces XML workspace was not initialized
      */
     void create_node(
             const std::string& tag_name);
@@ -255,6 +293,8 @@ private:
      *
      * @param[in]  xml_file string with the given file name
      * @param[out] file_exists bool reference to save file existence status
+     *
+     * @throw Error exception if Xerces XML workspace was not initialized
      *
      * @return std::string with the absolute path
      */
@@ -267,6 +307,8 @@ private:
      *
      * @param[in]  node_list with the nodes to be filtered
      *
+     * @throw Error exception if Xerces XML workspace was not initialized
+     *
      * @return std::unique_ptr<std::vector<uint>> with the indexes of the non-empty nodes
      */
     std::unique_ptr<std::vector<uint>>  get_real_index(
@@ -275,6 +317,7 @@ private:
     /**
      * @brief Clear node. Usage: remove all DOMText children from node.
      *
+     * @throw Error exception if Xerces XML workspace was not initialized
      */
     void reset_node();
 
@@ -303,6 +346,9 @@ private:
 
     // Flag to write before exit
     bool write_required = false;
+
+    // Flag variable to determine if library has been initialized
+    bool alive = false;
 };
 
 } /* parse */

--- a/lib/test/unit_test/DomainParticipant/CMakeLists.txt
+++ b/lib/test/unit_test/DomainParticipant/CMakeLists.txt
@@ -43,6 +43,7 @@ file(GLOB_RECURSE LIBRARY_SOURCES
     ${PROJECT_SOURCE_DIR}/src/cpp/domain_participant/Port.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/domain_participant/PropertiesPolicy.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/exception/Exception.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/QosProfilesManager.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/utils/ErrorHandlerXMLManager.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/utils/StringXMLManager.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/utils/XMLManager.cpp

--- a/lib/test/unit_test/DomainParticipant/DomainParticipant.cpp
+++ b/lib/test/unit_test/DomainParticipant/DomainParticipant.cpp
@@ -91,7 +91,7 @@ protected:
         }
 
         // Initialize the XML workspace
-        EXPECT_NO_THROW(initialize(xml_filename_, true));
+        EXPECT_NO_THROW(initialize(xml_filename_));
 
         // Passing an invalid index string must return BadParameter
         EXPECT_THROW(print_functor_(participant_profile_, std::string("invalid")), BadParameter);
@@ -307,7 +307,7 @@ TEST_F(DomainParticipantTests, default_profile_test)
     std::string another_participant_name_ = "second_participant_test";
 
     // Initialize the XML workspace
-    EXPECT_NO_THROW(initialize(xml_filename_, true));
+    EXPECT_NO_THROW(initialize(xml_filename_));
 
     // Try printing default profile for non-existing file
     EXPECT_THROW(print_default_profile(), FileNotFound);

--- a/lib/test/unit_test/DomainParticipant/DomainParticipant.cpp
+++ b/lib/test/unit_test/DomainParticipant/DomainParticipant.cpp
@@ -103,16 +103,16 @@ protected:
         }
 
         // Try printing from non-existing file
-        EXPECT_THROW(print_functor_(participant_profile_, std::string("0")), FileNotFound);
+        EXPECT_THROW(print_functor_(participant_profile_, std::string("0")), ElementNotFound);
 
         // Try updating in a non-existent file
         EXPECT_THROW(set_functor_(participant_profile_, valid_values_[0], std::string("0")),
-                FileNotFound);
+                ElementNotFound);
 
         // Try clearing in a non-existent file
         if (nullptr != clear_functor_)
         {
-            EXPECT_THROW(clear_functor_(participant_profile_, std::string("0")), FileNotFound);
+            EXPECT_THROW(clear_functor_(participant_profile_, std::string("0")), ElementNotFound);
         }
 
         // Push invalid value
@@ -310,13 +310,13 @@ TEST_F(DomainParticipantTests, default_profile_test)
     EXPECT_NO_THROW(initialize(xml_filename_));
 
     // Try printing default profile for non-existing file
-    EXPECT_THROW(print_default_profile(), FileNotFound);
+    EXPECT_THROW(print_default_profile(), ElementNotFound);
 
     // Set default profile to non-existent XML file
-    EXPECT_THROW(set_default_profile(participant_profile_), FileNotFound);
+    EXPECT_THROW(set_default_profile(participant_profile_), ElementNotFound);
 
     // Clear default profile from a non-existent XML file
-    EXPECT_THROW(clear_default_profile(), FileNotFound);
+    EXPECT_THROW(clear_default_profile(), ElementNotFound);
 
     // Set participant name in order to create file
     EXPECT_NO_THROW(set_name(participant_profile_, participant_name_));

--- a/lib/test/unit_test/DomainParticipant/DomainParticipant.cpp
+++ b/lib/test/unit_test/DomainParticipant/DomainParticipant.cpp
@@ -90,6 +90,9 @@ protected:
             ASSERT_EQ(invalid_values_.size(), invalid_messages_.size());
         }
 
+        // Initialize the XML workspace
+        EXPECT_NO_THROW(initialize(xml_filename_, true));
+
         // Passing an invalid index string must return BadParameter
         EXPECT_THROW(print_functor_(participant_profile_, std::string("invalid")), BadParameter);
         EXPECT_THROW(set_functor_(participant_profile_, valid_values_[0], std::string("invalid")),
@@ -287,6 +290,9 @@ protected:
             // Clear already cleared element does not throw
             EXPECT_NO_THROW(clear_functor_(participant_profile_, std::string("0")));
         }
+
+        // Terminate XML workspace
+        EXPECT_NO_THROW(terminate());
     }
 
 };

--- a/lib/test/unit_test/DomainParticipant/DomainParticipant.cpp
+++ b/lib/test/unit_test/DomainParticipant/DomainParticipant.cpp
@@ -26,7 +26,6 @@
 #include <fastdds_qos_profiles_manager_lib/exception/Exception.hpp>
 #include <fastdds_qos_profiles_manager_lib/QoSProfilesManager.hpp>
 
-
 using namespace eprosima::qosprof;
 using namespace eprosima::qosprof::domain_participant;
 


### PR DESCRIPTION
- Manager has been transformed to singleton
- Manager initialization is performed only once
- `get_node` methods have been renamed as `move_to_node` (more intuitive meaning)
- Write to file is performed only once, when all library calls have finished with successful outputs