### PR TITLE
[18339] Fix XML style

### DIFF
--- a/docs/rst/fastdds_qos_profiles_manager_cli/cli_usage.rst
+++ b/docs/rst/fastdds_qos_profiles_manager_cli/cli_usage.rst
@@ -1,4 +1,3 @@
-.. include:: ../01-exports/api-lib-aliases.include
 .. include:: ../01-exports/roles.include
 
 .. _fastdds_qos_profiles_manager_cli_usage:

--- a/lib/src/cpp/utils/XMLManager.cpp
+++ b/lib/src/cpp/utils/XMLManager.cpp
@@ -298,15 +298,23 @@ void XMLManager::create_node(
     reference_node =
             static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(tag_name.c_str())));
 
+    // Add text node to correctly set closing tag indentation
+    std::string dummy("\n");
+    for (int i = 0; i < depth_level - 1; i++)
+    {
+        dummy += "  ";
+    }
     // Append new node to parent node
     if (parent_node != nullptr)
     {
         parent_node->appendChild(reference_node);
+        parent_node->appendChild(doc->createTextNode(xercesc::XMLString::transcode(dummy.c_str())));
     }
     // Append new node directly to document
     else
     {
         doc->appendChild(reference_node);
+        doc->appendChild(doc->createTextNode(xercesc::XMLString::transcode(dummy.c_str())));
     }
 }
 
@@ -480,6 +488,9 @@ void XMLManager::move_to_node(
         exception_message += " XML element.\n";
         throw ElementNotFound(exception_message);
     }
+    
+    // Increase depth level
+    depth_level++;
 
     // Obtain list of nodes based on the target tag
     xercesc::DOMNodeList* node_list = static_cast<xercesc::DOMElement*>(reference_node)->getElementsByTagName(
@@ -524,6 +535,9 @@ void XMLManager::move_to_node(
         exception_message += " XML element.\n";
         throw ElementNotFound(exception_message);
     }
+    
+    // Increase depth level
+    depth_level++;
 
     // Index not empty
     if (!index.empty())
@@ -595,6 +609,9 @@ void XMLManager::move_to_node(
     }
 
     // TODO add a check if 'name' parameter is empty, return (do not update) actual reference_node
+    
+    // Increase depth level
+    depth_level++;
 
     // Obtain list of nodes based on the target tag
     xercesc::DOMNodeList* node_list = static_cast<xercesc::DOMElement*>(reference_node)->getElementsByTagName(
@@ -644,6 +661,9 @@ void XMLManager::move_to_node(
 void XMLManager::move_to_root_node(
         const bool create_if_not_existent)
 {
+    // Reinitialize depth level count.
+    depth_level = 0;
+
     // Set the last node as the root node
     xercesc::DOMNodeList* doc_node_list = doc->getElementsByTagName(xercesc::XMLString::transcode(tag::ROOT));
 
@@ -704,6 +724,9 @@ void XMLManager::move_to_locator_node(
     std::string tag = xercesc::XMLString::transcode(reference_node->getNodeName());
     if (tag == utils::tag::LOCATOR)
     {
+        // Increase depth level
+        depth_level++;
+
         // Obtain main list of nodes
         xercesc::DOMNodeList* node_list = reference_node->getChildNodes();
 
@@ -735,6 +758,9 @@ void XMLManager::move_to_transport_node(
         const std::string& transport_id,
         const bool create_if_not_existent)
 {
+    // Increase depth level
+    depth_level++;
+
     // Obtain list node
     move_to_node(utils::tag::TRANSPORT_DESCRIPTOR_LIST, create_if_not_existent);
 

--- a/lib/src/cpp/utils/XMLManager.cpp
+++ b/lib/src/cpp/utils/XMLManager.cpp
@@ -273,6 +273,7 @@ bool XMLManager::save_xml()
         // Config would configure serialized XML data
         config = serializer->getDomConfig();
         config->setParameter(xercesc::XMLUni::fgDOMWRTFormatPrettyPrint, true);
+        config->setParameter(xercesc::XMLUni::fgDOMWRTXercesPrettyPrint, false);
         config->setParameter(xercesc::XMLUni::fgDOMXMLDeclaration, true);
 
         // Save XML document in target file path

--- a/lib/src/cpp/utils/XMLManager.cpp
+++ b/lib/src/cpp/utils/XMLManager.cpp
@@ -299,22 +299,22 @@ void XMLManager::create_node(
             static_cast<xercesc::DOMNode*>(doc->createElement(xercesc::XMLString::transcode(tag_name.c_str())));
 
     // Add text node to correctly set closing tag indentation
-    std::string dummy("\n");
+    std::string node_formatting(LINE_BREAK);
     for (int i = 0; i < depth_level - 1; i++)
     {
-        dummy += "  ";
+        node_formatting += "  ";
     }
     // Append new node to parent node
     if (parent_node != nullptr)
     {
         parent_node->appendChild(reference_node);
-        parent_node->appendChild(doc->createTextNode(xercesc::XMLString::transcode(dummy.c_str())));
+        parent_node->appendChild(doc->createTextNode(xercesc::XMLString::transcode(node_formatting.c_str())));
     }
     // Append new node directly to document
     else
     {
         doc->appendChild(reference_node);
-        doc->appendChild(doc->createTextNode(xercesc::XMLString::transcode(dummy.c_str())));
+        doc->appendChild(doc->createTextNode(xercesc::XMLString::transcode(node_formatting.c_str())));
     }
 }
 
@@ -609,7 +609,7 @@ void XMLManager::move_to_node(
     }
 
     // TODO add a check if 'name' parameter is empty, return (do not update) actual reference_node
-    
+
     // Increase depth level
     depth_level++;
 

--- a/lib/src/cpp/utils/XMLManager.cpp
+++ b/lib/src/cpp/utils/XMLManager.cpp
@@ -488,7 +488,7 @@ void XMLManager::move_to_node(
         exception_message += " XML element.\n";
         throw ElementNotFound(exception_message);
     }
-    
+
     // Increase depth level
     depth_level++;
 
@@ -535,7 +535,7 @@ void XMLManager::move_to_node(
         exception_message += " XML element.\n";
         throw ElementNotFound(exception_message);
     }
-    
+
     // Increase depth level
     depth_level++;
 

--- a/lib/src/cpp/utils/XMLManager.cpp
+++ b/lib/src/cpp/utils/XMLManager.cpp
@@ -303,7 +303,7 @@ void XMLManager::create_node(
     std::string node_formatting(LINE_BREAK);
     for (int i = 0; i < depth_level - 1; i++)
     {
-        node_formatting += "  ";
+        node_formatting += NODE_INDENTATION;
     }
     // Append new node to parent node
     if (parent_node != nullptr)

--- a/lib/src/cpp/utils/XMLManager.hpp
+++ b/lib/src/cpp/utils/XMLManager.hpp
@@ -328,7 +328,7 @@ private:
 
     // Flag variable to determine if library has been initialized
     bool alive = false;
-    
+
     // XML depth level: auxiliary member to correctly set closing tags indentation
     int32_t depth_level;
 };

--- a/lib/src/cpp/utils/XMLManager.hpp
+++ b/lib/src/cpp/utils/XMLManager.hpp
@@ -304,6 +304,7 @@ private:
     constexpr static const char* CORE = "Core";
     constexpr static const char* UTF8 = "UTF-8";
     constexpr static const char* LINE_BREAK = "\n";
+    constexpr static const char* NODE_INDENTATION = "  ";
 
     // Xerces tools required for node management
     xercesc::DOMConfiguration* config = nullptr;

--- a/lib/src/cpp/utils/XMLManager.hpp
+++ b/lib/src/cpp/utils/XMLManager.hpp
@@ -328,6 +328,9 @@ private:
 
     // Flag variable to determine if library has been initialized
     bool alive = false;
+    
+    // XML depth level: auxiliary member to correctly set closing tags indentation
+    int32_t depth_level;
 };
 
 } /* parse */


### PR DESCRIPTION
This PR fixes the following style issues:

* Extra blank lines at the end of the XML file
* Incorrect indentation for closing tags

This PR is built over #71 and must be merge after that one.